### PR TITLE
Add support for icon_hash

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -258,6 +258,8 @@ def getResourceIfChangedAtomically(url,
             xattr_hash = writeCachedChecksum(destinationpath)
         if xattr_hash == expected_hash:
             #File is already current, no change.
+            munkicommon.display_debug1('%s: stored hash matches '
+                'with expected hash.' % destinationpath)
             return False
         elif munkicommon.pref(
              'PackageVerificationMode').lower() in ['hash_strict', 'hash']:

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -1580,7 +1580,7 @@ def processOptionalInstall(manifestitem, cataloglist, installinfo):
     iteminfo['description'] = item_pl.get('description', '')
     iteminfo['version_to_install'] = item_pl.get('version', 'UNKNOWN')
     iteminfo['display_name'] = item_pl.get('display_name', '')
-    for key in ['category', 'developer', 'icon_name',
+    for key in ['category', 'developer', 'icon_name', 'icon_hash',
                 'requires', 'RestartAction']:
         if key in item_pl:
             iteminfo[key] = item_pl[key]
@@ -1874,7 +1874,8 @@ def processInstall(manifestitem, cataloglist, installinfo):
                              'apple_item',
                              'category',
                              'developer',
-                             'icon_name']
+                             'icon_name',
+                             'icon_hash']
 
             for key in optional_keys:
                 if key in item_pl:
@@ -2738,6 +2739,7 @@ def download_icons(item_list):
     munkicommon.display_debug2('Icon base URL is: %s', icon_base_url)
     for item in item_list:
         icon_name = item.get('icon_name') or item['name']
+        pkginfo_icon_hash = item.get('icon_hash')
         if not os.path.splitext(icon_name)[1] in icon_known_exts:
             icon_name += '.png'
         icon_list.append(icon_name)
@@ -2751,16 +2753,20 @@ def download_icons(item_list):
                 munkicommon.display_error(
                     'Could not create %s' % icon_subdir)
                 continue
-        munkicommon.display_detail('Getting icon %s...', icon_name)
+        munkicommon.display_detail('Checking icon %s...', icon_name)
         item_name = item.get('display_name') or item['name']
-        message = 'Getting icon for %s...' % item_name
+        message = 'Getting icon %s for %s...' % (icon_name, item_name)
         try:
-            dummy_value = getResourceIfChangedAtomically(
-                icon_url, icon_path, message=message)
+            dummy_value = getResourceIfChangedAtomically(icon_url, icon_path,
+                                          resume=True,
+                                          message=message,
+                                          expected_hash=pkginfo_icon_hash,
+                                          verify=True)
         except fetch.MunkiDownloadError, err:
             munkicommon.display_debug1(
                 'Could not retrieve icon %s from the server: %s',
                 icon_name, err)
+
     # remove no-longer needed icons from the local directory
     for (dirpath, dummy_dirnames, filenames) in os.walk(
             icon_dir, topdown=False):


### PR DESCRIPTION
A rewrite of #425 which uses the xattr attribute com.googlecode.munki.sha256 to store the current hash. 

Check for the addition of an icon_hash key in a package plist. If the key is present and matches a hash of the corresponding icon that has already been downloaded, no attempt will be made to download the icon/verify the icon with the server. If the icon_hash is not present or the hash does not match the standard procedure for checking icons will be followed.
