### PR TITLE
Update updatecheck.py

### DIFF
--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -28,6 +28,7 @@ import subprocess
 import socket
 import urllib2
 import urlparse
+import xattr
 from urllib import quote_plus
 from OpenSSL.crypto import load_certificate, FILETYPE_PEM
 
@@ -2746,7 +2747,12 @@ def download_icons(item_list):
         icon_url = icon_base_url + urllib2.quote(icon_name)
         icon_path = os.path.join(icon_dir, icon_name)
         if os.path.isfile(icon_path):
-            local_icon_hash = munkicommon.getsha256hash(icon_path)
+            local_xattrs = xattr.xattr(icon_path)
+            if 'icon_hash' in local_xattrs:
+                local_icon_hash = local_xattrs['icon_hash']
+            else:
+                local_icon_hash = munkicommon.getsha256hash(icon_path)
+                local_xattrs['icon_hash'] = local_icon_hash
         else:
             local_icon_hash = 'nonexistent'
         icon_subdir = os.path.dirname(icon_path)

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2746,10 +2746,10 @@ def download_icons(item_list):
         icon_url = icon_base_url + urllib2.quote(icon_name)
         icon_path = os.path.join(icon_dir, icon_name)
         if os.path.isfile(icon_path):
-            xattr_hash = fetch.getxattr(icon_path, XATTR_SHA)
+            xattr_hash = fetch.getxattr(icon_path, fetch.XATTR_SHA)
             if not xattr_hash:
               xattr_hash = munkicommon.getsha256hash(icon_path)
-              fetch.writeCachedChecksum(icon_path, XATTR_SHA)
+              fetch.writeCachedChecksum(icon_path, xattr_hash)
         else:
             xattr_hash = 'nonexistent'
         icon_subdir = os.path.dirname(icon_path)
@@ -2772,7 +2772,7 @@ def download_icons(item_list):
                     icon_name, err)
             else:
                 if os.path.isfile(icon_path):
-                    fetch.writeCachedChecksum(icon_path, XATTR_SHA)
+                    fetch.writeCachedChecksum(icon_path)
     # remove no-longer needed icons from the local directory
     for (dirpath, dummy_dirnames, filenames) in os.walk(
             icon_dir, topdown=False):

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -1580,7 +1580,7 @@ def processOptionalInstall(manifestitem, cataloglist, installinfo):
     iteminfo['description'] = item_pl.get('description', '')
     iteminfo['version_to_install'] = item_pl.get('version', 'UNKNOWN')
     iteminfo['display_name'] = item_pl.get('display_name', '')
-    for key in ['category', 'developer', 'icon_name',
+    for key in ['category', 'developer', 'icon_name', 'icon_hash',
                 'requires', 'RestartAction']:
         if key in item_pl:
             iteminfo[key] = item_pl[key]
@@ -1874,7 +1874,8 @@ def processInstall(manifestitem, cataloglist, installinfo):
                              'apple_item',
                              'category',
                              'developer',
-                             'icon_name']
+                             'icon_name',
+                             'icon_hash']
 
             for key in optional_keys:
                 if key in item_pl:
@@ -2738,11 +2739,16 @@ def download_icons(item_list):
     munkicommon.display_debug2('Icon base URL is: %s', icon_base_url)
     for item in item_list:
         icon_name = item.get('icon_name') or item['name']
+        pkginfo_icon_hash = item.get('icon_hash')
         if not os.path.splitext(icon_name)[1] in icon_known_exts:
             icon_name += '.png'
         icon_list.append(icon_name)
         icon_url = icon_base_url + urllib2.quote(icon_name)
         icon_path = os.path.join(icon_dir, icon_name)
+        if os.path.isfile(icon_path):
+            local_icon_hash = munkicommon.getsha256hash(icon_path)
+        else:
+            local_icon_hash = 'nonexistent'
         icon_subdir = os.path.dirname(icon_path)
         if not os.path.exists(icon_subdir):
             try:
