### PR TITLE
Adding uninstall description pkginfo key

### DIFF
--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2286,7 +2286,10 @@ def processRemoval(manifestitem, cataloglist, installinfo):
     iteminfo = {}
     iteminfo['name'] = uninstall_item.get('name', '')
     iteminfo['display_name'] = uninstall_item.get('display_name', '')
-    iteminfo['description'] = 'Will be removed.'
+    iteminfo['description'] = uninstall_item.get(
+      'uninstall_description',
+      'Will be removed.'
+    )
 
     # we will ignore the unattended_uninstall key if the item needs a restart
     # or logout...


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!topic/munki-dev/zC03ac1jr6, I want to have an uninstall description to let users know the reason for the uninstall.  I've made the change locally on my machine and verified that the uninstall description is correct in MSC. 
![screen shot 2014-10-23 at 2 32 04 pm](https://cloud.githubusercontent.com/assets/6855782/4762187/da4274ac-5afe-11e4-8e2e-7e21d1868faf.png)
