### PR TITLE
Don't show status window until Setup Assistant has finished

### DIFF
--- a/code/apps/MunkiStatus/MunkiStatus/MSUStatusWindowController.py
+++ b/code/apps/MunkiStatus/MunkiStatus/MSUStatusWindowController.py
@@ -174,6 +174,11 @@ class MSUStatusWindowController(NSObject):
 
     def initStatusSession(self):
         '''Initialize our status session'''
+        # Wait for Setup Assistant to finish before showing the window.
+        if not os.path.exists('/private/var/log/.AppleSetupDone'):
+            NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                5.0, self, self.initStatusSession, None, NO)
+            return
         self.setWindowLevel()
         consoleuser = munki.getconsoleuser()
         if consoleuser == None or consoleuser == u"loginwindow":


### PR DESCRIPTION
This resolves the issue with Munki trying to run before Setup Assistant has finished (if it hasn't been bypassed with .AppleSetupDone), but getting stuck waiting for the network, blocking the user from using the assistant to configure networking.