### PR TITLE
Add support for `makepkginfo` and new Adobe installers

### DIFF
--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -1284,7 +1284,7 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                 product_saps = [
                     prod['SAPCode'] for
                     prod in option_xml_info['products']
-                    if prod['MediaType'] == 'Product'
+                    if prod.get('MediaType') == 'Product'
                 ]
                 for app_info in [app for app in hd_app_infos
                                  if app['SAPCode'] in product_saps]:

--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -1264,11 +1264,12 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                     os.path.join(dirpath, 'HD'), sap_code)
                 hd_app_infos.append(hd_app_info)
 
-            # installs keys will be populated if we have either RIBS
+            # 'installs' array will be populated if we have either RIBS
             # or HD installers, which may be mixed together in one
-            # CCP package
-            if mediasignatures or hd_app_infos:
-                installs = []
+            # CCP package.
+            # Acrobat Pro DC doesn't currently generate any useful installs
+            # info if it's part of a CCP package.
+            installs = []
 
             # media signatures are used for RIBS (CS5 to CC mid-2015)
             if mediasignatures:
@@ -1319,7 +1320,8 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                             installitem['type'] = 'file'
                             installs.append(installitem)
 
-            cataloginfo['installs'] = installs
+            if installs:
+                cataloginfo['installs'] = installs
 
             return cataloginfo
 

--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -1251,17 +1251,6 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                 mediasignature = cataloginfo['adobe_install_info'].get(
                     "media_signature")
                 mediasignatures = [mediasignature]
-            if mediasignatures:
-                # make a default <key>installs</key> array
-                uninstalldir = "/Library/Application Support/Adobe/Uninstall"
-                installs = []
-                for mediasignature in mediasignatures:
-                    signaturefile = mediasignature + ".db"
-                    filepath = os.path.join(uninstalldir, signaturefile)
-                    installitem = {}
-                    installitem['path'] = filepath
-                    installitem['type'] = 'file'
-                    installs.append(installitem)
 
             # Determine whether we have HD media as well in this installer
             hd_metadata_dirs = [
@@ -1275,12 +1264,29 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                     os.path.join(dirpath, 'HD'), sap_code)
                 hd_app_infos.append(hd_app_info)
 
-            # Make custom installs items for HD installers, but using only HDMedias
+            # installs keys will be populated if we have either RIBS
+            # or HD installers, which may be mixed together in one
+            # CCP package
+            if mediasignatures or hd_app_infos:
+                installs = []
+
+            # media signatures are used for RIBS (CS5 to CC mid-2015)
+            if mediasignatures:
+                # make a default <key>installs</key> array
+                uninstalldir = "/Library/Application Support/Adobe/Uninstall"
+                for mediasignature in mediasignatures:
+                    signaturefile = mediasignature + ".db"
+                    filepath = os.path.join(uninstalldir, signaturefile)
+                    installitem = {}
+                    installitem['path'] = filepath
+                    installitem['type'] = 'file'
+                    installs.append(installitem)
+
+            # Custom installs items for HD installers seem to need only HDMedias
             # from optionXML.xml with a MediaType of 'Product' and their
             # 'core' packages (e.g. language packs are 'non-core')
             if hd_app_infos:
                 uninstalldir = '/Library/Application Support/Adobe/Installers/uninstallXml'
