### PR TITLE
tests: Remove unused warning conditional in appleupdates.CheckForSoftwar...

### DIFF
--- a/tests/code/client/munkilib/appleupdates_test.py
+++ b/tests/code/client/munkilib/appleupdates_test.py
@@ -1073,13 +1073,11 @@ class TestAppleUpdates(mox.MoxTestBase):
         appleupdates.munkicommon.getsha256hash(
             self.au.apple_download_catalog_path).AndReturn(None)
         self.au.CacheAppleCatalog().AndRaise(exc(s))
-        if exc == appleupdates.ReplicationError:
+        if exc == appleupdates.ReplicationError or \
+           exc == appleupdates.fetch.MunkiDownloadError:
             appleupdates.munkicommon.display_warning(
                 'Could not download Apple SUS catalog:')
             appleupdates.munkicommon.display_warning('\t%s', s)
-        elif exc == appleupdates.fetch.MunkiDownloadError:
-            appleupdates.munkicommon.display_warning(
-                'Could not download Apple SUS catalog.')
 
         self.mox.ReplayAll()
         self.assertFalse(self.au.CheckForSoftwareUpdates())


### PR DESCRIPTION
Having just last week added a new build phase to the Munkibuilds Jenkins job that runs `runtests.sh`, a failure started somewhere after merging the NSURL branch. It looks to me like it was trying to evaluate a condition in reporting a failure for Apple SU checks that would no longer give the same warning strings as before, since the logic in appleupdates.py was simplified.

Since this is my first time even looking at the testing code I definitely don't know what I'm doing, but this looks very simple. Here's the fail log from before this fix:

```
...................F........................................................
======================================================================
FAIL: testCheckForSoftwareUpdatesMunkiDownloadError (__main__.TestAppleUpdates)
Tests CheckForSoftwareUpdates() with MunkiDownloadError.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tsutton/Library/Python/2.7/lib/python/site-packages/mox.py", line 1899, in new_method
    func(self, *args, **kwargs)
  File "./code/client/munkilib/appleupdates_test.py", line 1101, in testCheckForSoftwareUpdatesMunkiDownloadError
    appleupdates.fetch.MunkiDownloadError)
  File "./code/client/munkilib/appleupdates_test.py", line 1085, in _CheckForSoftwareUpdatesCacheAppleCatalogExceptionHelper
    self.assertFalse(self.au.CheckForSoftwareUpdates())
  File "/Users/tsutton/git/github/munki/code/client/munkilib/appleupdates.py", line 774, in CheckForSoftwareUpdates
    munkicommon.display_warning('Could not download Apple SUS catalog:')
  File "/Users/tsutton/Library/Python/2.7/lib/python/site-packages/mox.py", line 765, in __call__
    return mock_method(*params, **named_params)
  File "/Users/tsutton/Library/Python/2.7/lib/python/site-packages/mox.py", line 1002, in __call__
    expected_method = self._VerifyMethodCall()
  File "/Users/tsutton/Library/Python/2.7/lib/python/site-packages/mox.py", line 1060, in _VerifyMethodCall
    raise UnexpectedMethodCallError(self, expected)
UnexpectedMethodCallError: Unexpected method call.  unexpected:-  expected:+
- display_warning.__call__('Could not download Apple SUS catalog:') -> None
?                                                               ^

+ display_warning.__call__('Could not download Apple SUS catalog.') -> None
?                                                               ^


----------------------------------------------------------------------
Ran 76 tests in 0.070s

FAILED (failures=1)
..................
----------------------------------------------------------------------
Ran 18 tests in 0.001s

OK
```
