### PR TITLE
Remove find() breaks

### DIFF
--- a/code/client/manifestutil
+++ b/code/client/manifestutil
@@ -424,7 +424,7 @@ def find(args):
                     print '%s (%s): %s' % (name, key, value)
                     count += 1
 
-    print '%s items found.' % count
+    print '%s matches found.' % count
     return 0
 
 

--- a/code/client/manifestutil
+++ b/code/client/manifestutil
@@ -404,7 +404,6 @@ def find(args):
                             if findtext.upper() in item.upper():
                                 print '%s: %s' % (name, item)
                                 count += 1
-                                break
                         except AttributeError, err:
                             pass
                 elif findtext.upper() in value.upper():
@@ -419,7 +418,6 @@ def find(args):
                             if findtext.upper() in item.upper():
                                 print '%s (%s): %s' % (name, key, item)
                                 count += 1
-                                break
                         except AttributeError, err:
                             pass
                 elif findtext.upper() in value.upper():


### PR DESCRIPTION
Removing the breaks in the find function to allow multiple matches per section per manifest.
Addresses issue https://github.com/munki/munki/issues/512

Before the edits:

```
> find 2016 
testFind (managed_installs): my2016
1 items found.
> find 2016 --section managed_installs
testFind: my2016
1 items found.
```

After the edits:

```
> find 2016
testFind (managed_installs): my2016
testFind (managed_installs): your2016
2 items found.
> find 2016 --section managed_installs
testFind: my2016
testFind: your2016
2 items found.
```