-                installs = []
                 product_saps = [
                     prod['SAPCode'] for
                     prod in option_xml_info['products']

--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -1295,7 +1295,9 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                 for app_info in [app for app in hd_app_infos
                                  if app['SAPCode'] in product_saps]:
                     for pkg in app_info['Packages']:
-                        if pkg['Type'] == 'core':
+                        # Don't assume 'Type' key always exists. At least the 'AdobeIllustrator20-Settings'
+                        # package doesn't have this key set.
+                        if pkg.get('Type') == 'core':
                             uninstall_file_name = '_'.join([
                                 app_info['SAPCode'],
                                 app_info['BaseVersion'].replace('.', '_'),

--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -1322,8 +1322,8 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                             # SAPCode
                             pkg_prod_vers = [prod['prodVersion']
                                              for prod in option_xml_info['products']
-                                             if prod.get('hd_installer') and \
-                                                prod['SAPCode'] == app_info['SAPCode']][0]
+                                             if prod.get('hd_installer') and
+                                             prod['SAPCode'] == app_info['SAPCode']][0]
                             uninstall_file_name = '_'.join([
                                 app_info['SAPCode'],
                                 pkg_prod_vers.replace('.', '_'),

--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -1313,11 +1313,15 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                         # package doesn't have this key set.
                         if pkg.get('Type') == 'core':
                             # We can't use 'ProductVersion' from Application.json for the part following
-                            # the SAP code, because it's usually too specific and won't match the "short"
+                            # the SAPCode, because it's usually too specific and won't match the "short"
                             # product version. We can take 'prodVersion' from the optionXML.xml instead.
+                            # We filter out any non-HD installers to avoid matching up the wrong versions
+                            # for packages that may contain multiple different major versions of a given
+                            # SAPCode
                             pkg_prod_vers = [prod['prodVersion']
                                              for prod in option_xml_info['products']
-                                             if prod['SAPCode'] == app_info['SAPCode']][0]
+                                             if prod.get('hd_installer') and \
+                                                prod['SAPCode'] == app_info['SAPCode']][0]
                             uninstall_file_name = '_'.join([
                                 app_info['SAPCode'],
                                 pkg_prod_vers.replace('.', '_'),

--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -487,7 +487,9 @@ def getHDInstallerInfo(hd_payload_root, sap_code):
     # - Name: display_name pkginfo key
     # - ProductVersion: version pkginfo key and uninstall XML location
     # - SAPCode: an uninstallXml for an installs item if it's a 'core' Type
-    for key in ['Name', 'ProductVersion', 'SAPCode']:
+    # - BaseVersion and version: not currently used but may be useful once
+    #   there are more HD installers in the future
+    for key in ['BaseVersion', 'Name', 'ProductVersion', 'SAPCode', 'version']:
         hd_app_info[key] = json_info[key]
     hd_app_info['SAPCode'] = json_info['SAPCode']
 

--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -21,7 +21,7 @@ using the CS3/CS4/CS5 Deployment Toolkits.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#import sys
+# import sys
 import json
 import os
 import re
@@ -471,6 +471,7 @@ def parseOptionXML(option_xml_file):
                     info['products'].append(product)
 
     return info
+
 
 def getHDInstallerInfo(hd_payload_root, sap_code):
     '''Attempts to extract some information from a HyperDrive payload
@@ -1302,7 +1303,7 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                     cataloginfo.update({
                         'display_name': product_app_infos[0]['Name'],
                         'version': product_app_infos[0]['ProductVersion'],
-                        })
+                    })
 
                 for app_info in product_app_infos:
                     for pkg in app_info['Packages']:

--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -425,7 +425,8 @@ def parseOptionXML(option_xml_file):
 
         # CS5 to CC 2015.0-2015.2 releases use RIBS, and we retrieve a
         # display name, version and 'mediaSignature' for building installs
-        # items
+        # items. SAPCode is also stored so that we can later search by this
+        # key across both RIBS and HyperDrive installer metadata.
         medias_elements = installinfo[0].getElementsByTagName('Medias')
         if medias_elements:
             media_elements = medias_elements[0].getElementsByTagName('Media')
@@ -435,6 +436,7 @@ def parseOptionXML(option_xml_file):
                     product['prodName'] = getXMLtextElement(media, 'prodName')
                     product['prodVersion'] = getXMLtextElement(
                         media, 'prodVersion')
+                    product['SAPCode'] = getXMLtextElement(media, 'SAPCode')
                     setup_elements = media.getElementsByTagName('Setup')
                     if setup_elements:
                         mediaSignatureElements = setup_elements[


### PR DESCRIPTION
This adds initial support for the new Adobe "HyperDrive" installers released mid-June 2016, for `makepkginfo`. CCP packages built that include any of these new product versions include this new installer engine that's used for only those new versions. Since a CCP package can contain a mix of many different applications, many "monolithic" CCP packages made today will contain both the legacy "RIBS" and the newer installer formats.

Some discussion happened [earlier on munki-dev](https://groups.google.com/d/topic/munki-dev/5KzSwVIDbp4/discussion) on this support, and I believe @foigus, @clburlison, and @bochoven have tested this code (as have I used it to build pkginfos for all the new installers).

What this code does currently:

- generates `installs` items for the newer applications by assembling a special metadata path, very similar to how the `Uninstall.db` paths work from CS5 and up
- if the package contains a single app, extract sane `version` and `display_name` keys from the package metadata

I haven't found it necessary to add any code to the installer process itself. Because the new installers log to new (and unpredictable, thanks!) locations I've not made attempts to attach to these logs to follow installation progress. However, the HyperDrive installers are so much faster (i.e. a 2 GB app installed in 30 seconds) that I think it's less of an issue. Not ruling out the idea but just didn't want to add a lot more code that would need to be thoroughly tested just for adding progress info.

In the future I think it would be also helpful to extract `installed_size` by counting the relevant payloads in the metadata, as well as extracting actual apps to build `installs` application types if possible - the latter seeming easier now than it did with the old RIBS data. However I figured it would be better to get some initial functional support reviewed and brought in first, and deal with those details later.

This brings Adobe creative packages support in pretty much to parity with where it was before (with the added advantage of having better `version` info generated wherever possible, compared to prior CCP package support).