### PR TITLE
small changes to el-cap css

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/WebResources/base.css
+++ b/code/apps/Managed Software Center/Managed Software Center/WebResources/base.css
@@ -517,7 +517,7 @@ div.titled-box li.link a {
     display: block;
     font-size: 11px;
     font-weight: normal;
-    color: #4f5459;
+    color: #222;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap

--- a/code/apps/Managed Software Center/Managed Software Center/WebResources/base.css
+++ b/code/apps/Managed Software Center/Managed Software Center/WebResources/base.css
@@ -474,7 +474,7 @@ div.titled-box h2, div.titled-box hr {
 }
 
 div.titled-box hr {
-    margin: 28px 0
+    margin: 14px 0
 }
 
 div.titled-box li.popup {

--- a/code/apps/Managed Software Center/Managed Software Center/WebResources/base.css
+++ b/code/apps/Managed Software Center/Managed Software Center/WebResources/base.css
@@ -517,7 +517,7 @@ div.titled-box li.link a {
     display: block;
     font-size: 11px;
     font-weight: normal;
-    color: #222;
+    color: #4f5459;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap


### PR DESCRIPTION
This is a simple change to the base.css for links. Apple has two link colors in the App Store. We are currently using the color for App links, versus traditional URL links.

This change helps with links on the sidebar.