### PR TITLE
fix for issue #710

### DIFF
--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -1049,6 +1049,9 @@ def main():
                         '%s is an unknown type.' % uninstaller_item)
                     cleanup_and_exit(-1)
                 else:
+                    # Strip trailing '/' from uninstaller_item
+                    uninstaller_item = uninstaller_item.rstrip('/')
+
                     # we need to convert to dmg
                     dmg_path = make_dmg(uninstaller_item)
                     if dmg_path:


### PR DESCRIPTION
Resolves #710 

installer_item [already had](https://github.com/munki/munki/blob/0a6e515994daed6f411c1960a46733f727468161/code/client/munkiimport#L993-L994) trailing slashes removed.

This also removes a trailing slash from an uninstall_item right before it is sent to make_dmg