### PR TITLE
Create power assertion for downloads

### DIFF
--- a/code/client/munkilib/updatecheck/download.py
+++ b/code/client/munkilib/updatecheck/download.py
@@ -31,6 +31,7 @@ from .. import fetch
 from .. import info
 from .. import munkihash
 from .. import osutils
+from .. import powermgr
 from .. import prefs
 from .. import reports
 
@@ -104,6 +105,8 @@ def download_installeritem(item_pl, installinfo, uninstalling=False):
     Returns True if the item was downloaded, False if it was already cached.
     Raises an error if there are issues..."""
 
+    # Create a power assertion to stop sleep during downloads
+    no_idle_sleep_assertion_id = powermgr.assertNoIdleSleep()
     download_item_key = 'installer_item_location'
     item_hash_key = 'installer_item_hash'
     if uninstalling and 'uninstaller_item_location' in item_pl:
@@ -151,6 +154,9 @@ def download_installeritem(item_pl, installinfo, uninstalling=False):
 
     dl_message = 'Downloading %s...' % pkgname
     expected_hash = item_pl.get(item_hash_key, None)
+
+    # Release power assertion
+    powermgr.removeNoIdleSleepAssertion(no_idle_sleep_assertion_id)
     return fetch.munki_resource(pkgurl, destinationpath,
                                 resume=True,
                                 message=dl_message,


### PR DESCRIPTION
In pre-deployment testing of munki, I've noticed that "fresh" installs of macOS will go to sleep while downloading packages. It appears power assertions are created for a package installation, but aren't created for downloading packages.

This is an issue for fresh installs of macOS, especially where you are doing a 'first run' to get all software deployed to a machine. I've also seen this issue occur on laptops with aggressive energy saver settings.

Adding a power assertion during the download process fixed this issue in testing.