### PR TITLE
Xcode6 compatibility: move Embed version info phase

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center.xcodeproj/project.pbxproj
+++ b/code/apps/Managed Software Center/Managed Software Center.xcodeproj/project.pbxproj
@@ -230,10 +230,10 @@
 			buildConfigurationList = C090050E16CDD84E00BE34CE /* Build configuration list for PBXNativeTarget "Managed Software Center" */;
 			buildPhases = (
 				C09CE1D918BEA41000B9724A /* Localize */,
-				C09CE1DA18BEA59E00B9724A /* Embed version info */,
 				C09004E916CDD84E00BE34CE /* Sources */,
 				C09004EA16CDD84E00BE34CE /* Frameworks */,
 				C09004EB16CDD84E00BE34CE /* Resources */,
+				C09CE1DA18BEA59E00B9724A /* Embed version info */,
 			);
 			buildRules = (
 			);

--- a/code/apps/MunkiStatus/MunkiStatus.xcodeproj/project.pbxproj
+++ b/code/apps/MunkiStatus/MunkiStatus.xcodeproj/project.pbxproj
@@ -191,10 +191,10 @@
 			buildConfigurationList = C090050E16CDD84E00BE34CE /* Build configuration list for PBXNativeTarget "MunkiStatus" */;
 			buildPhases = (
 				C09CE1DB18BEA77500B9724A /* Localize */,
-				C09CE1DC18BEA78300B9724A /* Embed version info */,
 				C09004E916CDD84E00BE34CE /* Sources */,
 				C09004EA16CDD84E00BE34CE /* Frameworks */,
 				C09004EB16CDD84E00BE34CE /* Resources */,
+				C09CE1DC18BEA78300B9724A /* Embed version info */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
I can't seem to Google well enough for exactly what changed about the build process as of Xcode 6, besides possibly a change in their app templates, but with Xcode 6, the template Info plist doesn't seem to exist yet when the 'Embed version info' phase runs, so PlistBuddy commands fail (and even if they were fixed, the template plist doesn't exist yet anyway).

With this tweak of moving this phase to the end, I can still successfully build MSC and MunkiStatus in Xcode 5.1.1 on 10.8 and 10.9, and build installer packages. They seem to work and have the same version info.

Here's a one-liner to copy the 10.8 SDK from a mounted Xcode 5 DMG (at `/Volumes/Xcode`) to an installed Xcode 6.0.1 in /Applications:

`sudo cp -R /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/`
