### PR TITLE
Remove RunAtLoad from LaunchAgent plists

### DIFF
--- a/launchd/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
+++ b/launchd/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
@@ -22,7 +22,5 @@
 		<string>-a</string>
 		<string>/Applications/Managed Software Center.app</string>
 	</array>
-	<key>RunAtLoad</key>
-	<false/>
 </dict>
 </plist>

--- a/launchd/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
+++ b/launchd/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
@@ -26,7 +26,5 @@
 	<array>
 		<string>/Applications/Managed Software Center.app/Contents/Resources/MunkiStatus.app/Contents/MacOS/MunkiStatus</string>
 	</array>
-	<key>RunAtLoad</key>
-	<false/>
 </dict>
 </plist>

--- a/launchd/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
+++ b/launchd/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
@@ -29,7 +29,5 @@
 		<string>/usr/local/munki/managedsoftwareupdate</string>
 		<string>--logoutinstall</string>
 	</array>
-	<key>RunAtLoad</key>
-	<false/>
 </dict>
 </plist>

--- a/launchd/LaunchAgents/com.googlecode.munki.munki-notifier.plist
+++ b/launchd/LaunchAgents/com.googlecode.munki.munki-notifier.plist
@@ -22,7 +22,5 @@
 		<string>-a</string>
 		<string>/Applications/Managed Software Center.app/Contents/Resources/munki-notifier.app</string>
 	</array>
-	<key>RunAtLoad</key>
-	<false/>
 </dict>
 </plist>

--- a/launchd/LaunchDaemons/com.googlecode.munki.logouthelper.plist
+++ b/launchd/LaunchDaemons/com.googlecode.munki.logouthelper.plist
@@ -8,7 +8,5 @@
 	<array>
 		<string>/usr/local/munki/logouthelper</string>
 	</array>
-	<key>RunAtLoad</key>
-	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Apologies for missing this, but I forgot one other change.

According to launchd's documentation, RunAtLoad is not needed. I ran into this before on another tool:

```     RunAtLoad <boolean>
     This optional key is used to control whether your job is launched once at the time the job is loaded.
     The default is false.
```

https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man5/launchd.plist.5.html

This key is not needed as by default it will be false.