### PR TITLE
Only attempt to download icons with hashes

### DIFF
--- a/code/client/munkilib/updatecheck.py
+++ b/code/client/munkilib/updatecheck.py
@@ -2886,7 +2886,8 @@ def download_icons(item_list):
                 munkicommon.display_error(
                     'Could not create %s' % icon_subdir)
                 return
-        if pkginfo_icon_hash != xattr_hash:
+        # only fetch icons that exist and don't match our cache.
+        if pkginfo_icon_hash != xattr_hash and pkginfo_icon_hash is not None:
             item_name = item.get('display_name') or item['name']
             message = 'Getting icon %s for %s...' % (icon_name, item_name)
             try:


### PR DESCRIPTION
Fixes #670

Currently munki attempts to download icons for every optional item.  If you're using `makecatalogs` from Munki 2.2 or later, icon hashes are added for every item where an icon is present.

This change has munki skip requests for packages where no icon_hash is present, saving a lot of requests and time particularly for those who have a lot of packages without icons.
