### PR TITLE
Update getmanifest to create unique filename for local copy of manifest

### DIFF
--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2635,7 +2635,7 @@ def cleanUpManifests(subdir=""):
             else:
                 os.unlink(path)
 
-    # Remove folder is empty
+    # Remove folder if empty
     try:
         os.rmdir(manifest_dir)
     except OSError:

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2635,11 +2635,12 @@ def cleanUpManifests():
 
     for (dirpath, dirnames, filenames) in os.walk(manifest_dir, topdown=False):
         for name in filenames:
+
+            if name in exceptions:
+                continue
+                
             abs_path = os.path.join(dirpath, name)
             rel_path = abs_path[len(manifest_dir):].lstrip("/")
-
-            if rel_path in exceptions:
-                continue
 
             if rel_path not in MANIFESTS.keys():
                 os.unlink(abs_path)

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2572,7 +2572,10 @@ def getmanifest(partialurl, suppress_errors=False):
     else:
         # request for nested manifest
         manifestdisplayname = partialurl
-        manifestname = os.path.split(partialurl)[1]
+        
+        valid_chars = "-_.() %s%s" % (string.ascii_letters, string.digits)
+        manifestname = ''.join(c if c in valid_chars else "_" for c in partialurl)
+
         manifesturl = manifestbaseurl + urllib2.quote(partialurl)
 
     if manifestname in MANIFESTS:

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2622,12 +2622,20 @@ def cleanUpManifests(subdir=""):
     manifest_dir = os.path.join(munkicommon.pref('ManagedInstallDir'),
                                'manifests')
 
+    exceptions = [
+        "SelfServeManifest"
+    ]
+
     # For recursive calls (checking subfolders), append subdir to root manifest directory
     if subdir:
         manifest_dir = os.path.join(manifest_dir, subdir)
 
     for item in os.listdir(manifest_dir):
         cachename = os.path.join(subdir, item)
+
+        if cachename in exceptions:
+            continue
+            
         if cachename not in MANIFESTS.keys():
             path = os.path.join(manifest_dir, item)
             if os.path.isdir(path):

--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2611,8 +2611,8 @@ def getmanifest(partialurl, suppress_errors=False):
         manifestname = partialurl
         manifesturl = manifestbaseurl + urllib2.quote(partialurl)
 
-    if manifestname in MANIFESTS:
-        return MANIFESTS[manifestname]
+    if getFromManifestCache(manifestname)
+        return getFromManifestCache(manifestname)
 
     munkicommon.display_debug2('Manifest base URL is: %s', manifestbaseurl)
     munkicommon.display_detail('Getting manifest %s...', manifestdisplayname)
@@ -2650,7 +2650,7 @@ def getmanifest(partialurl, suppress_errors=False):
         raise ManifestException(errormsg)
     else:
         # plist is valid
-        MANIFESTS[manifestname] = manifestpath
+        addToManifestCache(manifestname, manifestpath)
         return manifestpath
 
 


### PR DESCRIPTION
One thing I noticed in the way Munki handles manifests is that it uses the filename part when storing locally. This means that having multiple manifests with the same name but in different folders will cause clients to play up.

This changes the local naming scheme for manifests to allow multiple manifests with the same name, but in different folders on the server. It does this by including the relative folder portion of the path in the manifest filename.