### PR TITLE
Return a sorted file list

### DIFF
--- a/code/client/munkilib/munkirepo/FileRepo.py
+++ b/code/client/munkilib/munkirepo/FileRepo.py
@@ -201,7 +201,12 @@ class FileRepo(Repo):
                     abs_path = os.path.join(dirpath, name)
                     rel_path = abs_path[len(search_dir):].lstrip("/")
                     file_list.append(rel_path)
-            return file_list
+            '''Different filesystems return items in different orders, so sort
+            before returning them to produce consisten results.  For example,
+            items are generally returned in an ascending order on an HFS+
+            volume, but are returned in a somewhat random, descending, and
+            unpredictable order on AFPS.'''
+            return sorted(file_list)
         except (OSError, IOError), err:
             raise RepoError(err)
 


### PR DESCRIPTION
When running `os.walk` on a directory, results can be inconsistent depending on the filesystem it is being run on.  On HFS+, you generally get an already sorted list back.  On an APFS volume, the result is seemingly random, roughly descending, and is not consistent at all.  This can mean that running `makecatalogs` results in a different output every time it is run, even though the pkginfos haven't changed.

This change makes the itemlist function always return a sorted list, which will always be consistent given the same input.