### PR TITLE
fix: Correct issue with Auth Restart

### DIFF
--- a/code/client/munkilib/authrestart/__init__.py
+++ b/code/client/munkilib/authrestart/__init__.py
@@ -126,7 +126,7 @@ def get_auth_restart_key(quiet=False):
             display.display_error(
                 'We had trouble getting info from %s...', recoverykeyplist)
         return ''
-    except KeyError:
+    except (KeyError, ValueError):
         if not quiet:
             display.display_error(
                 'Problem with key: RecoveryKey in %s...', recoverykeyplist)


### PR DESCRIPTION
An invalid RecoveryKey can be set that causes FoundationPlist to throw
a ValueError. If this happens no restart happens. Instead we should log
the error and revert to a non-auth restart.

Tested that this does indeed Fix #799 