### PR TITLE
Catch missing conditional shebang.

### DIFF
--- a/code/client/munkilib/utils.py
+++ b/code/client/munkilib/utils.py
@@ -123,13 +123,18 @@ def runExternalScript(script, allow_insecure=False, script_args=()):
         cmd = [script]
         if script_args:
             cmd.extend(script_args)
-        proc = subprocess.Popen(cmd, shell=False,
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        (stdout, stderr) = proc.communicate()
-        return proc.returncode, stdout.decode('UTF-8', 'replace'), \
-                                stderr.decode('UTF-8', 'replace')
+        proc = None
+        try:
+            proc = subprocess.Popen(cmd, shell=False,
+                                    stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+        except OSError:
+            raise RunExternalScriptError('%s can not be interpreted' % script)
+        if proc:
+            (stdout, stderr) = proc.communicate()
+            return proc.returncode, stdout.decode('UTF-8', 'replace'), \
+                                    stderr.decode('UTF-8', 'replace')
     else:
         raise RunExternalScriptError('%s not executable' % script)
 

--- a/code/client/munkilib/utils.py
+++ b/code/client/munkilib/utils.py
@@ -129,8 +129,9 @@ def runExternalScript(script, allow_insecure=False, script_args=()):
                                     stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
-        except OSError:
-            raise RunExternalScriptError('%s can not be interpreted' % script)
+        except (OSError, IOError), err:
+            raise RunExternalScriptError(
+                'Error %s when attempting to run %s' % (unicode(err), script))
         if proc:
             (stdout, stderr) = proc.communicate()
             return proc.returncode, stdout.decode('UTF-8', 'replace'), \


### PR DESCRIPTION
Fixing #598.

Tested. Output looks like this:
```
Starting...
    Performing preflight tasks...
/usr/local/munki/conditions/wan_ip.py can not be interpreted
Checking for available updates...
```

Have also tested that:
- You still receive this message when not executable
```
/usr/local/munki/conditions/wan_ip.py not executable
```
- The conditional still works.
