### PR TITLE
manifestutil: Added display_included_manifests()

### DIFF
--- a/code/client/manifestutil
+++ b/code/client/manifestutil
@@ -576,6 +576,37 @@ def display_manifest(args):
         return 2 # No such file or directory
 
 
+def display_included_manifests(args):
+    parser = MyOptionParser()
+    parser.set_usage('''display-included-manifest MANIFESTNAME
+        Prints included manifests in the specified manifest''')
+    try:
+        _, arguments = parser.parse_args(args)
+    except MyOptParseError, errmsg:
+        print >> sys.stderr, str(errmsg)
+        return 22 # Invalid argument
+    if len(arguments) != 1:
+        parser.print_usage(sys.stderr)
+        return 7 # Argument list too long
+    manifestname = arguments[0]
+    manifest = get_manifest(manifestname)
+    if manifest:
+        print 'Manifest: %s' % manifestname
+        manifest_recurser(manifest)
+    else:
+        return 2 # No such file or directory
+
+
+def manifest_recurser(manifest):
+    # No infinite loop checking! Be wary!
+    printplist(manifest)
+    if 'included_manifests' in manifest:
+        for item in manifest['included_manifests']:
+            manifest = get_manifest(item)
+            print '\nManifest %s' % item
+            manifest_recurser(manifest)
+
+
 def new_manifest(args):
     '''Creates a new, empty manifest'''
     parser = MyOptionParser()


### PR DESCRIPTION
This is the suggested new verb for `manifestutil` to display included manifests.
Usage would be `manifestutil display-included-manifests`

Output is as below:
```
[cwindus@netadmin10]:~ # manifestutil display-included-manifests VMH49bwaLxlK
Manifest: VMH49bwaLxlK
 catalogs:
     testing
     production
 display_name: macOS Sierra Test VM
 included_manifests:
     au.edu.qld.redlands.staff.desktop.exec-assistants

Manifest au.edu.qld.redlands.staff.desktop.exec-assistants
 catalogs:
     production
 included_manifests:
     au.edu.qld.redlands.staff.desktop.common
 optional_installs:
     au.edu.qld.redlands.app.handbrake
     au.edu.qld.redlands.app.ibooks-author

Manifest au.edu.qld.redlands.staff.desktop.common
 catalogs:
     production
 included_manifests:
     au.edu.qld.redlands.apps-collection.office.mandatory-install
     au.edu.qld.redlands.apps-collection.iwork.mandatory-install
     au.edu.qld.redlands.all.common
     au.edu.qld.redlands.apps-collection.teachers.mandatory-install
     au.edu.qld.redlands.lpt-collection.staff.mandatory-install
 managed_installs:
     au.edu.qld.redlands.pol.common.clear-nvram
     au.edu.qld.redlands.pol.common.computer-sleep
     au.edu.qld.redlands.pol.common.device-aup
     au.edu.qld.redlands.pol.common.efi-passwd
     au.edu.qld.redlands.pol.common.partitions
     au.edu.qld.redlands.pol.common.shared-user-fix
     au.edu.qld.redlands.pol.common.user-mask
     au.edu.qld.redlands.pol.profile.common.disable-siri
     au.edu.qld.redlands.pol.profile.common.screensaver-lock
     au.edu.qld.redlands.pol.profile.staff.common.app-restrictions
 optional_installs:
     au.edu.qld.redlands.app.virtualbox
```