### PR TITLE
An option to silently skip pkg check

### DIFF
--- a/code/client/makecatalogs
+++ b/code/client/makecatalogs
@@ -318,7 +318,7 @@ def main():
     parser.add_option('--force', '-f', action='store_true', dest='force',
                       help='Disable sanity checks.')
     parser.add_option('--skip-pkg-check', '-s', action='store_true', dest='skip_payload_check',
-                      help='Skip check of pkg infos. Useful'
+                      help='Skip checking of pkg existence. Useful'
                            'when pkgs aren\'t on the same server'
                            'as pkginfo, catalogs and manifests.')
     parser.add_option('--repo_url', '--repo-url',

--- a/code/client/makecatalogs
+++ b/code/client/makecatalogs
@@ -318,7 +318,7 @@ def main():
     parser.add_option('--force', '-f', action='store_true', dest='force',
                       help='Disable sanity checks.')
     parser.add_option('--skip-pkg-check', '-s', action='store_true', dest='skip_payload_check',
-                      help='Skip check of pkg infos. Usefull'
+                      help='Skip check of pkg infos. Useful'
                            'when pkgs aren\'t on the same server'
                            'as pkginfo, catalogs and manifests.')
     parser.add_option('--repo_url', '--repo-url',

--- a/code/client/makecatalogs
+++ b/code/client/makecatalogs
@@ -146,6 +146,8 @@ def makecatalogs(repo, options):
             do_pkg_check = False
         if pkginfo.get('PackageURL'):
             do_pkg_check = False
+        if options.skip_payload_check:
+            do_pkg_check = False
 
 
         if do_pkg_check:
@@ -315,13 +317,17 @@ def main():
                       help='Print the version of the munki tools and exit.')
     parser.add_option('--force', '-f', action='store_true', dest='force',
                       help='Disable sanity checks.')
+    parser.add_option('--skip-pkg-check', '-s', action='store_true', dest='skip_payload_check',
+                      help='Skip check of pkg infos. Usefull'
+                           'when pkgs aren\'t on the same server'
+                           'as pkginfo, catalogs and manifests.')
     parser.add_option('--repo_url', '--repo-url',
                       help='Optional repo URL that takes precedence '
                            'over the default repo_url specified via '
                            '--configure.')
     parser.add_option('--plugin',
                       help='Specify a custom plugin to connect to repo.')
-    parser.set_defaults(force=False)
+    parser.set_defaults(force=False, skip_payload_check=False)
     options, arguments = parser.parse_args()
 
     if options.version:


### PR DESCRIPTION
Add --skip-pkg-check (-s) option
This PR add a manual option to skip the pkg_check process in addition to PackageCompleteURL & PackageURL based detection.
Manual request for this option is usefull when a unique server contain data and metadata but both are push from different sources. (Like GIT + rsync)
The difference with the force option rely in the warning message that are avoided here and the check done on the metadata part aren't skiped.