### PR TITLE
builtin.super doesn't work with Cocoa classes, use objc.super instead

### DIFF
--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -25,6 +25,9 @@ curl replacement using NSURLConnection and friends
 import os
 import xattr
 
+# builtin super doesn't work with Cocoa classes in recent PyObjC releases.
+from objc import super
+
 # PyLint cannot properly find names inside Cocoa libraries, so issues bogus
 # No name 'Foo' in module 'Bar' warnings. Disable them.
 # pylint: disable=E0611


### PR DESCRIPTION
This will allow support for more recent PyObjC installs (3.x) than what's on the system (2.x).

Using objc.super works with system python/pyobjc on both 10.9 and 10.10.

Ref: https://bitbucket.org/ronaldoussoren/pyobjc/issue/110/