### PR TITLE
Ensure 60, 30, 10 & 5m reboot notices are seen.

### DIFF
--- a/code/client/logouthelper
+++ b/code/client/logouthelper
@@ -28,7 +28,7 @@ import os
 import time
 from munkilib import munkicommon
 from munkilib import FoundationPlist
-from munkilib import updatecheck 
+from munkilib import updatecheck
 from Foundation import NSDate
 from Foundation import NSDictionary
 from Foundation import NSDistributedNotificationCenter
@@ -37,7 +37,7 @@ from Foundation import NSNotificationPostToAllSessions
 
 
 NOTIFICATION_MINS = [240, 180, 120, 90, 60, 45, 30, 15, 10, 5]
-MINIMUM_NOTIFICATION_MINS = 60
+MANDATORY_NOTIFICATIONS = [60, 30, 10, 5]
 
 def log(msg):
     '''Logs messages from this tool with an identifier'''
@@ -50,7 +50,7 @@ def earliestForceInstallDate():
     Returns None or earliest force_install_after_date converted to local time
     '''
     earliest_date = None
-    
+
     ManagedInstallDir = munkicommon.pref('ManagedInstallDir')
     installinfo_types = {
         'InstallInfo.plist' : 'managed_installs',
@@ -92,7 +92,7 @@ def alertUserOfForcedLogout(info=None):
     '''
     consoleuser = munkicommon.getconsoleuser()
     if not munkicommon.findProcesses(
-        exe="/Applications/Managed Software Center.app", 
+        exe="/Applications/Managed Software Center.app",
         user=consoleuser):
         # Managed Software Center.app isn't running.
         # Use our LaunchAgent to start
@@ -107,17 +107,17 @@ def alertUserOfForcedLogout(info=None):
         # because if we don't, sending the logoutwarn notification
         # may fall on deaf ears.
         time.sleep(4)
-    
+
     # if set, convert Python dictionary to NSDictionary.
     if info is not None:
         info = NSDictionary.dictionaryWithDictionary_(info)
     # cause MSC.app to display the Forced Logout warning
     dnc = NSDistributedNotificationCenter.defaultCenter()
     dnc.postNotificationName_object_userInfo_options_(
-        'com.googlecode.munki.ManagedSoftwareUpdate.logoutwarn', 
+        'com.googlecode.munki.ManagedSoftwareUpdate.logoutwarn',
         None, info,
         NSNotificationDeliverImmediately + NSNotificationPostToAllSessions)
-        
+
     # make sure flag is in place to cause munki to install at logout
     f = open('/private/tmp/com.googlecode.munki.installatlogout', 'w')
     f.close()
@@ -129,8 +129,9 @@ def main():
     log('launched')
     sent_notifications = []
     logout_time_override = None
+    # datetime of now plus largest MANDATORY_NOTIFICATIONS value (with padding).
     minimum_notifications_logout_time = NSDate.date().addTimeInterval_(
-        60 * MINIMUM_NOTIFICATION_MINS + 30)
+        60 * max(MANDATORY_NOTIFICATIONS) + 30)
     while True:
         if not munkicommon.currentGUIusers():
             # no-one is logged in, so bail
@@ -153,7 +154,7 @@ def main():
             logout_time = next_logout_time
         else:
             # allow the new next_logout_time from InstallInfo to be used
-            # if it has changed to a later time since when we decided to 
+            # if it has changed to a later time since when we decided to
             # override it.
             if next_logout_time > logout_time_override:
                 logout_time = next_logout_time
@@ -161,22 +162,25 @@ def main():
                 logout_time_override = None
                 sent_notifications = []
 
-        # always give at least a MINIMUM_NOTIFICATION_MINS warning
+        # always give at least MANDATORY_NOTIFICATIONS warnings
         if logout_time < minimum_notifications_logout_time:
-            if MINIMUM_NOTIFICATION_MINS not in sent_notifications:
-                # logout time is in the past, and the minimum notification
-                # has not been sent, so reset the logout_time to the future.
-                log('%d minute notification not sent.' 
-                    % MINIMUM_NOTIFICATION_MINS)
-                logout_time = minimum_notifications_logout_time
-                log('reset logout_time to: %s' % logout_time)
-                logout_time_override = logout_time
+            for mandatory_notification in MANDATORY_NOTIFICATIONS:
+                if mandatory_notification not in sent_notifications:
+                    # logout time is in the past, and a mandatory notification
+                    # has not been sent, so reset the logout_time to the future.
+                    log('%d minute notification not sent.'
+                        % mandatory_notification)
+                    logout_time = NSDate.date(
+                        ).addTimeInterval_(60 * mandatory_notification + 30)
+                    log('reset logout_time to: %s' % logout_time)
+                    logout_time_override = logout_time
+                    break
 
         minutes_until_logout = int(logout_time.timeIntervalSinceNow() / 60)
         info = {'logout_time': logout_time}
         if minutes_until_logout in NOTIFICATION_MINS:
             sent_notifications.append(minutes_until_logout)
-            log('Warning user of %s minutes until forced logout' 
+            log('Warning user of %s minutes until forced logout'
                 % minutes_until_logout)
             alertUserOfForcedLogout(info)
         elif minutes_until_logout < 1:
@@ -192,6 +196,6 @@ def main():
         munkicommon.forceLogoutNow()
     log('exited')
     exit(0)
-    
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Ensure that 60, 30, 10, and 5 minute notifications are *all* seen before forcefully rebooting a machine, not merely the 60 minute notification.

Previously, if the 60m notice was seen, then the machine was put to sleep for 55m+, it could reboot without another notice after waking up.