### PR TITLE
standardize format of all launchagents and launchdaemons

### DIFF
--- a/launchd/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
+++ b/launchd/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
@@ -2,27 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.ManagedSoftwareCenter</string>
-  <key>LimitLoadToSessionType</key>
-  <array>
-    <string>Aqua</string>
-  </array>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/munki/launchapp</string>
-    <string>-a</string>
-    <string>/Applications/Managed Software Center.app</string>
-  </array>
-  <key>RunAtLoad</key>
-  <false/>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/var/run/com.googlecode.munki.ManagedSoftwareCenter</key>
-       <true/>
-     </dict>
-  </dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/var/run/com.googlecode.munki.ManagedSoftwareCenter</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.googlecode.munki.ManagedSoftwareCenter</string>
+	<key>LimitLoadToSessionType</key>
+	<array>
+		<string>Aqua</string>
+	</array>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/munki/launchapp</string>
+		<string>-a</string>
+		<string>/Applications/Managed Software Center.app</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
 </dict>
 </plist>

--- a/launchd/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
+++ b/launchd/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.MunkiStatus</string>
-  <key>LimitLoadToSessionType</key>
-  <array>
-    <string>LoginWindow</string>
-  </array>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/Applications/Managed Software Center.app/Contents/Resources/MunkiStatus.app/Contents/MacOS/MunkiStatus</string>
-  </array>
-  <key>RunAtLoad</key>
-  <false/>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/var/run/com.googlecode.munki.MunkiStatus</key>
-       <true/>
-       <key>/private/tmp/com.googlecode.munki.installatlogout</key>
-       <true/>
-       <key>/Users/Shared/.com.googlecode.munki.checkandinstallatstartup</key>
-       <true/>
-       <key>/Users/Shared/.com.googlecode.munki.installatstartup</key>
-       <true/>
-     </dict>
-  </dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/Users/Shared/.com.googlecode.munki.checkandinstallatstartup</key>
+			<true/>
+			<key>/Users/Shared/.com.googlecode.munki.installatstartup</key>
+			<true/>
+			<key>/private/tmp/com.googlecode.munki.installatlogout</key>
+			<true/>
+			<key>/var/run/com.googlecode.munki.MunkiStatus</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.googlecode.munki.MunkiStatus</string>
+	<key>LimitLoadToSessionType</key>
+	<array>
+		<string>LoginWindow</string>
+	</array>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/Managed Software Center.app/Contents/Resources/MunkiStatus.app/Contents/MacOS/MunkiStatus</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
 </dict>
 </plist>

--- a/launchd/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
+++ b/launchd/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
@@ -2,35 +2,34 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.managedsoftwareupdate-loginwindow</string>
-  <key>LimitLoadToSessionType</key>
-  <array>
-    <string>LoginWindow</string>
-  </array>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/munki/supervisor</string>
-    <string>--timeout</string>
-    <string>43200</string>
-    <string>--</string>
-    <string>/usr/local/munki/managedsoftwareupdate</string>
-    <string>--logoutinstall</string>
-  </array>
-  <key>RunAtLoad</key>
-  <false/>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/private/tmp/com.googlecode.munki.installatlogout</key>
-       <true/>
-       <key>/Users/Shared/.com.googlecode.munki.checkandinstallatstartup</key>
-       <true/>
-       <key>/Users/Shared/.com.googlecode.munki.installatstartup</key>
-       <true/>
-     </dict>
-  </dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/Users/Shared/.com.googlecode.munki.checkandinstallatstartup</key>
+			<true/>
+			<key>/Users/Shared/.com.googlecode.munki.installatstartup</key>
+			<true/>
+			<key>/private/tmp/com.googlecode.munki.installatlogout</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.googlecode.munki.managedsoftwareupdate-loginwindow</string>
+	<key>LimitLoadToSessionType</key>
+	<array>
+		<string>LoginWindow</string>
+	</array>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/munki/supervisor</string>
+		<string>--timeout</string>
+		<string>43200</string>
+		<string>--</string>
+		<string>/usr/local/munki/managedsoftwareupdate</string>
+		<string>--logoutinstall</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
 </dict>
 </plist>
-

--- a/launchd/LaunchAgents/com.googlecode.munki.munki-notifier.plist
+++ b/launchd/LaunchAgents/com.googlecode.munki.munki-notifier.plist
@@ -2,27 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.munki-notifier</string>
-  <key>LimitLoadToSessionType</key>
-  <array>
-    <string>Aqua</string>
-  </array>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/munki/launchapp</string>
-    <string>-a</string>
-    <string>/Applications/Managed Software Center.app/Contents/Resources/munki-notifier.app</string>
-  </array>
-  <key>RunAtLoad</key>
-  <false/>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/var/run/com.googlecode.munki.munki-notifier</key>
-       <true/>
-     </dict>
-  </dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/var/run/com.googlecode.munki.munki-notifier</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.googlecode.munki.munki-notifier</string>
+	<key>LimitLoadToSessionType</key>
+	<array>
+		<string>Aqua</string>
+	</array>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/munki/launchapp</string>
+		<string>-a</string>
+		<string>/Applications/Managed Software Center.app/Contents/Resources/munki-notifier.app</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
 </dict>
 </plist>

