### PR TITLE
Add AllowHTTPRedirects client option: true, false, "https"

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -101,10 +101,9 @@ def header_dict_from_list(array):
             header_dict[key.strip()] = value.strip()
     return header_dict
 
-
 def get_url(url, destinationpath,
             custom_headers=None, message=None, onlyifnewer=False,
-            resume=False, follow_redirects=None):
+            resume=False, follow_redirects=False):
     """Gets an HTTP or HTTPS URL and stores it in
     destination path. Returns a dictionary of headers, which includes
     http_result_code and http_result_description.
@@ -115,9 +114,6 @@ def get_url(url, destinationpath,
     server.
     If you set resume to True, Gurl will attempt to resume an
     interrupted download."""
-
-    if follow_redirects is None:
-        follow_redirects = munkicommon.pref('AllowHTTPRedirects')
 
     tempdownloadpath = destinationpath + '.download'
     if os.path.exists(tempdownloadpath) and not resume:
@@ -135,7 +131,8 @@ def get_url(url, destinationpath,
 
     options = {'url': url,
                'file': tempdownloadpath,
-               'follow_redirects': follow_redirects,
+               'must_follow_redirects': follow_redirects,
+               'allow_redirects': munkicommon.pref('AllowHTTPRedirects'),
                'can_resume': resume,
                'additional_headers': header_dict_from_list(custom_headers),
                'download_only_if_changed': onlyifnewer,
@@ -235,7 +232,7 @@ def getResourceIfChangedAtomically(url,
                                    message=None,
                                    resume=False,
                                    verify=False,
-                                   follow_redirects=None):
+                                   follow_redirects=False):
     """Gets file from a URL.
        Checks first if there is already a file with the necessary checksum.
        Then checks if the file has changed on the server, resuming or
@@ -356,7 +353,7 @@ def getFileIfChangedAtomically(path, destinationpath):
 def getHTTPfileIfChangedAtomically(url, destinationpath,
                                    custom_headers=None,
                                    message=None, resume=False,
-                                   follow_redirects=None):
+                                   follow_redirects=False):
     """Gets file from HTTP URL, checking first to see if it has changed on the
        server.
 

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -69,7 +69,6 @@ class PackageVerificationError(MunkiDownloadError):
     """Package failed verification"""
     pass
 
-
 def getxattr(pathname, attr):
     """Get a named xattr from a file. Return None if not present"""
     if attr in xattr.listxattr(pathname):
@@ -105,7 +104,7 @@ def header_dict_from_list(array):
 
 def get_url(url, destinationpath,
             custom_headers=None, message=None, onlyifnewer=False,
-            resume=False, follow_redirects=False):
+            resume=False, follow_redirects=None):
     """Gets an HTTP or HTTPS URL and stores it in
     destination path. Returns a dictionary of headers, which includes
     http_result_code and http_result_description.
@@ -116,6 +115,9 @@ def get_url(url, destinationpath,
     server.
     If you set resume to True, Gurl will attempt to resume an
     interrupted download."""
+
+    if follow_redirects is None:
+        follow_redirects = munkicommon.pref('AllowHTTPRedirects')
 
     tempdownloadpath = destinationpath + '.download'
     if os.path.exists(tempdownloadpath) and not resume:
@@ -184,7 +186,7 @@ def get_url(url, destinationpath,
     if connection.error != None:
         # Gurl returned an error
         munkicommon.display_detail(
-            'Download error %s: %s', connection.error.code(), 
+            'Download error %s: %s', connection.error.code(),
             connection.error.localizedDescription())
         if connection.SSLerror:
             munkicommon.display_detail(
@@ -193,7 +195,7 @@ def get_url(url, destinationpath,
         munkicommon.display_detail('Headers: %s', connection.headers)
         if os.path.exists(tempdownloadpath) and not resume:
             os.remove(tempdownloadpath)
-        raise GurlError(connection.error.code(), 
+        raise GurlError(connection.error.code(),
                         connection.error.localizedDescription())
 
     if connection.response != None:
@@ -233,7 +235,7 @@ def getResourceIfChangedAtomically(url,
                                    message=None,
                                    resume=False,
                                    verify=False,
-                                   follow_redirects=False):
+                                   follow_redirects=None):
     """Gets file from a URL.
        Checks first if there is already a file with the necessary checksum.
        Then checks if the file has changed on the server, resuming or
@@ -354,7 +356,7 @@ def getFileIfChangedAtomically(path, destinationpath):
 def getHTTPfileIfChangedAtomically(url, destinationpath,
                                    custom_headers=None,
                                    message=None, resume=False,
-                                   follow_redirects=False):
+                                   follow_redirects=None):
     """Gets file from HTTP URL, checking first to see if it has changed on the
        server.
 
@@ -486,4 +488,3 @@ def verifySoftwarePackageIntegrity(file_path, item_hash, always_hash=False):
             'illegal value: %s' % munkicommon.pref('PackageVerificationMode'))
 
     return (False, chash)
-

--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -24,6 +24,7 @@ curl replacement using NSURLConnection and friends
 
 import os
 import xattr
+from urlparse import urlparse
 
 # PyLint cannot properly find names inside Cocoa libraries, so issues bogus
 # No name 'Foo' in module 'Bar' warnings. Disable them.
@@ -361,8 +362,9 @@ class Gurl(NSObject):
         # site that told us to redirect. All we know is that we were told
         # to redirect and where the new location is.
         newURL = request.URL().absoluteString()
+        parsedURL = urlparse(newURL)
         self.redirection.append([newURL, dict(response.allHeaderFields())])
-        if self.follow_redirects:
+        if (self.follow_redirects == 'https' and parsedURL.scheme == 'https') or self.follow_redirects:
             # Allow the redirect
             self.log('Allowing redirect to: %s' % newURL)
             return request

--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -364,7 +364,8 @@ class Gurl(NSObject):
         newURL = request.URL().absoluteString()
         parsedURL = urlparse(newURL)
         self.redirection.append([newURL, dict(response.allHeaderFields())])
-        if (self.follow_redirects == 'https' and parsedURL.scheme == 'https') or self.follow_redirects:
+        if (self.follow_redirects == 'https' and parsedURL.scheme == 'https') or \
+           self.follow_redirects == True:
             # Allow the redirect
             self.log('Allowing redirect to: %s' % newURL)
             return request

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1209,7 +1209,7 @@ def pref(pref_name):
         'SuppressAutoInstall': False,
         'SuppressStopButtonOnInstall': False,
         'PackageVerificationMode': 'hash',
-        'AllowHTTPRedirects': False,
+        'AllowHTTPRedirects': 'none',
     }
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value == None:

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1208,7 +1208,8 @@ def pref(pref_name):
         'SuppressUserNotification': False,
         'SuppressAutoInstall': False,
         'SuppressStopButtonOnInstall': False,
-        'PackageVerificationMode': 'hash'
+        'PackageVerificationMode': 'hash',
+        'AllowHTTPRedirects': False,
     }
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value == None:

