### PR TITLE
fix SecureManagedInstallsPreferences

### DIFF
--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -57,6 +57,7 @@ from Foundation import NSDate, NSMetadataQuery, NSPredicate, NSRunLoop
 from Foundation import CFPreferencesAppSynchronize
 from Foundation import CFPreferencesCopyAppValue
 from Foundation import CFPreferencesCopyKeyList
+from Foundation import CFPreferencesCopyValue
 from Foundation import CFPreferencesSetValue
 from Foundation import kCFPreferencesAnyUser
 from Foundation import kCFPreferencesCurrentUser
@@ -1176,6 +1177,15 @@ class SecureManagedInstallsPreferences(Preferences):
         Preferences.__init__(self, 'ManagedInstalls',
                              user=kCFPreferencesCurrentUser,
                              host=kCFPreferencesAnyHost)
+
+    def __contains__(self, pref_name):
+        pref_value = CFPreferencesCopyValue(pref_name, self.bundle_id,
+                                            self.user, self.host)
+        return pref_value is not None
+
+    def __getitem__(self, pref_name):
+        return CFPreferencesCopyValue(pref_name, self.bundle_id,
+                                      self.user, self.host)
 
 
 def reload_prefs():


### PR DESCRIPTION
after munki@93b0d07
CFPreferencesCopyAppValue will return old value (set by old client), so
CFPreferencesCopyValue with matching user/host values should be used instead.