### PR TITLE
Add 'Featured'/'Featured items' ru strings

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/ru.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/ru.lproj/Localizable.strings
@@ -119,10 +119,10 @@
 "Due:" = "До:";
 
 /* FeaturedLabel */
-"Featured" = "Featured";
+"Featured" = "Подборка";
 
 /* FeaturedItemsHeaderText */
-"Featured items" = "Featured items";
+"Featured items" = "Подборка элементов";
 
 /* managedsoftwareupdate message */
 "Finishing..." = "Завершение...";


### PR DESCRIPTION
One more Russian update for #749, this just adds the 'Featured' items (the one I [suggested](https://github.com/munki/munki/pull/759#issue-225447860) was wrong, but this is correct according to a native speaker).