### PR TITLE
Support http(s) redirects with client certificates

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -105,7 +105,7 @@ def header_dict_from_list(array):
 
 def get_url(url, destinationpath,
             custom_headers=None, message=None, onlyifnewer=False,
-            resume=False, follow_redirects=False):
+            resume=False, follow_redirects=True):
     """Gets an HTTP or HTTPS URL and stores it in
     destination path. Returns a dictionary of headers, which includes
     http_result_code and http_result_description.
@@ -233,7 +233,7 @@ def getResourceIfChangedAtomically(url,
                                    message=None,
                                    resume=False,
                                    verify=False,
-                                   follow_redirects=False):
+                                   follow_redirects=True):
     """Gets file from a URL.
        Checks first if there is already a file with the necessary checksum.
        Then checks if the file has changed on the server, resuming or
@@ -354,7 +354,7 @@ def getFileIfChangedAtomically(path, destinationpath):
 def getHTTPfileIfChangedAtomically(url, destinationpath,
                                    custom_headers=None,
                                    message=None, resume=False,
-                                   follow_redirects=False):
+                                   follow_redirects=True):
     """Gets file from HTTP URL, checking first to see if it has changed on the
        server.
 

--- a/code/client/munkilib/keychain.py
+++ b/code/client/munkilib/keychain.py
@@ -142,6 +142,11 @@ def get_munki_client_cert_info():
             url = munkicommon.pref(key)
             if url:
                 site_urls.append(url.rstrip('/') + '/')
+        # CertificateWildcardURL cannot contain an ending /, so separate it out:
+        for key in ['CertificateWildcardURL']:
+            url = munkicommon.pref(key)
+            if url:
+                site_urls.append(url)
         cert_info['site_urls'] = site_urls
     return cert_info
 


### PR DESCRIPTION
This commit enables redirects for http(s).
In order for https-redirects to work with client certificates, we also
need to add a wildcard identity-preference in the format of
*.example.com .
This is done with the CertificateWildcardURL preference.