### PR TITLE
Update updatecheck.py

### DIFF
--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2901,8 +2901,7 @@ def download_client_resources():
             resources_name += '.zip'
         filenames.append(resources_name)
     else:
-        filenames.append(munkicommon.report['ManifestName'] + '.zip')
-    filenames.append('site_default.zip')
+        filenames.append('site_default.zip')
 
     resource_base_url = (
         munkicommon.pref('ClientResourceURL') or


### PR DESCRIPTION
fix client_resources/site_default.zip error. ClientResourcesFilename is being assigned the ManifestName resource_name.

   
 `2016/03/17 20:37:33 [error] 24315#0: *54456 open() "/usr/local/munki_repo/client_resources/osx_managed.zip" failed (2: No such file or directory), client: 207.231.170.7, server: munki.domain.com, request: "GET /munki_repo/client_resources/osx_manage
d.zip HTTP/1.1", host: "munki.domain.com"`
   