### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,6 @@ munki
 
 _Managed software installation for OS X_
 
-###Announcement
-An exploit has been discovered against Munki tools older than version 2.1.
-
-Untrusted input can be passed to the curl binary, causing arbitrary files to be downloaded to arbitrary locations.
-
-Recommendation is to update to Munki 2.1 or later, which is not susceptible to this exploit, as version 2.1 and later no longer use the curl binary for http/https communication.
-
-This vulnerability has been assigned a CVE ID: CVE-2015-2211
-
-If you cannot update to Munki 2.1, there is a patch for Munki 2.0.1 here:
-https://github.com/munki/munki/releases/tag/v2.0.1.2254
-
-And another for Munki 1.0.0 here:
-https://github.com/munki/munki/releases/tag/v1.0.0.1896.0
-
 ####Introduction
 
 Munki is a set of tools that, used together with a webserver-based repository of packages and package metadata, can be used by OS X administrators to manage software installs (and in many cases removals) on OS X client machines.
@@ -41,3 +26,18 @@ If you have questions, or need additional help getting started, the [munki-dev](
 Issues with MunkiWebAdmin should be discussed in its group: [munki-web-admin](http://groups.google.com/group/munki-web-admin).
 
 ![](https://github.com/munki/munki/wiki/images/managed_software_center.png)
+
+###Announcement
+An exploit has been discovered against Munki tools older than version 2.1.
+
+Untrusted input can be passed to the curl binary, causing arbitrary files to be downloaded to arbitrary locations.
+
+Recommendation is to update to Munki 2.1 or later, which is not susceptible to this exploit, as version 2.1 and later no longer use the curl binary for http/https communication.
+
+This vulnerability has been assigned a CVE ID: CVE-2015-2211
+
+If you cannot update to Munki 2.1, there is a patch for Munki 2.0.1 here:
+https://github.com/munki/munki/releases/tag/v2.0.1.2254
+
+And another for Munki 1.0.0 here:
+https://github.com/munki/munki/releases/tag/v1.0.0.1896.0


### PR DESCRIPTION
Moves the announcement to the bottom of the readme.  It has been at the top of the page for 8 months and while still important, doesn't need to be the first text one reads about Munki.