### PR TITLE
No hash hashing

### DIFF
--- a/code/client/makecatalogs
+++ b/code/client/makecatalogs
@@ -50,6 +50,9 @@ def hash_icons(repo):
     icons = {}
     print_utf8("Getting list of icons...")
     icon_list = repo.itemlist('icons')
+    # Don't hash the hashes, they aren't icons.
+    if '_icon_hashes.plist' in icon_list:
+        icon_list.remove('_icon_hashes.plist')
     for icon_ref in icon_list:
         print_utf8("Hashing %s..." % (icon_ref))
         # Try to read the icon file


### PR DESCRIPTION
`repo.itemlist('icons')` will return `_icon_hashes.plist` if it exists, so remove that from our list so there's not a loop with a changing hash list on every `makecatalogs` run.