### PR TITLE
fix: Don't print blank lines during munkiimport

### DIFF
--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -82,7 +82,9 @@ def make_dmg(pkgpath):
         output = proc.stdout.readline()
         if not output and (proc.poll() != None):
             break
-        print output.rstrip('\n').decode('UTF-8')
+        line = output.rstrip('\n').decode('UTF-8')
+        if len(line) > 0:
+            print line
         sys.stdout.flush()
     retcode = proc.poll()
     if retcode:


### PR DESCRIPTION
This line was printing between 20-50 blank lines on each munkiimport