### PR TITLE
Set User-Agent header in HTTP requests

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -25,6 +25,7 @@ Created by Greg Neagle on 2011-09-29.
 import calendar
 import errno
 import os
+import sys
 import re
 import shutil
 import subprocess
@@ -39,6 +40,7 @@ import munkicommon
 from gurl import Gurl
 
 from Foundation import NSHTTPURLResponse
+import FoundationPlist
 
 
 # XATTR name storing the ETAG of the file when downloaded via http(s).
@@ -97,8 +99,10 @@ def header_dict_from_list(array):
     header_dict = {}
     machine = munkicommon.getMachineFacts()
     darwin_version = os.uname()[2]
-    header_dict["User-Agent"] = ("managedsoftwareupdate/%s Darwin/%s (%s) (%s)"
-        % (machine['munki_version'], darwin_version,
+    python_version = "%d.%d.%d" % (sys.version_info[0],sys.version_info[1],sys.version_info[2])
+    cfnetwork_version = FoundationPlist.readPlist("/System/Library/Frameworks/CFNetwork.framework/Resources/Info.plist")['CFBundleShortVersionString']
+    header_dict["User-Agent"] = ("Python/%s CFNetwork/%s managedsoftwareupdate/%s Darwin/%s (%s) (%s)"
+        % (python_version, cfnetwork_version, machine['munki_version'], darwin_version,
            machine['arch'], machine['machine_model']))
 
     if array is None:

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -93,8 +93,15 @@ def writeCachedChecksum(file_path, fhash=None):
 def header_dict_from_list(array):
     """Given a list of strings in http header format, return a dict.
     If array is None, return None"""
+    header_dict = {}
+    machine = munkicommon.getMachineFacts()
+    darwin_version = os.uname()[2]
+    header_dict["User-Agent"] = ("managedsoftwareupdate/%s Darwin/%s (%s) (%s)"
+        % (machine['munki_version'], darwin_version,
+           machine['arch'], machine['machine_model']))
+
     if array is None:
-        return array
+        return header_dict
     header_dict = {}
     for item in array:
         (key, sep, value) = item.partition(':')

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -92,7 +92,8 @@ def writeCachedChecksum(file_path, fhash=None):
 
 def header_dict_from_list(array):
     """Given a list of strings in http header format, return a dict.
-    If array is None, return None"""
+    A User-Agent header is added if none is present in the list.
+    If array is None, returns a dict with only the User-Agent header."""
     header_dict = {}
     machine = munkicommon.getMachineFacts()
     darwin_version = os.uname()[2]

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -48,6 +48,15 @@ XATTR_ETAG = 'com.googlecode.munki.etag'
 # XATTR name storing the sha256 of the file after original download by munki.
 XATTR_SHA = 'com.googlecode.munki.sha256'
 
+# default value for User-Agent header
+machine = munkicommon.getMachineFacts()
+darwin_version = os.uname()[2]
+python_version = "%d.%d.%d" % sys.version_info[:3]
+cfnetwork_version = FoundationPlist.readPlist("/System/Library/Frameworks/CFNetwork.framework/Resources/Info.plist")['CFBundleShortVersionString']
+DEFAULT_USER_AGENT = "Python/%s CFNetwork/%s managedsoftwareupdate/%s Darwin/%s (%s) (%s)"
+                     % (python_version, cfnetwork_version, machine['munki_version'],
+                        darwin_version, machine['arch'], machine['machine_model'])
+
 
 class GurlError(Exception):
     pass
@@ -97,13 +106,7 @@ def header_dict_from_list(array):
     A User-Agent header is added if none is present in the list.
     If array is None, returns a dict with only the User-Agent header."""
     header_dict = {}
-    machine = munkicommon.getMachineFacts()
-    darwin_version = os.uname()[2]
-    python_version = "%d.%d.%d" % (sys.version_info[0],sys.version_info[1],sys.version_info[2])
-    cfnetwork_version = FoundationPlist.readPlist("/System/Library/Frameworks/CFNetwork.framework/Resources/Info.plist")['CFBundleShortVersionString']
-    header_dict["User-Agent"] = ("Python/%s CFNetwork/%s managedsoftwareupdate/%s Darwin/%s (%s) (%s)"
-        % (python_version, cfnetwork_version, machine['munki_version'], darwin_version,
-           machine['arch'], machine['machine_model']))
+    header_dict["User-Agent"] = DEFAULT_USER_AGENT
 
     if array is None:
         return header_dict

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -53,9 +53,9 @@ machine = munkicommon.getMachineFacts()
 darwin_version = os.uname()[2]
 python_version = "%d.%d.%d" % sys.version_info[:3]
 cfnetwork_version = FoundationPlist.readPlist("/System/Library/Frameworks/CFNetwork.framework/Resources/Info.plist")['CFBundleShortVersionString']
-DEFAULT_USER_AGENT = "Python/%s CFNetwork/%s managedsoftwareupdate/%s Darwin/%s (%s) (%s)"
-                     % (python_version, cfnetwork_version, machine['munki_version'],
-                        darwin_version, machine['arch'], machine['machine_model'])
+DEFAULT_USER_AGENT = "Python/%s CFNetwork/%s managedsoftwareupdate/%s Darwin/%s (%s) (%s)" % (
+                      python_version, cfnetwork_version, machine['munki_version'],
+                      darwin_version, machine['arch'], machine['machine_model'])
 
 
 class GurlError(Exception):

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -103,7 +103,6 @@ def header_dict_from_list(array):
 
     if array is None:
         return header_dict
-    header_dict = {}
     for item in array:
         (key, sep, value) = item.partition(':')
         if sep and value:


### PR DESCRIPTION
Right now Munki only sets a User-Agent header on requests made from the appleupdates.py code. Everything else (catalog, manifest, package downloading) reports something like `"Python/2.7.5 CFNetwork/673.6 Darwin/13.4.0 (x86_64) (VMware7%2C1)"` to the server. For certain server-side stuff, it can be useful to have something like `managedsoftwareupdate/2.3.1.2535` prepended.