### PR TITLE
Adobe-hyperdrive: Fix bug in json parsing

### DIFF
--- a/code/client/munkilib/adobeutils.py
+++ b/code/client/munkilib/adobeutils.py
@@ -1315,7 +1315,7 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                             # product version. We can take 'prodVersion' from the optionXML.xml instead.
                             pkg_prod_vers = [prod['prodVersion']
                                              for prod in option_xml_info['products']
-                                             if prod['SAPCode'] == app_info['SAPCode']][0]
+                                             if prod.get('SAPCode') == app_info['SAPCode']][0]
                             uninstall_file_name = '_'.join([
                                 app_info['SAPCode'],
                                 pkg_prod_vers.replace('.', '_'),


### PR DESCRIPTION
We should retrieve the SAPCode via get. This will properly return a None value for Adobe bundles that are not core. Which allows us to properly parse the Application.json and retrieve the correct product version.

This resolves the bug located https://github.com/munki/munki/pull/641#issuecomment-238607492

@timsutton 