### PR TITLE
munkicommon: remove tmpdir at exit

### DIFF
--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -22,6 +22,7 @@ Created by Greg Neagle on 2008-11-18.
 Common functions used by the munki tools.
 """
 
+import atexit
 import ctypes
 import ctypes.util
 import fcntl
@@ -2706,8 +2707,13 @@ def blockingApplicationsRunning(pkginfoitem):
 #debug = False
 verbose = 1
 munkistatusoutput = False
-tmpdir = tempfile.mkdtemp(prefix='munki-', dir='/tmp')
 report = {}
+
+tmpdir = tempfile.mkdtemp(prefix='munki-', dir='/tmp')
+def cleanup_tmpdir():
+    shutil.rmtree(tmpdir)
+atexit.register(cleanup_tmpdir)
+
 
 def main():
     """Placeholder"""


### PR DESCRIPTION
Currently importing munkicommon has the side-effect of creating a temporary directory in /tmp and this temporary directory is never cleaned up. To fix this with as small a change as possible, register an atexit function to clean-up this directory when the importing script exits.

This won't clean-up the directory in the event that the importing script exits with sys._exit or an un-handled exception. The cleanup function could be changed to remove any directory matching /tmp/munki-\* if that were desirable.
