### PR TITLE
importing "os" so the launchctld function will actually work

### DIFF
--- a/code/pkgtemplate/Scripts_launchd/postinstall
+++ b/code/pkgtemplate/Scripts_launchd/postinstall
@@ -4,6 +4,7 @@ Postinstall script to load munki's launchdaemons.
 """
 import subprocess
 import sys
+import os
 
 
 def getconsoleuser():


### PR DESCRIPTION
added `import os`..

post install appears to work for DEP after this :)