### PR TITLE
Stop displaying of script tag in MSC footer

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/WebResources/base.css
+++ b/code/apps/Managed Software Center/Managed Software Center/WebResources/base.css
@@ -307,6 +307,10 @@ footer {
     padding: 0 20px
 }
 
+footer script {
+   display: none !important;
+}
+
 footer div.bottom-links {
     margin: 0 0 0 0;
     border-top: 1px solid #d3d7db;


### PR DESCRIPTION
Wildcard in CSS for footer div.bottom-links overrides the script tag’s inherent display:none, this restores it.

For example, using the code below in the footer_template:
`<script type="text/javascript">document.write(new Date().getFullYear());</script>`

Would display as: document.write(new Date().getFullYear());2017, instead of just 2017.