### PR TITLE
Authrestart launchd fix

### DIFF
--- a/launchd/LaunchDaemons/com.googlecode.munki.authrestartd.plist
+++ b/launchd/LaunchDaemons/com.googlecode.munki.authrestartd.plist
@@ -12,10 +12,10 @@
 	<dict>
 		<key>authrestartd</key>
 		<dict>
-			<key>SockPathName</key>
-			<string>/var/run/authrestartd</string>
 			<key>SockPathMode</key>
 			<integer>438</integer>
+			<key>SockPathName</key>
+			<string>/var/run/authrestartd</string>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
This has the `authrestartd` keys in correct order and adds a blank line at the end.