### PR TITLE
fix preinstall_alert and preuninstall_alert unicode support

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
@@ -944,7 +944,7 @@ class MSCMainWindowController(NSWindowController):
                 cancelLabel,
                 OKLabel,
                 nil,
-                u"%@", NSLocalizedString(alertDetail, u'alertDetail text'))
+                u"%@", alertDetail)
         alert.beginSheetModalForWindow_modalDelegate_didEndSelector_contextInfo_(self.window(), self, self.actionAlertDidEnd_returnCode_contextInfo_, nil)
                 
     def actionAlertDidEnd_returnCode_contextInfo_(self, alert, returncode, contextinfo):


### PR DESCRIPTION
This fixes the issue reported by Jason Hatman in this thread https://groups.google.com/forum/#!topic/munki-dev/lUgDD6wgKb8