--- a/tests/code/client/munkilib/gurl_redirects_test.py
+++ b/tests/code/client/munkilib/gurl_redirects_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+# encoding: utf-8
+"""
+gurl_redirects_test.py
+
+Unit tests for munkicommon's display_* functions.
+
+"""
+# Copyright 2015 Andreas Fuchs.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from gurl import Gurl
+import munkicommon
+import sys
+import unittest
+
+def log(msg, logname=''):
+    """Redefine munkicommon's logging function so our tests don't write
+    a bunch of garbage to Munki's logs"""
+    pass
+munkicommon.log = log
+
+class GurlUnitTest(unittest.TestCase):
+    def gurl(self, must_follow_redirects=False, allow_redirects='none'):
+        options = {'url': 'http://example.com',
+                   'file': '/tmp/munki_test_tempfile',
+                   'must_follow_redirects': must_follow_redirects,
+                   'allow_redirects': allow_redirects,
+                   'can_resume': False,
+                   'additional_headers': dict(),
+                   'download_only_if_changed': False,
+                   'cache_data': None,
+                   'logging_function': munkicommon.display_debug2}
+        return Gurl.alloc().initWithOptions_(options)
+
+class TestMustFollowRedirect(GurlUnitTest):
+    """Test behavior on following redirects as requested by munki
+    internals."""
+
+    def test_with_allowed_redirects_none(self):
+        gurl = self.gurl(must_follow_redirects = True, allow_redirects = 'none')
+        self.assertEqual(True, gurl.redirect_allowed('http://something.com'))
+
+    def test_with_allowed_redirects_https(self):
+        gurl = self.gurl(must_follow_redirects = True, allow_redirects = 'https')
+        self.assertEqual(True, gurl.redirect_allowed('http://something.com'))
+
+    def test_with_allowed_redirects_all(self):
+        gurl = self.gurl(must_follow_redirects = True, allow_redirects = 'all')
+        self.assertEqual(True, gurl.redirect_allowed('http://something.com'))
+
+class TestAllowRedirects(GurlUnitTest):
+    """Test behavior on following redirects as given by the preference
+    AllowHTTPRedirects."""
+
+    def test_disallow_for_none(self):
+        gurl = self.gurl(allow_redirects = 'none')
+        self.assertEqual(False, gurl.redirect_allowed('http://unsafe.example.com'))
+        self.assertEqual(False, gurl.redirect_allowed('https://ssl.example.com'))
+
+    def test_allow_only_https(self):
+        gurl = self.gurl(allow_redirects = 'https')
+        self.assertEqual(False, gurl.redirect_allowed('http://unsafe.example.com'))
+        self.assertEqual(True, gurl.redirect_allowed('https://ssl.example.com'))
+
+    def test_allow_all(self):
+        gurl = self.gurl(allow_redirects = 'all')
+        self.assertEqual(True, gurl.redirect_allowed('http://unsafe.example.com'))
+        self.assertEqual(True, gurl.redirect_allowed('https://ssl.example.com'))
+
+    def test_treat_others_as_none(self):
+        for value in ['oink', 1, True, dict()]:
+            gurl = self.gurl(allow_redirects = value)
+            self.assertEqual(False, gurl.redirect_allowed('http://unsafe.example.com'))
+            self.assertEqual(False, gurl.redirect_allowed('https://ssl.example.com'))
+
+def main():
+    unittest.main(buffer=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds an option to the munki client called AllowHTTPRedirects,
which can have three values:

* `false` (the default) - never follow redirects,
* `true` - always follow redirects,
* `"https"` - follow redirects only to HTTPS URLs.

I believe this may be what was requested in #452 - hope this is more acceptable (: