### PR TITLE
Fix InDesign 2017 size calculation

### DIFF
--- a/code/client/munkilib/adobeutils/adobeinfo.py
+++ b/code/client/munkilib/adobeutils/adobeinfo.py
@@ -584,7 +584,12 @@ def getAdobeCatalogInfo(mountpoint, pkgname=""):
                         # languages are very close to the same size. We also
                         # get one included language package which would be the
                         # case for any install.
+                        #
+                        # Because InDesign CC 2017 is not like any other package
+                        # and contains a 'Condition' key but as an empty
+                        # string, we explicitly test this case as well.
                         if ('Condition' not in package.keys() or
+                                package.get('Condition') == '' or
                                 '[installLanguage]==en_US' in
                                 package.get('Condition', '')):
                             installed_size += package.get(


### PR DESCRIPTION
Thanks to @foigus for checking my work in #765, and thanks Adobe for being inconsistent across packaging groups as usual.

I opted to not simplify this if conditional and use a falsey value test just so that it's clear that there are different possible cases here. Checked this with PyLint this time.