### PR TITLE
 Fix for issue #428 (only valid for French translation).

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/fr.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/fr.lproj/Localizable.strings
@@ -215,7 +215,7 @@
 "OK" = "OK";
 
 /* Forced Install Date summary */
-"One or more items must be installed by %s" = "Un article doit être installés avant le %s";
+"One or more items must be installed by %s" = "Un article doit être installé avant le %s";
 
 /* Mandatory Updates Imminent detail */
 "One or more mandatory updates are overdue for installation. A logout will be forced soon." = "Une ou plusieurs mises à jour obligatoires sont en retard. Une fermeture de session va être forcée très bientôt.";


### PR DESCRIPTION
Fixes issue #428 by reducing the lenght of the translated text to leave enough space for the button to show on default window width.
