### PR TITLE
Fixed bug that would clear restart requirement

### DIFF
--- a/code/client/munkilib/installer/core.py
+++ b/code/client/munkilib/installer/core.py
@@ -303,7 +303,7 @@ def install_with_info(
                     retcode = -1
             # nopkg (Packageless) install
             elif installer_type == "nopkg":
-                restartflag = requires_restart(item)
+                restartflag |= requires_restart(item)
             # unknown installer_type
             elif installer_type != "":
                 # we've encountered an installer type


### PR DESCRIPTION
This patch fixes issue #802 which causes managedsoftwareupdate to skipping a reboot. The "=" overrides a previous True value for "restartflag" if the nopkg script requires no restart.