### PR TITLE
Add option to set NSMutableURLRequest timeoutInterval property

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -156,7 +156,8 @@ def get_url(url, destinationpath,
                'additional_headers': header_dict_from_list(custom_headers),
                'download_only_if_changed': onlyifnewer,
                'cache_data': cache_data,
-               'logging_function': munkicommon.display_debug2}
+               'logging_function': munkicommon.display_debug2,
+               'connection_timeout': munkicommon.pref('HTTPConnectionTimeoutInterval')}
     munkicommon.display_debug2('Options: %s' % options)
 
     connection = Gurl.alloc().initWithOptions_(options)

--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -138,7 +138,7 @@ class Gurl(NSObject):
         self.download_only_if_changed = options.get(
             'download_only_if_changed', False)
         self.cache_data = options.get('cache_data')
-        self.connection_timeout = options.get('connection_timeout', 10)
+        self.connection_timeout = options.get('connection_timeout')
 
         self.log = options.get('logging_function', NSLog)
 

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1214,6 +1214,7 @@ def pref(pref_name):
         'SuppressStopButtonOnInstall': False,
         'PackageVerificationMode': 'hash',
         'FollowHTTPRedirects': 'none',
+        'HTTPConnectionTimeoutInterval': 10,
     }
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value == None:


### PR DESCRIPTION
NSMutableURLRequest timeoutInterval property was originally set with magic constant (10 seconds) in gurl.py. I propose to set timeoutInterval from Munki preferences making it easily configurable by user.

Proposed key is called **HTTPConnectionTimeoutInterval** and is set to default value of 10 seconds in munkicommon.py.

This is result of my testing [described](https://groups.google.com/forum/#!topic/munki-discuss/irW_64WJOhM) in munki-discuss google group. Setting bigger value for HTTPConnectionTimeoutInterval should increase download survivability in bad network conditions.

Please verify my changes. I am new to Munki codebase and it is possible I've missed something.