### PR TITLE
Added subcommand refresh-cache

### DIFF
--- a/code/client/manifestutil
+++ b/code/client/manifestutil
@@ -1102,6 +1102,25 @@ def remove_included_manifest(args):
             return 1 # Operation not permitted
 
 
+def refresh_cache(args):
+	'''Refreshes the repo data if changes were made while manifestutil was running. Updates manifests, catalogs, and packages.'''
+	parser = MyOptionParser()
+	parser.set_usage('''refresh-cache
+	   Refreshes the repo data''')
+	try:
+		_, arguments = parser.parse_args(args)
+	except MyOptParseError, errmsg:
+		print >> sys.stderr, str(errmsg)
+		return 22 # Invalid argument
+
+	if len(arguments) != 0:
+		parser.print_usage(sys.stderr)
+		return 22 # Invalid argument
+	CMD_ARG_DICT['manifests'] = get_manifest_names()
+	CMD_ARG_DICT['catalogs'] = get_catalogs()
+	CMD_ARG_DICT['pkgs'] = get_installer_item_names(get_catalogs())
+
+
 def show_help():
     '''Prints available subcommands'''
     print "Available sub-commands:"
@@ -1212,6 +1231,7 @@ def main():
             'new-manifest':              'default',
             'copy-manifest':             'manifests',
             'rename-manifest':           'manifests',
+            'refresh-cache':            'default',
             'exit':                      'default',
             'help':                      'default',
             'configure':                 'default',


### PR DESCRIPTION
This subcommand will refresh the cached repo data for manifests, catalog, and packages from the repo source to allow tab autocomplete of items that have been added/changed while manifestutil is running.