### PR TITLE
Add optional preinstall_alert key to pkginfo plist.

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
@@ -915,12 +915,12 @@ class MSCMainWindowController(NSWindowController):
             msclog.debug_log('Can\'t find item: %s' % item_name)
             return
         
-        if item['status'] == 'not-installed' and item.get('pre_install_alert'):
+        if item['status'] == 'not-installed' and item.get('preinstall_alert'):
             self.clickedItem = item_name
-            self.displayPreInstallUninstallAlert_(item['pre_install_alert'])
-        elif item['status'] == 'installed' and item.get('pre_uninstall_alert'):
+            self.displayPreInstallUninstallAlert_(item['preinstall_alert'])
+        elif item['status'] == 'installed' and item.get('preuninstall_alert'):
             self.clickedItem = item_name
-            self.displayPreInstallUninstallAlert_(item['pre_uninstall_alert'])
+            self.displayPreInstallUninstallAlert_(item['preuninstall_alert'])
         else:
             self.actionButtonPerformAction_(item_name)
     

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -1592,10 +1592,10 @@ def processOptionalInstall(manifestitem, cataloglist, installinfo):
                                warn=False):
             iteminfo['note'] = \
                 'Insufficient disk space to download and install.'
-    if item_pl.get('pre_install_alert'):
-        iteminfo['pre_install_alert'] = item_pl.get('pre_install_alert')
-    if item_pl.get('pre_uninstall_alert'):
-        iteminfo['pre_uninstall_alert'] = item_pl.get('pre_uninstall_alert')
+    if item_pl.get('preinstall_alert'):
+        iteminfo['preinstall_alert'] = item_pl.get('preinstall_alert')
+    if item_pl.get('preuninstall_alert'):
+        iteminfo['preuninstall_alert'] = item_pl.get('preuninstall_alert')
 
     munkicommon.display_debug1(
         'Adding %s to the optional install list', iteminfo['name'])


### PR DESCRIPTION
Displays text that end users can agree or not before continuing with install.

This is a requirement for some software, such as skype or dropbox, that may be provided but needs extra conditions outside regular acceptable use policy that the user needs to be aware of e.g. a user must agree that while dropbox is permitted, to not store protected IP in a dropbox folder.

The added key:string pair user_agreement will contain the content of the message on a per package basis.