@@ -2751,16 +2757,16 @@ def download_icons(item_list):
                 munkicommon.display_error(
                     'Could not create %s' % icon_subdir)
                 continue
-        munkicommon.display_detail('Getting icon %s...', icon_name)
-        item_name = item.get('display_name') or item['name']
-        message = 'Getting icon for %s...' % item_name
-        try:
-            dummy_value = getResourceIfChangedAtomically(
-                icon_url, icon_path, message=message)
-        except fetch.MunkiDownloadError, err:
-            munkicommon.display_debug1(
-                'Could not retrieve icon %s from the server: %s',
-                icon_name, err)
+        if pkginfo_icon_hash != local_icon_hash:
+            item_name = item.get('display_name') or item['name']
+            message = 'Getting icon %s for %s...' % (icon_name, item_name)
+            try:
+                dummy_value = getResourceIfChangedAtomically(
+                    icon_url, icon_path, message=message)
+            except fetch.MunkiDownloadError, err:
+                munkicommon.display_debug1(
+                    'Could not retrieve icon %s from the server: %s',
+                    icon_name, err)
     # remove no-longer needed icons from the local directory
     for (dirpath, dummy_dirnames, filenames) in os.walk(
             icon_dir, topdown=False):
@@ -3056,8 +3062,11 @@ def check(client_id='', localmanifestpath=None):
         # and active installs/removals
         item_list = list(installinfo.get('optional_installs', []))
         item_list.extend(installinfo['managed_installs'])
-        item_list.extend(installinfo['removals'])
         download_icons(item_list)
+        # We don't need to download iconds for items being removed,
+        # they should alredy be present and if they aren't we're
+        # making beds in a burning building.
+        item_list.extend(installinfo['removals'])
 
         # get any custom client resources
         download_client_resources()

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -3064,7 +3064,7 @@ def check(client_id='', localmanifestpath=None):
         item_list.extend(installinfo['managed_installs'])
         item_list.extend(installinfo['removals'])
         download_icons(item_list)
-        
+
         # get any custom client resources
         download_client_resources()
 

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -3062,12 +3062,9 @@ def check(client_id='', localmanifestpath=None):
         # and active installs/removals
         item_list = list(installinfo.get('optional_installs', []))
         item_list.extend(installinfo['managed_installs'])
-        download_icons(item_list)
-        # We don't need to download iconds for items being removed,
-        # they should alredy be present and if they aren't we're
-        # making beds in a burning building.
         item_list.extend(installinfo['removals'])
-
+        download_icons(item_list)
+        
         # get any custom client resources
         download_client_resources()
 

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2749,7 +2749,7 @@ def download_icons(item_list):
             xattr_hash = fetch.getxattr(icon_path, XATTR_SHA)
             if not xattr_hash:
               xattr_hash = munkicommon.getsha256hash(icon_path)
-              fetch.writeCachedChecksum(icon_path, xattr_hash)
+              fetch.writeCachedChecksum(icon_path, XATTR_SHA)
         else:
             xattr_hash = 'nonexistent'
         icon_subdir = os.path.dirname(icon_path)
@@ -2772,7 +2772,7 @@ def download_icons(item_list):
                     icon_name, err)
             else:
                 if os.path.isfile(icon_path):
-                    fetch.writeCachedChecksum(icon_path, xattr_hash)
+                    fetch.writeCachedChecksum(icon_path, XATTR_SHA)
     # remove no-longer needed icons from the local directory
     for (dirpath, dummy_dirnames, filenames) in os.walk(
             icon_dir, topdown=False):


### PR DESCRIPTION
Check for the addition of an icon_hash key in a package plist. If the key is present and matches a hash of an icon that has already been downloaded no attempt will be made to download the icon again. If the icon_hash is not present or the hash does not match the behavior will revert back to normal.