### PR TITLE
Plugins can Inherit FileRepo

### DIFF
--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -820,7 +820,7 @@ def configure():
             plugins = [fn for fn in os.listdir(plugin_path)
               if any(fn.endswith(ext) for ext in included_extensions)]
             for plugin in plugins:
-                if 'FileRepo' not in plugin:
+                if 'FileRepo' not in plugin and '__init__' not in plugin:
                     hasPlugin = True
             if not os.path.isdir(plugin_path):
                 continue

--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -815,6 +815,8 @@ def configure():
             if not os.path.exists(plugin_path):
                 # didn't find it; assume the default install path
                 plugin_path = '/usr/local/munki/munkilib/plugins'
+            if not os.path.isdir(plugin_path):
+                continue
             hasPlugin = False
             included_extensions = ['py']
             plugins = [fn for fn in os.listdir(plugin_path)
@@ -822,8 +824,6 @@ def configure():
             for plugin in plugins:
                 if 'FileRepo' not in plugin:
                     hasPlugin = True
-            if not os.path.isdir(plugin_path):
-                continue
             if not hasPlugin:
                 continue
         _prefs[key] = raw_input_with_default('%15s: ' % prompt, pref(key))

--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -815,8 +815,6 @@ def configure():
             if not os.path.exists(plugin_path):
                 # didn't find it; assume the default install path
                 plugin_path = '/usr/local/munki/munkilib/plugins'
-            if not os.path.isdir(plugin_path):
-                continue
             hasPlugin = False
             included_extensions = ['py']
             plugins = [fn for fn in os.listdir(plugin_path)
@@ -824,6 +822,8 @@ def configure():
             for plugin in plugins:
                 if 'FileRepo' not in plugin:
                     hasPlugin = True
+            if not os.path.isdir(plugin_path):
+                continue
             if not hasPlugin:
                 continue
         _prefs[key] = raw_input_with_default('%15s: ' % prompt, pref(key))

--- a/code/client/munkilib/plugins/__init__.py
+++ b/code/client/munkilib/plugins/__init__.py
@@ -1,0 +1,3 @@
+# this is needed to make Python recognize the directory as a module package.
+#
+# Warning: do NOT put any Python imports here that require ObjC.


### PR DESCRIPTION
Added __init__.py to denote that plugins directory contains packages and able to import modules from plugins directory.

Added a condition whether to show plugin option during munkiimport configure to also ignore __init__

Based on Pull Request https://github.com/munki/munki/pull/689#pullrequestreview-16492427