### PR TITLE
Add logging about skipped ASU checks when installing Apple items.

### DIFF
--- a/code/client/managedsoftwareupdate
+++ b/code/client/managedsoftwareupdate
@@ -766,7 +766,8 @@ def main():
             os.unlink(appleupdates_plist)
         except OSError:
             pass
-
+        munkicommon.log('Not doing Apple Software Updates because we are '
+                        'installing Apple items with Munki items.')
     else:
         # check the normal preferences
         should_do_apple_updates = munkicommon.pref(
@@ -878,7 +879,7 @@ def main():
                     munkicommon.log('No GUI users, installing at login window.')
                     munkistatus.launchMunkiStatus()
                     mustrestart = doInstallTasks(appleupdatesavailable)
-                    # reset our count of available updates 
+                    # reset our count of available updates
                     updatesavailable = 0
                     appleupdatesavailable = 0
             else:  # there are GUI users


### PR DESCRIPTION
After running into a situation where no ASU checks were done on clients due to a pending Apple item (Java 6) I realized no logging is done about it. Though the behavior is by design and not problematic by itself, not having any logging about it can be confusing. I've added a single line of logging to make it easier to recognize this case.