### PR TITLE
munkiimport: Add argument to specify package icon

### DIFF
--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -731,6 +731,9 @@ def main():
     parser.add_option('--repo_url', '--repo-url', default='',
                     help="""Optional repo fileshare URL that takes precedence
                     over the default repo_url specified via --configure.""")
+    parser.add_option('--icon_path', '--icon-path', default='', type='string',
+                    help="""Path to an icon file for the package.
+                    Will overwrite an existing icon.""")
     parser.add_option('--version', '-V', action='store_true',
                     help='Print the version of the munki tools and exit.')
     parser.add_option('--verbose', '-v', action='store_true',
@@ -763,6 +766,10 @@ def main():
 
     if options.repo_url:
         REPO_URL = options.repo_url
+
+    if options.icon_path and not os.path.isfile(options.icon_path):
+        print >> sys.stderr, ('The specified icon file does not exist.')
+        exit(-1)
 
     if len(arguments) == 0:
         parser.print_usage()
@@ -945,7 +952,7 @@ def main():
             options.subdirectory = promptForSubdirectory(
                                                     options.subdirectory)
 
-        if not iconExistsInRepo(pkginfo):
+        if not iconExistsInRepo(pkginfo) and not options.icon_path:
             print 'No existing product icon found.'
             answer = raw_input('Attempt to create a product icon? [y/n] ')
             if answer.lower().startswith('y'):
@@ -979,9 +986,9 @@ def main():
         pkginfo['installer_item_location'] = uploaded_pkgpath
 
     # if we have an icon, upload it
-    if False: #options.iconpath:
+    if options.icon_path:
         try:
-            copyIconToRepo(options.iconpath)
+            convert_and_install_icon(pkginfo, options.icon_path)
         except RepoCopyError, errmsg:
             print >> sys.stderr, errmsg
 


### PR DESCRIPTION
This patch adds a command line option to munkiimport for specifying an icon file for the package.  The specified icon will be renamed and copied to the REPO_PATH/icons folder as appropriate.  It also consolidates some repeated icon import code into a function.

On line 995 there is an `if False:` statement.  I can't tell if this was just a stub for future improvement or a fix to prevent an undesirable effect of the icon import code.

I believe this would be one method of resolving issue #371.  If you would prefer to have an interactive prompt for a manual icon path in the event that an icon is not automatically found just let me know and I'll recode.  I was attempting to minimize admin interaction.
