### PR TITLE
Wait until the user has finished making changes before refreshing.

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
@@ -42,6 +42,7 @@ class MSCMainWindowController(NSWindowController):
     _alertedUserToOutstandingUpdates = False
     
     _update_in_progress = False
+    _pending_update = 0
     managedsoftwareupdate_task = None
     _update_queue = set()
     
@@ -385,6 +386,12 @@ class MSCMainWindowController(NSWindowController):
         # switch to updates view, then display alert
         self.loadUpdatesPage_(self)
         self.alert_controller.forcedLogoutWarning(notification_obj)
+
+    def checkForUpdatesAfterDelay(self, suppress_apple_update_check=False):
+        '''Start an update check session if we've not triggered another'''
+        self._pending_update-=1;
+        if self._pending_update == 0:
+            self.checkForUpdates(suppress_apple_update_check);
 
     def checkForUpdates(self, suppress_apple_update_check=False):
         '''start an update check session'''
@@ -840,7 +847,8 @@ class MSCMainWindowController(NSWindowController):
         
         if MunkiItems.updateCheckNeeded():
             # check for updates after a short delay so UI changes visually complete first
-            self.performSelector_withObject_afterDelay_(self.checkForUpdates, True, 1.0)
+            self._pending_update+=1;
+            self.performSelector_withObject_afterDelay_(self.checkForUpdatesAfterDelay, True, 1.5)
 
     def myItemsActionButtonClicked_(self, item_name):
         '''this method is called from JavaScript when the user clicks

--- a/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
@@ -389,9 +389,9 @@ class MSCMainWindowController(NSWindowController):
 
     def checkForUpdatesAfterDelay(self, suppress_apple_update_check=False):
         '''Start an update check session if we've not triggered another'''
-        self._pending_update-=1;
+        self._pending_update-=1
         if self._pending_update == 0:
-            self.checkForUpdates(suppress_apple_update_check);
+            self.checkForUpdates(suppress_apple_update_check)
 
     def checkForUpdates(self, suppress_apple_update_check=False):
         '''start an update check session'''
@@ -708,6 +708,7 @@ class MSCMainWindowController(NSWindowController):
                          'myItemsActionButtonClicked:',
                          'changeSelectedCategory:',
                          'installButtonClicked',
+                         'incrementPendingUpdate',
                          'updateOptionalInstallButtonClicked:']:
             return NO # this selector is NOT _excluded_ from scripting, so it can be called.
         return YES # disallow everything else
@@ -771,6 +772,9 @@ class MSCMainWindowController(NSWindowController):
                 container_div_classes.append('updating')
                 container_div.setClassName_(' '.join(container_div_classes))
 
+    def incrementPendingUpdate(self):
+        self._pending_update+=1
+
     def updateOptionalInstallButtonClicked_(self, item_name):
         '''this method is called from JavaScript when a user clicks
         the cancel or add button in the updates list'''
@@ -806,6 +810,7 @@ class MSCMainWindowController(NSWindowController):
                 table = document.getElementById_('other-updates-table')
             if not table:
                 msclog.debug_log('Unexpected error: could not find other-updates-table')
+                self._pending_update-=1
                 return
             # this isn't the greatest way to add something to the DOM
             # but it works...
@@ -847,8 +852,9 @@ class MSCMainWindowController(NSWindowController):
         
         if MunkiItems.updateCheckNeeded():
             # check for updates after a short delay so UI changes visually complete first
-            self._pending_update+=1;
-            self.performSelector_withObject_afterDelay_(self.checkForUpdatesAfterDelay, True, 1.5)
+            self.performSelector_withObject_afterDelay_(self.checkForUpdatesAfterDelay, True, 3.5)
+        else:
+            self._pending_update-=1
 
     def myItemsActionButtonClicked_(self, item_name):
         '''this method is called from JavaScript when the user clicks

--- a/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MSCMainWindowController.py
@@ -850,11 +850,8 @@ class MSCMainWindowController(NSWindowController):
         # update count badges
         self.displayUpdateCount()
         
-        if MunkiItems.updateCheckNeeded():
-            # check for updates after a short delay so UI changes visually complete first
-            self.performSelector_withObject_afterDelay_(self.checkForUpdatesAfterDelay, True, 3.5)
-        else:
-            self._pending_update-=1
+        # check for updates after a delay to ensure that user doesn't wish to make more changes.
+        self.performSelector_withObject_afterDelay_(self.checkForUpdatesAfterDelay, True, 3.5)
 
     def myItemsActionButtonClicked_(self, item_name):
         '''this method is called from JavaScript when the user clicks

--- a/code/apps/Managed Software Center/Managed Software Center/WebResources/updates.js
+++ b/code/apps/Managed Software Center/Managed Software Center/WebResources/updates.js
@@ -33,6 +33,7 @@ function showOrHideMoreLinks() {
 function fadeOutAndRemove(item_name) {
     /* add a class to trigger a CSS transition fade-out, then
        register a callback for when the transition completes so we can remove the item */
+    window.AppController.incrementPendingUpdate();
     update_table_row = document.getElementById(item_name + '_update_table_row');
     update_table_row.classList.add('deleted');
     update_table_row.addEventListener('webkitAnimationEnd',


### PR DESCRIPTION
Hi,
One thing I've had complaints about is that it is very hard to make changes when using the Updates tab as it refreshes after each click, so I've attempted to put a delay in.
I initially had a 5 second delay but figured that was too long, so I've settled on 1.5, though I'd be interested to get others' thoughts.
Cheers,
Chris
