### PR TITLE
Catch unicode error messages for downloads

### DIFF
--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -1990,7 +1990,7 @@ def processInstall(manifestitem, cataloglist, installinfo,
             munkicommon.display_warning(
                 'Download of %s failed: %s', manifestitem, errmsg)
             iteminfo['installed'] = False
-            iteminfo['note'] = 'Download failed (%s)' % errmsg
+            iteminfo['note'] = u'Download failed (%s)' % errmsg
             iteminfo['version_to_install'] = item_pl.get('version', 'UNKNOWN')
             installinfo['managed_installs'].append(iteminfo)
             if manifestitemname in installinfo['processed_installs']:


### PR DESCRIPTION
On Yosemite the error message can have a `'` in it.

```
Downloading Command_Line_Tools_OS_X_10.10_for_Xcode_7.2-7.2.0.0.1.1447826929.dmg...
    0..20.WARNING: Download of Command Line Tools for Xcode failed: Error -1001: The operation couldn't be completed. (NSURLErrorDomain error -1001.)
ERROR: Unexpected error in updatecheck:
Traceback (most recent call last):
  File "/usr/local/munki/managedsoftwareupdate", line 1052, in <module>
    main()
  File "/usr/local/munki/managedsoftwareupdate", line 743, in main
    client_id=options.id.decode('UTF-8'))
  File "/usr/local/munki/munkilib/updatecheck.py", line 3027, in check
    installinfo)
  File "/usr/local/munki/munkilib/updatecheck.py", line 2172, in processManifestForKey
    item, cataloglist, installinfo)
  File "/usr/local/munki/munkilib/updatecheck.py", line 1993, in processInstall
    iteminfo['note'] = 'Download failed (%s)' % errmsg
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 33: ordinal not in range(128)
```