### PR TITLE
Consistently use /usr/bin/python shebang.

### DIFF
--- a/code/apps/Managed Software Center/msu_testing/generate_msu_test_data.py
+++ b/code/apps/Managed Software Center/msu_testing/generate_msu_test_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # encoding: utf-8
 """
 generate_msu_test_data.py

--- a/code/client/makecatalogs
+++ b/code/client/makecatalogs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # encoding: utf-8
 #
 # Copyright 2009-2016 Greg Neagle.

--- a/code/client/repoclean
+++ b/code/client/repoclean
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # encoding: utf-8
 #
 # Copyright 2016 Greg Neagle.

--- a/code/server/getmanifest.py
+++ b/code/server/getmanifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # encoding: utf-8
 # Copyright 2009 Greg Neagle.
 #


### PR DESCRIPTION
A `#!/usr/bin/env python` can cause problems where scripts are unable to
load munkilib from the python path. Whatever we use, we should use
consistently across all scripts.

For example, a homebrew python at `/usr/local/bin/python` can cause
messages like this:

    The following errors occurred while building catalogs:

    WARNING: FoundationPlist is not available, using plistlib instead.