### PR TITLE
Add deploy percent functionality

### DIFF
--- a/tests/code/client/munkilib/munkicommon_test.py
+++ b/tests/code/client/munkilib/munkicommon_test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+"""
+munkicommon_test.py
+
+Unit tests for munkicommon functions
+
+"""
+
+import mock
+import unittest
+
+import munkicommon
+
+class MunkicommonGetMachineDeployPercentTest(unittest.TestCase):
+    def setUp(self):
+        """Setup tests with """
+        self.managedinstalls = {
+        }
+
+        self.machine_facts = {
+            'serial_number': 'C02Q32Y5GCN4',
+        }
+
+        self.machine_conditions = {}
+
+    def test_deploy_percent_function(self):
+        """Make sure percent is correct with a known serial and result"""
+        assert munkicommon.get_machine_deploy_percent(
+            self.machine_facts['serial_number']
+        ) == 31
+
+    @mock.patch('munkicommon.pref', return_value=100)
+    def test_deploy_percent_override(self, munkicommon_mock):
+        """Mock munkicommon.pref to return a deploy percent setting.
+        This should return that setting back rather than generating
+        a machine deploy percent (which would be 31 if generated)
+        """
+        assert munkicommon.get_machine_deploy_percent(
+            self.machine_facts['serial_number']
+        ) == 100
+
+
+def main():
+    unittest.main(buffer=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds deploy percent functionality to munki.

This will allow you to set a deploy percent in the pkginfo for a given item, which would ensure it gets deployed to that percent of the total clients.

get_machine_shard has chunks set to 100, so machines will get distributed equally between 1 and 100.

Pkginfo Key Example:

```
<key>deploy_percent</key>
<integer>20</integer>
```

This would deploy the given package to 20% of the clients. This seeds a md5 hash using the serial number, so the shards are more or less evenly distributed among a given set of clients.

This setting is to allow a ramped deployment of a given package. You would set this percent to a number you are comfortable with. The package will be roughly be deployed to that percent of the fleet. Once you are confident the package deployment is working as intended, you could remove the key and all clients would get it or you could increase the percent and watch the results, then keep increasing it until 100 (or just remove it).

An example deployment might be to set deploy_percent to 10 for 24 hours, increase it to 20 for another 24 hours and then finally remove the key to deploy it to the entire fleet.

Another thing we should consider is making the percent a truly random portion of the fleet. Instead of the same n% of machines getting the new packages each time, we should seed the md5 using serial + package name + version. This would allow a truly random % of the fleet to get the package rather than the same % each time.

Once we agree (or not) on the functional code, I'll get it tested on our fleet, update makepkginfo and add documentation for this feature.
