### PR TITLE
Increase network wait time before Munki run.

### DIFF
--- a/code/client/managedsoftwareupdate
+++ b/code/client/managedsoftwareupdate
@@ -534,10 +534,10 @@ def main():
                     # network interfaces to come up
                     # before continuing
                     munkicommon.display_status_minor('Waiting for network...')
-                    for dummy_i in range(60):
+                    for dummy_i in range(30):
                         if networkUp():
                             break
-                        time.sleep(0.5)
+                        time.sleep(1)
                 else:
                     # delete triggerfile if _not_ checkandinstallatstartup
                     os.unlink(filename)


### PR DESCRIPTION
This will increase Munki's wait time to 30 seconds before exit, which should help with larger networks.
