### PR TITLE
Adding the ability to Perform FileVault Authorized Restarts. 

### DIFF
--- a/code/client/managedsoftwareupdate
+++ b/code/client/managedsoftwareupdate
@@ -279,6 +279,17 @@ def doRestart():
     if not consoleuser or consoleuser == u'loginwindow':
         # no-one is logged in or we're at the loginwindow
         time.sleep(5)
+        #check to see if we should perform an AuthRestart
+        if (munkicommon.pref('PerformAuthRestarts')
+                and munkicommon.pref('RecoveryKeyFile')):
+            munkicommon.log('Starting Authorized Restart...')
+            # try to perform an auth restart
+            munkicommon.perform_auth_restart()
+            time.sleep(2)
+            # if we got to here then the auth restart failed notify that it did
+            # then perform a normal restart
+            munkicommon.display_warning(
+                'Authorized Restart Failed... Performing normal restart')
         dummy_retcode = subprocess.call(['/sbin/shutdown', '-r', 'now'])
     else:
         if munkicommon.munkistatusoutput:

--- a/code/client/managedsoftwareupdate
+++ b/code/client/managedsoftwareupdate
@@ -286,10 +286,10 @@ def doRestart():
             # try to perform an auth restart
             munkicommon.perform_auth_restart()
             time.sleep(2)
-            # if we got to here then the auth restart failed notify that it did
+            # if we got to here then the auth restart failed, notify that it did
             # then perform a normal restart
             munkicommon.display_warning(
-                'Authorized Restart Failed... Performing normal restart')
+                'Authorized Restart Failed. Performing normal restart...')
         dummy_retcode = subprocess.call(['/sbin/shutdown', '-r', 'now'])
     else:
         if munkicommon.munkistatusoutput:

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -2770,6 +2770,63 @@ def blockingApplicationsRunning(pkginfoitem):
         return True
     return False
 
+def supports_auth_restart():
+    """Check if the the machine supports and authorized
+    restart, returns True or False accordingly"""
+    cmd = ['/usr/bin/fdesetup', 'supportsauthrestart']
+    if subprocess.check_output(cmd).strip() == 'true':
+        return True
+    else:
+        return False
+
+def get_auth_restart_key():
+    """Returns recovery key as a string... If we failed
+    to get the proper information, returns an empty string"""
+    # checks to see if recovery key preference is set
+    recoverykeyplist = pref('RecoveryKeyFile')
+    if not recoverykeyplist:
+        display_warning(
+            "RecoveryKeyFile preference is not set")
+        return ''
+    display_debug1(
+        'RecoveryKeyFile preference is set to {0}...'.format(recoverykeyplist))
+    # try to get the recovery key from the defined location
+    try:
+        keyplist = FoundationPlist.readPlist(recoverykeyplist)
+        recovery_key = keyplist['RecoveryKey'].strip()
+        return recovery_key
+    except FoundationPlist.NSPropertyListSerializationException:
+        display_error(
+            'We had trouble getting info from {0}...'.format(recoverykeyplist))
+        return ''
+    except KeyError:
+        display_error(
+        'Problem with Key: RecoveryKey in {0}...'.format(recoverykeyplist))
+        return ''
+
+def perform_auth_restart():
+    """When called this will perform an authorized restart. Before trying
+    to perform an authorized restart it checks to see if the machine supports
+    the feature. If supported it will then look for the defined plist containing
+    a key called RecoveryKey. It will use that value to perform the restart"""
+    display_debug1('Checking if machine supports Authorized Restarts...')
+    if not supports_auth_restart():
+        display_warning("Machine doesn't support Authorized Restarts...")
+        return ''
+    display_debug1('Machine Supports Authorized Restarts...')
+    recovery_key = get_auth_restart_key()
+    if not recovery_key:
+        return ''
+    key = { 'Password': recovery_key }
+    inputplist = FoundationPlist.writePlistToString(key)
+    log('Atempting an Authorized Restart Now...')
+    cmd = subprocess.Popen(
+        ['/usr/bin/fdesetup','authrestart','-inputplist'],
+    stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    (out, err) = cmd.communicate(input=inputplist)
+    if err:
+        display_error(err)
+
 
 # module globals
 #debug = False

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1223,6 +1223,7 @@ def pref(pref_name):
         'PackageVerificationMode': 'hash',
         'FollowHTTPRedirects': 'none',
         'UnattendedAppleUpdates': False,
+        'PerformAuthRestarts': False,
     }
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value == None:

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -2772,8 +2772,11 @@ def blockingApplicationsRunning(pkginfoitem):
     return False
 
 def supports_auth_restart():
-    """Check if the the machine supports and authorized
-    restart, returns True or False accordingly"""
+    """Check if the machine supports an authorized
+    restart, returns True or False accordingly
+    NOTE: This does not check to see if FileVault is
+    enabled as it may return true on a machine with
+    FileVault disabled."""
     cmd = ['/usr/bin/fdesetup', 'supportsauthrestart']
     if subprocess.check_output(cmd).strip() == 'true':
         return True
@@ -2820,7 +2823,7 @@ def perform_auth_restart():
         return ''
     key = { 'Password': recovery_key }
     inputplist = FoundationPlist.writePlistToString(key)
-    log('Atempting an Authorized Restart Now...')
+    log('Attempting an Authorized Restart Now...')
     cmd = subprocess.Popen(
         ['/usr/bin/fdesetup','authrestart','-inputplist'],
     stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
This adds the ability to perform AuthRestarts via the fdesetup command. It requires two Preferences be defined PerformAuthRestarts(bool) and RecoveryKeyFile which is a path to a plist where the recovery key is stored that will be used to perform the restart. The RecoveryKeyFile needs to contain a Key labeled RecoveryKey(this is the default name provided by fdesetup's outputplist feature) with a value containing either the individual recovery key or a password of an account enabled in FileVault. This feature works extremely well for major OS X upgrades as it now mimics that of the AppStore. I'll happily write the full documentation for this feature. 

munki-dev discussion. https://groups.google.com/forum/#!topic/munki-dev/iYBW5qM9LXM

cc @keeleysam @grahamgilbert   