### PR TITLE
Add uninstall-pkg command to managed_uninstalls in manifestutil

### DIFF
--- a/code/client/manifestutil
+++ b/code/client/manifestutil
@@ -624,6 +624,65 @@ def add_pkg(repo, args):
         return 1 # Operation not permitted
 
 
+def uninstall_pkg(repo, args):
+    '''Moves a package from one section to managed_uninstalls in a manifest.'''
+    parser = MyOptionParser()
+    parser.set_usage(
+        '''uninstall-pkg PKGNAME --manifest MANIFESTNAME [--section SECTIONNAME]
+       Moves a package from one section to managed_uninstalls in a manifest. Package is removed from
+       managed_installs unless a different manifest section is specified with
+       the --section option''')
+    parser.add_option('--manifest',
+                      metavar='MANIFESTNAME',
+                      help='''name of manifest on which to operate''')
+    parser.add_option('--section', default='managed_installs',
+                      metavar='SECTIONNAME',
+                      help=('manifest section from which to move the '
+                            'package to. Defaults to managed_uninstalls.'))
+    try:
+        options, arguments = parser.parse_args(args)
+    except MyOptParseError, errmsg:
+        print >> sys.stderr, str(errmsg)
+        return 22 # Invalid argument
+    except MyOptParseExit:
+        return 0
+
+    if not options.manifest:
+        if len(arguments) == 2:
+            options.manifest = arguments[1]
+            del arguments[1]
+        else:
+            parser.print_usage(sys.stderr)
+            return 7 # Argument list too long
+    if len(arguments) != 1:
+        parser.print_usage(sys.stderr)
+        return 7 # Argument list too long
+    pkgname = arguments[0]
+
+    manifest = get_manifest(repo, options.manifest)
+    if not manifest:
+        return 2 # No such file or directory
+    if not options.section in manifest:
+        print >> sys.stderr, ('Section %s is not in manifest %s.'
+                              % (options.section, manifest))
+        return 1 # Operation not permitted
+    if pkgname not in manifest[options.section]:
+        print >> sys.stderr, ('Package %s is not in section %s '
+                              'of manifest %s.'
+                              % (pkgname, options.section, options.manifest))
+        return 1 # Operation not permitted
+    else:
+        manifest[options.section].remove(pkgname)
+        manifest['managed_uninstalls'].append(pkgname)
+        if save_manifest(repo, manifest, options.manifest,
+                         overwrite_existing=True):
+            print ('Removed %s from section %s and added to section managed_uninstalls of manifest %s.'
+                   % (pkgname, options.section, options.manifest))
+            return 0
+        else:
+            return 1 # Operation not permitted
+
+
 def remove_pkg(repo, args):
     '''Removes a package from a manifest.'''
     parser = MyOptionParser()
@@ -1035,6 +1094,7 @@ def main():
             'add-catalog':               'catalogs',
             'add-included-manifest':     'manifests',
             'remove-pkg':                'pkgs',
+            'uninstall-pkg':             'pkgs',
             'remove-catalog':            'catalogs',
             'remove-included-manifest':  'manifests',
             'list-manifests':            'manifests',

--- a/code/client/manifestutil
+++ b/code/client/manifestutil
@@ -624,11 +624,11 @@ def add_pkg(repo, args):
         return 1 # Operation not permitted
 
 
