### PR TITLE
add arguments check to criteria test

### DIFF
--- a/code/client/makepkginfo
+++ b/code/client/makepkginfo
@@ -1131,7 +1131,8 @@ def main():
     # add user/environment metadata
     catinfo['_metadata'] = make_pkginfo_metadata()
 
-    if not has_valid_install_critieria(catinfo):
+    if (len(arguments) == 1 and
+            not has_valid_install_critieria(catinfo)):
         item = catinfo['name']
         msg = (
             "WARNING: pkginfo for '%s' contains no installation check info!\n"


### PR DESCRIPTION
Checks for a single argument (installer item) as well as has_valid_install_critieria.  

Multiple arguments fail (with warnings) via other checks, zero arguments (script_options) pass for pkginfo generation.