### PR TITLE
only create Managed Software Update.app symlink if it previously existed

### DIFF
--- a/code/pkgtemplate/Scripts_app/preinstall
+++ b/code/pkgtemplate/Scripts_app/preinstall
@@ -1,13 +1,11 @@
 #!/bin/sh
 
-# remove any Managed Software Update.app bundle since the installer
-# won't replace a bundle with a symlink, leading to yucky stuff like
-# "/Applications/Utilities/Managed Software Update.app 1"
+# Replace any Managed Software Update.app bundle with a symlink to Managed
+# Software Center.app
 
 if [ -d "$3/Applications/Utilities/Managed Software Update.app" ] ; then
     /bin/rm -r "$3/Applications/Utilities/Managed Software Update.app"
-fi
-
-if [ -d "$3/Applications/Utilities/Managed Software Update.app 1" ] ; then
-    /bin/rm -r "$3/Applications/Utilities/Managed Software Update.app 1"
+    # make a symlink for the old MSU.app
+    /bin/ln -s "$3/Applications/Managed Software Center.app" \
+    "$3/Applications/Utilities/Managed Software Update.app"
 fi

--- a/code/tools/make_munki_mpkg.sh
+++ b/code/tools/make_munki_mpkg.sh
@@ -174,7 +174,7 @@ echo "  metapackage version: $MPKGVERSION"
 echo
 
 # Build Managed Software Center.
-echo "Building Managed Software Update.xcodeproj..."
+echo "Building Managed Software Center.xcodeproj..."
 pushd "$MUNKIROOT/code/apps/Managed Software Center" > /dev/null
 /usr/bin/xcodebuild -project "Managed Software Center.xcodeproj" -alltargets clean > /dev/null
 /usr/bin/xcodebuild -project "Managed Software Center.xcodeproj" -alltargets build > /dev/null
@@ -368,7 +368,7 @@ echo "Creating applications package template..."
 # Create directory structure.
 APPROOT="$PKGTMP/munki_app"
 mkdir -m 1775 "$APPROOT"
-mkdir -p "$APPROOT/Applications/Utilities"
+mkdir "$APPROOT/Applications"
 chmod -R 775 "$APPROOT/Applications"
 # Copy Managed Software Center application.
 cp -R "$MSCAPP" "$APPROOT/Applications/"
@@ -376,8 +376,6 @@ cp -R "$MSCAPP" "$APPROOT/Applications/"
 cp -R "$MSAPP" "$APPROOT/Applications/Managed Software Center.app/Contents/Resources/"
 # make sure not writeable by group or other
 chmod -R go-w "$APPROOT/Applications/Managed Software Center.app"
-# make a symlink for the old MSU.app
-ln -s "../Managed Software Center.app" "$APPROOT/Applications/Utilities/Managed Software Update.app"
 # Create package info file.
 APPSIZE=`du -sk $APPROOT | cut -f1`
 NFILES=$(echo `find $APPROOT/ | wc -l`)


### PR DESCRIPTION
Resolves the issue from the last commit of #502