### PR TITLE
Added try block to catch malformed Info.plist.

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.py
@@ -244,28 +244,32 @@ def convertIconToPNG(app_name, destination_path, desired_size):
     except FoundationPlist.FoundationPlistException:
         info = {}
     try:
-        icon_filename = info.get('CFBundleIconFile', app_name)
-    except AttributeError:
+        try:
+            icon_filename = info.get('CFBundleIconFile', app_name)
+        except AttributeError:
+            icon_filename = app_name
+        icon_path = os.path.join(app_path, 'Contents/Resources', icon_filename)
+        if not os.path.splitext(icon_path)[1]:
+            # no file extension, so add '.icns'
+            icon_path += u'.icns'
+        if os.path.exists(icon_path):
+            image_data = NSData.dataWithContentsOfFile_(icon_path)
+            bitmap_reps = NSBitmapImageRep.imageRepsWithData_(image_data)
+            chosen_rep = None
+            for bitmap_rep in bitmap_reps:
+                if not chosen_rep:
+                    chosen_rep = bitmap_rep
+                elif (bitmap_rep.pixelsHigh() >= desired_size
+                      and bitmap_rep.pixelsHigh() < chosen_rep.pixelsHigh()):
+                    chosen_rep = bitmap_rep
+            if chosen_rep:
+                png_data = chosen_rep.representationUsingType_properties_(
+                    NSPNGFileType, None)
+                png_data.writeToFile_atomically_(destination_path, False)
+                return True
+    except Exception:
         return False
-    icon_path = os.path.join(app_path, 'Contents/Resources', icon_filename)
-    if not os.path.splitext(icon_path)[1]:
-        # no file extension, so add '.icns'
-        icon_path += u'.icns'
-    if os.path.exists(icon_path):
-        image_data = NSData.dataWithContentsOfFile_(icon_path)
-        bitmap_reps = NSBitmapImageRep.imageRepsWithData_(image_data)
-        chosen_rep = None
-        for bitmap_rep in bitmap_reps:
-            if not chosen_rep:
-                chosen_rep = bitmap_rep
-            elif (bitmap_rep.pixelsHigh() >= desired_size
-                  and bitmap_rep.pixelsHigh() < chosen_rep.pixelsHigh()):
-                chosen_rep = bitmap_rep
-        if chosen_rep:
-            png_data = chosen_rep.representationUsingType_properties_(
-                NSPNGFileType, None)
-            png_data.writeToFile_atomically_(destination_path, False)
-            return True
+
     return False
 
 

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.py
@@ -243,7 +243,10 @@ def convertIconToPNG(app_name, destination_path, desired_size):
             os.path.join(app_path, 'Contents/Info.plist'))
     except FoundationPlist.FoundationPlistException:
         info = {}
-    icon_filename = info.get('CFBundleIconFile', app_name)
+    try:
+        icon_filename = info.get('CFBundleIconFile', app_name)
+    except AttributeError:
+        return False
     icon_path = os.path.join(app_path, 'Contents/Resources', icon_filename)
     if not os.path.splitext(icon_path)[1]:
         # no file extension, so add '.icns'


### PR DESCRIPTION
convertIconToPNG() would cause MSC Updates tab to hang when processing applications with a malformed Info.plist file. This wraps `info.get('CFBundleIconFile', app_name)` in a try block that returns `False` if the `get()` fails. Fixes #552.