### PR TITLE
Preference to Follow HTTP Recirects

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -225,7 +225,6 @@ def get_url(url, destinationpath,
         raise HTTPError(connection.status,
                         connection.headers.get('http_result_description',''))
 
-
 def getResourceIfChangedAtomically(url,
                                    destinationpath,
                                    custom_headers=None,
@@ -268,6 +267,10 @@ def getResourceIfChangedAtomically(url,
         munkicommon.log('Cached payload does not match hash in catalog, '
                 'will check if changed and redownload: %s' % destinationpath)
         #continue with normal if-modified-since/etag update methods.
+
+    if follow_redirects != True:
+        # If we haven't explicitly said to follow redirect, the preference decides
+        follow_redirects = munkicommon.pref('FollowHTTPRedirects')
 
     url_parse = urlparse.urlparse(url)
     if url_parse.scheme in ['http', 'https']:

--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -24,6 +24,7 @@ curl replacement using NSURLConnection and friends
 
 import os
 import xattr
+from urlparse import urlparse
 
 # builtin super doesn't work with Cocoa classes in recent PyObjC releases.
 from objc import super
@@ -374,12 +375,19 @@ class Gurl(NSObject):
         # to redirect and where the new location is.
         newURL = request.URL().absoluteString()
         self.redirection.append([newURL, dict(response.allHeaderFields())])
-        if self.follow_redirects:
+        newParsedURL = urlparse(newURL)
+        if self.follow_redirects == True or self.follow_redirects == 'all':
             # Allow the redirect
             self.log('Allowing redirect to: %s' % newURL)
             return request
+        elif self.follow_redirects == 'https' and newParsedURL.scheme == 'https':
+            # Once again, allow the redirect
+            self.log('Allowing redirect to: %s' % newURL)
+            return request
         else:
-            # Deny the redirect
+            # If we're down here either the preference was set to 'none',
+            # the url we're forwarding on to isn't https or follow_redirects
+            # was explicitly set to False
             self.log('Denying redirect to: %s' % newURL)
             return None
 

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1212,7 +1212,8 @@ def pref(pref_name):
         'SuppressUserNotification': False,
         'SuppressAutoInstall': False,
         'SuppressStopButtonOnInstall': False,
-        'PackageVerificationMode': 'hash'
+        'PackageVerificationMode': 'hash',
+        'FollowTTPRedirects': 'none',
     }
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value == None:

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1213,7 +1213,7 @@ def pref(pref_name):
         'SuppressAutoInstall': False,
         'SuppressStopButtonOnInstall': False,
         'PackageVerificationMode': 'hash',
-        'FollowTTPRedirects': 'none',
+        'FollowHTTPRedirects': 'none',
     }
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value == None:


### PR DESCRIPTION
This adds a preference to allow Munki to follow HTTP redirects (``FollowHTTPRedirects``). 

The possible values are:

* ``none`` - This is the default and is the same as the present behaviour. No redirects are followed.
* ``https`` - Only redirects to URLs using HTTPS are followed. Redirects to HTTP URLs are not followed.
* ``all`` - Redirects to both HTTP and HTTPS URLs are followed.