### PR TITLE
Add entry to better catch SwitchBoard.app in killStupidProcesses

### DIFF
--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -475,7 +475,8 @@ def killStupidProcesses():
     stupid_processes = ["Adobe AIR Installer",
                         "Adobe AIR Application Installer",
                         "InstallAdobeHelp",
-                        "open -a /Library/Application Support/Adobe/SwitchBoard/SwitchBoard.app"]
+                        "open -a /Library/Application Support/Adobe/SwitchBoard/SwitchBoard.app",
+                        "/bin/bash /Library/Application Support/Adobe/SwitchBoard/SwitchBoard.app/Contents/MacOS/switchboard.sh"]
 
     for procname in stupid_processes:
         pid = utils.getPIDforProcessName(procname)


### PR DESCRIPTION
The existing entry to kill off SwitchBoard.app being launched in the loginwindow context did not always work. Adding "/bin/bash /Library/Application Support/Adobe/SwitchBoard/SwitchBoard.app/Contents/MacOS/switchboard.sh" resolves this issue.
