### PR TITLE
Warn when any Munki repo URLs are not https

### DIFF
--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1220,6 +1220,11 @@ def pref(pref_name):
     if isinstance(pref_value, NSDate):
         # convert NSDate/CFDates to strings
         pref_value = str(pref_value)
+    if 'URL' in pref_name and not pref_value == None:
+        if not 'https' in pref_value:
+            display_warning(
+                "%s is not secure. See the munki wiki for details on"
+                "securing your repository." % pref_value)
     return pref_value
 
 #####################################################


### PR DESCRIPTION
This is to follow up on the discussion we had had at MacTech regarding munki repos that do not use https.

Any suggestions on a better place to put this sort of check is appreciated, although I think warning at preference load is probably the best as it is less likely to get lost in the output of a normal run.