### PR TITLE
More context in the logs for auto runs

### DIFF
--- a/code/client/managedsoftwareupdate
+++ b/code/client/managedsoftwareupdate
@@ -861,6 +861,7 @@ def main():
                     # no GUI users, system is idle, so we can install
                     # but first, enable status output over login window
                     munkicommon.munkistatusoutput = True
+                    munkicommon.log('No GUI users, installing at login window.')
                     munkistatus.launchMunkiStatus()
                     mustrestart = doInstallTasks(appleupdatesavailable)
 


### PR DESCRIPTION
The idea here is to make the default log level have slightly more context in them regarding which type of auto run it was.

I've found that when troubleshooting issues after the fact, it is sometimes difficult to determine if things were installed at login window or within a User's GUI session. This makes it clear when it is a login window auto runtype, with all other runs implicitly being user session runs.