### PR TITLE
Allows gURL to send post data

### DIFF
--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -33,7 +33,7 @@ from objc import super
 # pylint: disable=E0611
 from Foundation import NSBundle
 from Foundation import NSRunLoop, NSDate
-from Foundation import NSObject, NSURL, NSURLConnection
+from Foundation import NSObject, NSData, NSString, NSURL, NSURLConnection
 from Foundation import NSMutableURLRequest
 from Foundation import NSURLRequestReloadIgnoringLocalCacheData
 from Foundation import NSURLResponseUnknownLength
@@ -141,6 +141,8 @@ class Gurl(NSObject):
 
         self.log = options.get('logging_function', NSLog)
 
+        self.post_data = options.get('post_data', None)
+
         self.resume = False
         self.response = None
         self.headers = None
@@ -167,6 +169,12 @@ class Gurl(NSObject):
             NSMutableURLRequest.requestWithURL_cachePolicy_timeoutInterval_(
                 url, NSURLRequestReloadIgnoringLocalCacheData,
                 self.connection_timeout))
+        if self.post_data:
+            request.setHTTPMethod_('POST')
+            data_unicode = unicode(self.post_data)
+            data = NSData.dataWithBytes_length_(NSString.stringWithString_(data_unicode).UTF8String(), len(data_unicode.encode('utf-8')))
+            request.setHTTPBody_(data)
+
         if self.additional_headers:
             for header, value in self.additional_headers.items():
                 request.setValue_forHTTPHeaderField_(value, header)


### PR DESCRIPTION
This is the modification I made to gurl.py to allow Imagr to send POST data. This would probably be useful for pre and postflight scripts to have available to them.