### PR TITLE
Check for a nil NSNotification.userInfo dict for 10.6

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/MSCAppDelegate.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MSCAppDelegate.py
@@ -46,13 +46,15 @@ class MSCAppDelegate(NSObject):
     def applicationDidFinishLaunching_(self, sender):
         '''NSApplication delegate method called at launch'''
         
-        userNotification = sender.userInfo().get('NSApplicationLaunchUserNotificationKey')
-        # we get this notification at launch because it's too early to have declared ourself
-        # a NSUserNotificationCenterDelegate
-        if userNotification:
-            NSLog("Launched via Notification interaction")
-            self.userNotificationCenter_didActivateNotification_(
-                NSUserNotificationCenter.defaultUserNotificationCenter(), userNotification)
+        # userInfo dict can be nil, seems to be with 10.6
+        if sender.userInfo():
+            userNotification = sender.userInfo().get('NSApplicationLaunchUserNotificationKey')
+            # we get this notification at launch because it's too early to have declared ourself
+            # a NSUserNotificationCenterDelegate
+            if userNotification:
+                NSLog("Launched via Notification interaction")
+                self.userNotificationCenter_didActivateNotification_(
+                    NSUserNotificationCenter.defaultUserNotificationCenter(), userNotification)
         
         # Prevent automatic relaunching at login on Lion+
         if NSApp.respondsToSelector_('disableRelaunchOnLogin'):


### PR DESCRIPTION
I found this issue introduced with 42e2cf17f1e63511bb717f0c38637b3784f0ea6e in the process of testing for #484. I'm guessing that it's ok for this whole block to not execute on 10.6, since it's only for handling data from Notification Center. This whole section of Munki is code I'm very unfamiliar with but I hope this simple check is sufficient for supporting 10.6.

The comment spells out the reasoning, though if it's preferable it could instead be done with a 10.6 OS version check is done a little further down in this method, assuming that in other OSes userInfo() doesn't return a NoneType. I tested that on Lion this issue isn't present, and I haven't ever noticed this issue on 10.8 and 10.9 VMs that have been running on master since the initial NC support was committed.