### PR TITLE
catch the exception if /var/run/syslog is not listening

### DIFF
--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -555,7 +555,15 @@ def configure_syslog():
         logger.removeHandler(handler)
     logger.setLevel(logging.DEBUG)
 
-    syslog = logging.handlers.SysLogHandler('/var/run/syslog')
+    # If /System/Library/LaunchDaemons/com.apple.syslogd.plist is restarted
+    # then /var/run/syslog stops listening.  If we fail to catch this then
+    # Munki completely errors.
+    try:
+        syslog = logging.handlers.SysLogHandler('/var/run/syslog')
+    except:
+        log('LogToSyslog is enabled but socket connection failed.')
+        return
+
     syslog.setFormatter(logging.Formatter('munki: %(message)s'))
     syslog.setLevel(logging.INFO)
     logger.addHandler(syslog)


### PR DESCRIPTION
If `/System/Library/LaunchDaemons/com.apple.syslogd.plist` is restarted, `/var/run/syslog` stops responding until the Mac is restarted.

It's currently an uncaught exception so if you have `LogToSyslog` enabled and are in this condition Munki completely breaks.

```
# managedsoftwareupdate 
Traceback (most recent call last):
  File "/usr/local/munki/managedsoftwareupdate", line 1052, in <module>
    main()
  File "/usr/local/munki/managedsoftwareupdate", line 632, in main
    munkicommon.configure_syslog()
  File "/usr/local/munki/munkilib/munkicommon.py", line 558, in configure_syslog
    syslog = logging.handlers.SysLogHandler('/var/run/syslog')
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/handlers.py", line 762, in __init__
    self._connect_unixsocket(address)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/handlers.py", line 790, in _connect_unixsocket
    self.socket.connect(address)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 61] Connection refused
```