### PR TITLE
fix: Add basic PEP8 back into travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+sudo: no
 language: python
 python:
   - "2.7"
 install:
   - pip install flake8 pep8
 script:
-  - python tests/travisci.py
+  - git diff HEAD^ | flake8 --diff --ignore=E501


### PR DESCRIPTION
Gonna leave this here. If @natewalck / @keeleysam have comments post below. 

The current implementation doesn't require the repo to have a separate script just for running a basic pep8 test. Plus it's off of travis slower legacy system with the addition of `sudo: no`.

If this gets merged someone with repo access will need to re-enable the Travis CI integration.