### PR TITLE
Version ordering option

### DIFF
--- a/code/client/managedsoftwareupdate
+++ b/code/client/managedsoftwareupdate
@@ -469,7 +469,7 @@ def main():
     p.add_option('--auto', '-a', action='store_true',
                  help='Used by launchd LaunchAgent for scheduled runs. '
                  'No user feedback or intervention. All other options '
-                 'ignored.')
+                 'ignored except --semanticversionordering.')
     p.add_option('--logoutinstall', '-l', action='store_true',
                  help='Used by launchd LaunchAgent when running at the '
                  'loginwindow.')
@@ -498,6 +498,9 @@ def main():
                  'packages.')
     p.add_option('--munkipkgsonly', action='store_true',
                  help='Only check/install Munki packages, skip Apple SUS.')
+    p.add_option('--semanticversionordering', action='store_true',
+                 help='Order prereleases before releases when sorting packages, '
+                 'e.g. 1.2b1 before 1.2.')
     p.add_option('--version', '-V', action='store_true',
                  help='Print the version of the munki tools and exit.')
 
@@ -612,6 +615,7 @@ def main():
     # set munkicommon globals
     munkicommon.munkistatusoutput = options.munkistatusoutput
     munkicommon.verbose = options.verbose
+    munkicommon.semantic_version_ordering = options.semanticversionordering
 
     # Set environment variable for verbosity
     os.environ['MUNKI_VERBOSITY_LEVEL'] = str(options.verbose)

--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1321,13 +1321,23 @@ class MunkiLooseVersion(version.LooseVersion):
             cmp_list.append(0)
         return cmp_list
 
+    def _tag(self, version_list):
+        # attach a tag to each element so that strings are ordered before numbers
+        return [(0 if isinstance(e, StringType) else 1, e) for e in version_list]
+
+    def _normalize(self, version_list, max_length):
+        if semantic_version_ordering:
+            return self._tag(self._pad(version_list, max_length))
+        else:
+            return self._pad(version_list, max_length)
+
     def __cmp__(self, other):
         if isinstance(other, StringType):
             other = MunkiLooseVersion(other)
 
         max_length = max(len(self.version), len(other.version))
-        self_cmp_version = self._pad(self.version, max_length)
-        other_cmp_version = self._pad(other.version, max_length)
+        self_cmp_version = self._normalize(self.version, max_length)
+        other_cmp_version = self._normalize(other.version, max_length)
 
         return cmp(self_cmp_version, other_cmp_version)
 
@@ -2783,6 +2793,7 @@ def blockingApplicationsRunning(pkginfoitem):
 #debug = False
 verbose = 1
 munkistatusoutput = False
+semantic_version_ordering = False
 _TMPDIR = None
 report = {}
 

--- a/versionpatch/munkicommon.py
+++ b/versionpatch/munkicommon.py
@@ -1,0 +1,46 @@
+# encoding: utf-8
+#
+# Copyright 2009-2018 Greg Neagle.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+munkicommon
+
+Created by Greg Neagle on 2008-11-18.
+
+Common functions used by the munki tools.
+"""
+
+# this module current exists purely for backwards-compatibity so that anything
+# calling munkicommon functions will still work (for now)
+
+# We wildcard-import from submodules for backwards compatibility; functions
+# that were previously available from this module
+# pylint: disable=wildcard-import
+from .constants import *
+from .display import *
+from .dmgutils import *
+from .munkihash import *
+from .info import *
+from .munkilog import *
+from .osutils import *
+from .pkgutils import *
+from .prefs import *
+from .processes import *
+from .reports import *
+from .scriptutils import *
+from .versionpatch import *
+# pylint: enable=wildcard-import
+
+if __name__ == '__main__':
+    print 'This is a library of support tools for the Munki Suite.'

--- a/versionpatch/versionpatch.py
+++ b/versionpatch/versionpatch.py
@@ -1,0 +1,46 @@
+# encoding: utf-8
+
+class MunkiLooseVersion(version.LooseVersion):
+    '''Subclass version.LooseVersion to compare things like
+    "10.6" and "10.6.0" as equal'''
+
+    def __init__(self, vstring=None):
+        if vstring is None:
+            # treat None like an empty string
+            self.parse('')
+        if vstring is not None:
+            if isinstance(vstring, unicode):
+                # unicode string! Why? Oh well...
+                # convert to string so version.LooseVersion doesn't choke
+                vstring = vstring.encode('UTF-8')
+            self.parse(str(vstring))
+
+    def _pad(self, version_list, max_length):
+        """Pad a version list by adding extra 0
+        components to the end if needed"""
+        # copy the version_list so we don't modify it
+        cmp_list = list(version_list)
+        while len(cmp_list) < max_length:
+            cmp_list.append(0)
+        return cmp_list
+
+    def _tag(self, version_list):
+        # attach a tag to each element so that strings are ordered before numbers
+        return [(0 if isinstance(e, StringType) else 1, e) for e in version_list]
+
+    def _normalize(self, version_list, max_length):
+    	semantic_version_ordering = True
+        if semantic_version_ordering:
+            return self._tag(self._pad(version_list, max_length))
+        else:
+            return self._pad(version_list, max_length)
+
+    def __cmp__(self, other):
+        if isinstance(other, StringType):
+            other = MunkiLooseVersion(other)
+
+        max_length = max(len(self.version), len(other.version))
+        self_cmp_version = self._normalize(self.version, max_length)
+        other_cmp_version = self._normalize(other.version, max_length)
+
+        return cmp(self_cmp_version, other_cmp_version)


### PR DESCRIPTION
Hi Greg,

Munki uses the LooseVersion class, which behaves in an unusual way when comparing versions for alpha and beta builds with the standard notation (1.0, 1.0a1, 1.0b1).
I added an option to managedsoftwareupdate, to change the way prereleases are compared to releases. When managedsoftwareupdate is invoked with the --semanticversionordering option, the releases above are ordered this way: 1.0a1, 1.0b1, 1.0.
This option is disabled by default, so that scripts relying on the current behaviour are not impacted.
Feel free to add this contribution to a future release of Munki if you think it can be useful.

Best regards,
Frank