-def uninstall_pkg(repo, args):
+def move_install_to_uninstall(repo, args):
     '''Moves a package from managed_installs to managed_uninstalls in a manifest.'''
     parser = MyOptionParser()
     parser.set_usage(
-        '''uninstall-pkg PKGNAME --manifest MANIFESTNAME
+        '''move-install-to-uninstall PKGNAME --manifest MANIFESTNAME
        Moves a package from managed_installs to managed_uninstalls in a manifest.''')
     parser.add_option('--manifest',
                       metavar='MANIFESTNAME',
@@ -1091,7 +1091,7 @@ def main():
             'add-catalog':               'catalogs',
             'add-included-manifest':     'manifests',
             'remove-pkg':                'pkgs',
-            'uninstall-pkg':             'pkgs',
+            'move-install-to-uninstall': 'pkgs',
             'remove-catalog':            'catalogs',
             'remove-included-manifest':  'manifests',
             'list-manifests':            'manifests',

--- a/code/client/manifestutil
+++ b/code/client/manifestutil
@@ -625,20 +625,14 @@ def add_pkg(repo, args):
 
 
 def uninstall_pkg(repo, args):
-    '''Moves a package from one section to managed_uninstalls in a manifest.'''
+    '''Moves a package from managed_installs to managed_uninstalls in a manifest.'''
     parser = MyOptionParser()
     parser.set_usage(
-        '''uninstall-pkg PKGNAME --manifest MANIFESTNAME [--section SECTIONNAME]
-       Moves a package from one section to managed_uninstalls in a manifest. Package is removed from
-       managed_installs unless a different manifest section is specified with
-       the --section option''')
+        '''uninstall-pkg PKGNAME --manifest MANIFESTNAME
+       Moves a package from managed_installs to managed_uninstalls in a manifest.''')
     parser.add_option('--manifest',
                       metavar='MANIFESTNAME',
                       help='''name of manifest on which to operate''')
-    parser.add_option('--section', default='managed_installs',
-                      metavar='SECTIONNAME',
-                      help=('manifest section from which to move the '
-                            'package to. Defaults to managed_uninstalls.'))
     try:
         options, arguments = parser.parse_args(args)
     except MyOptParseError, errmsg:
@@ -662,22 +656,25 @@ def uninstall_pkg(repo, args):
     manifest = get_manifest(repo, options.manifest)
     if not manifest:
         return 2 # No such file or directory
-    if not options.section in manifest:
-        print >> sys.stderr, ('Section %s is not in manifest %s.'
-                              % (options.section, manifest))
-        return 1 # Operation not permitted
-    if pkgname not in manifest[options.section]:
-        print >> sys.stderr, ('Package %s is not in section %s '
-                              'of manifest %s.'
-                              % (pkgname, options.section, options.manifest))
-        return 1 # Operation not permitted
     else:
-        manifest[options.section].remove(pkgname)
-        manifest['managed_uninstalls'].append(pkgname)
+        if pkgname in manifest['managed_installs']:
+            manifest['managed_installs'].remove(pkgname)
+            print ('Removed %s from section %s of mainfest %s' % (pkgname, 'managed_installs', options.manifest))
+        else:
+            print >> sys.stderr, ('WARNING: Package %s is not in section %s '
+                                  'of manifest %s. No changes made.'
+                                  % (pkgname, 'managed_installs', options.manifest))
+            return 1 # Operation not permitted
+        if pkgname in manifest['managed_uninstalls']:
+            print ('%s is already in section managed_uninstalls of manifest %s.'
+                   % (pkgname, options.manifest))
+        else:
+            manifest['managed_uninstalls'].append(pkgname)
+            print ('Added %s to section managed_uninstalls of manifest %s.'
+                   % (pkgname, options.manifest))
+
         if save_manifest(repo, manifest, options.manifest,
                          overwrite_existing=True):
-            print ('Removed %s from section %s and added to section managed_uninstalls of manifest %s.'
-                   % (pkgname, options.section, options.manifest))
             return 0
         else:
             return 1 # Operation not permitted
@@ -723,7 +720,7 @@ def remove_pkg(repo, args):
         return 2 # No such file or directory
     if not options.section in manifest:
         print >> sys.stderr, ('Section %s is not in manifest %s.'
-                              % (options.section, manifest))
+                              % (options.section, options.manifest))
         return 1 # Operation not permitted
     if pkgname not in manifest[options.section]:
         print >> sys.stderr, ('Package %s is not in section %s '


### PR DESCRIPTION
Added a command `uninstall-pkg` to manifestutil to move a pkg from a section to the managed_uninstalls section instead of having to run two commands: `remove-pkg` then `add-pkg`.

CLA submitted.

-Eric