--- a/launchd/LaunchDaemons/com.googlecode.munki.logouthelper.plist
+++ b/launchd/LaunchDaemons/com.googlecode.munki.logouthelper.plist
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.logouthelper</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/munki/logouthelper</string>
-  </array>
-  <key>RunAtLoad</key>
-  <false/>
+	<key>Label</key>
+	<string>com.googlecode.munki.logouthelper</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/munki/logouthelper</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
 </dict>
 </plist>

--- a/launchd/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-check.plist
+++ b/launchd/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-check.plist
@@ -2,24 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.managedsoftwareupdate-check</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/munki/supervisor</string>
-    <string>--delayrandom</string>
-    <string>3600</string>
-    <string>--timeout</string>
-    <string>43200</string>
-    <string>--</string>
-    <string>/usr/local/munki/managedsoftwareupdate</string>
-    <string>--auto</string>
-  </array>
-  <key>StartCalendarInterval</key>
-  <dict>
-    <key>Minute</key>
-    <integer>10</integer>
-  </dict>
+	<key>Label</key>
+	<string>com.googlecode.munki.managedsoftwareupdate-check</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/munki/supervisor</string>
+		<string>--delayrandom</string>
+		<string>3600</string>
+		<string>--timeout</string>
+		<string>43200</string>
+		<string>--</string>
+		<string>/usr/local/munki/managedsoftwareupdate</string>
+		<string>--auto</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Minute</key>
+		<integer>10</integer>
+	</dict>
 </dict>
 </plist>
-

--- a/launchd/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-install.plist
+++ b/launchd/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-install.plist
@@ -2,27 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.managedsoftwareupdate-install</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/munki/supervisor</string>
-    <string>--timeout</string>
-    <string>43200</string>
-    <string>--</string>
-    <string>/usr/local/munki/managedsoftwareupdate</string>
-    <string>--installwithnologout</string>
-  </array>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/private/tmp/.com.googlecode.munki.managedinstall.launchd</key>
-       <true/>
-     </dict>
-  </dict>
-  <key>OnDemand</key>
-  <true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/private/tmp/.com.googlecode.munki.managedinstall.launchd</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.googlecode.munki.managedsoftwareupdate-install</string>
+	<key>OnDemand</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/munki/supervisor</string>
+		<string>--timeout</string>
+		<string>43200</string>
+		<string>--</string>
+		<string>/usr/local/munki/managedsoftwareupdate</string>
+		<string>--installwithnologout</string>
+	</array>
 </dict>
 </plist>
-

--- a/launchd/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-manualcheck.plist
+++ b/launchd/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-manualcheck.plist
@@ -2,28 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.managedsoftwareupdate-manualcheck</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/munki/supervisor</string>
-    <string>--timeout</string>
-    <string>43200</string>
-    <string>--</string>
-    <string>/usr/local/munki/managedsoftwareupdate</string>
-    <string>--manualcheck</string>
-  </array>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/private/tmp/.com.googlecode.munki.updatecheck.launchd</key>
-       <true/>
-     </dict>
-  </dict>
-  <key>OnDemand</key>
-  <true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/private/tmp/.com.googlecode.munki.updatecheck.launchd</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.googlecode.munki.managedsoftwareupdate-manualcheck</string>
+	<key>OnDemand</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/munki/supervisor</string>
+		<string>--timeout</string>
+		<string>43200</string>
+		<string>--</string>
+		<string>/usr/local/munki/managedsoftwareupdate</string>
+		<string>--manualcheck</string>
+	</array>
 </dict>
 </plist>
-
-

--- a/launchd/app_usage_LaunchDaemon/com.googlecode.munki.app_usage_monitor.plist
+++ b/launchd/app_usage_LaunchDaemon/com.googlecode.munki.app_usage_monitor.plist
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.googlecode.munki.app_usage_monitor</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/munki/app_usage_monitor</string>
-  </array>
-  <key>RunAtLoad</key>
-  <true/>
+	<key>Label</key>
+	<string>com.googlecode.munki.app_usage_monitor</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/munki/app_usage_monitor</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This change simply lints all the launchagents and daemons.

I figure since we the launchd package is already updating, this is a perfect time.

By doing this, an admin can install the normal launchd's with a standard munki package, and then manage those same launchd's with a CM tool (say) chef without the CM tool thinking something is wrong with the files and attempting to unload/load them.