### PR TITLE
Localized pkgsinfo support

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/CocoaWrapper.py
+++ b/code/apps/Managed Software Center/Managed Software Center/CocoaWrapper.py
@@ -29,7 +29,6 @@ from Foundation import (
     NSFileHandle,
     NSFileManager,
     NSInsetRect,
-    NSLocale,
     NSLocalizedString,
     NSLog,
     NSMakePoint,

--- a/code/apps/Managed Software Center/Managed Software Center/CocoaWrapper.py
+++ b/code/apps/Managed Software Center/Managed Software Center/CocoaWrapper.py
@@ -29,6 +29,7 @@ from Foundation import (
     NSFileHandle,
     NSFileManager,
     NSInsetRect,
+    NSLocale,
     NSLocalizedString,
     NSLog,
     NSMakePoint,

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.py
@@ -534,6 +534,8 @@ class GenericItem(dict):
 
     def __init__(self, *arg, **kw):
         super(GenericItem, self).__init__(*arg, **kw)
+        if self.get('localized_strings'):
+            self.add_localizations()
         # now normalize values
         if not self.get('display_name'):
             self['display_name'] = self['name']
@@ -938,6 +940,30 @@ class GenericItem(dict):
     def more_link_text(self):
         return NSLocalizedString(u"More", u"More link text")
 
+    def add_localizations(self):
+        available_locales = list(self['localized_strings'])
+        fallback_locale = self['localized_strings'].get('fallback_locale')
+        if fallback_locale:
+            available_locales.remove('fallback_locale')
+            available_locales.append(fallback_locale)
+        language_code = self._get_preferred_locale(available_locales)
+        if language_code != fallback_locale:
+            locale_dict = self['localized_strings'].get(language_code)
+            if locale_dict:
+                localized_keys = ['category',
+                                  'description',
+                                  'display_name',
+                                  'preinstall_alert',
+                                  'preuninstall_alert',
+                                  'preupgrade_alert']
+                for key in localized_keys:
+                    if key in locale_dict:
+                        self[key] = locale_dict[key]
+
+    def _get_preferred_locale(self, available_locales):
+        code = NSBundle.preferredLocalizationsFromArray_forPreferences_(
+                    available_locales, None)
+        return code[0]
 
 class OptionalItem(GenericItem):
     '''Dictionary subclass that models a given optional install item'''
@@ -946,25 +972,6 @@ class OptionalItem(GenericItem):
         '''Initialize an OptionalItem from a item dict from the
         InstallInfo.plist optional_installs array'''
         super(OptionalItem, self).__init__(*arg, **kw)
-        if self.get('localized_strings'):
-            available_locales = list(self['localized_strings'])
-            fallback_locale = self['localized_strings'].get('fallback_locale')
-            if fallback_locale:
-                available_locales.remove('fallback_locale')
-                available_locales.append(fallback_locale)
-            language_code = self._get_preferred_locale(available_locales)
-            if language_code != fallback_locale:
-                locale_dict = self['localized_strings'].get(language_code)
-                if locale_dict:
-                    localized_keys = ['category',
-                                      'description',
-                                      'display_name',
-                                      'preinstall_alert',
-                                      'preuninstall_alert',
-                                      'preupgrade_alert']
-                    for key in localized_keys:
-                        if key in locale_dict:
-                            self[key] = locale_dict[key]
         if 'category' not in self:
             self['category'] = NSLocalizedString(u"Uncategorized",
                                                  u"No Category name")
@@ -988,12 +995,7 @@ class OptionalItem(GenericItem):
             self['note'] = self._get_note_from_problem_items()
         if not self.get('status'):
             self['status'] = self._get_status()
-    
-    def _get_preferred_locale(self, available_locales):
-        code = NSBundle.preferredLocalizationsFromArray_forPreferences_(
-                    available_locales, None)
-        return code[0]
-                    
+
     def _get_status(self):
         '''Calculates initial status for an item and also sets a boolean
         if a updatecheck is needed'''

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.py
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.py
@@ -946,6 +946,19 @@ class OptionalItem(GenericItem):
         '''Initialize an OptionalItem from a item dict from the
         InstallInfo.plist optional_installs array'''
         super(OptionalItem, self).__init__(*arg, **kw)
+        if self.get('localized_strings'):
+            language_code = NSLocale.currentLocale().languageCode()
+            locale_dict = self['localized_strings'].get(language_code)
+            if locale_dict:
+                localized_keys = ['category',
+                                  'description',
+                                  'display_name',
+                                  'preinstall_alert',
+                                  'preuninstall_alert',
+                                  'preupgrade_alert']
+                for key in localized_keys:
+                    if key in locale_dict:
+                        self[key] = locale_dict[key]
         if 'category' not in self:
             self['category'] = NSLocalizedString(u"Uncategorized",
                                                  u"No Category name")

--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -959,7 +959,8 @@ Extended Options: (makepkginfo options)
                             'category',
                             'developer',
                             'icon_name',
-                            'unused_software_removal_info']:
+                            'unused_software_removal_info',
+                            'localized_strings']:
                     if key in matchingpkginfo:
                         print 'Copying %s: %s' % (key, matchingpkginfo[key])
                         pkginfo[key] = matchingpkginfo[key]

--- a/code/client/munkilib/updatecheck/analyze.py
+++ b/code/client/munkilib/updatecheck/analyze.py
@@ -371,6 +371,9 @@ def process_install(manifestitem, cataloglist, installinfo,
     iteminfo['display_name'] = item_pl.get('display_name', iteminfo['name'])
     iteminfo['description'] = item_pl.get('description', '')
 
+    if(item_pl.get('localized_strings')):
+        iteminfo['localized_strings'] = item_pl['localized_strings']
+
     if not dependencies_met:
         display.display_warning(
             'Didn\'t attempt to install %s because could not resolve all '

--- a/code/client/munkilib/updatecheck/analyze.py
+++ b/code/client/munkilib/updatecheck/analyze.py
@@ -264,7 +264,8 @@ def process_optional_install(manifestitem, cataloglist, installinfo):
                      'preupgrade_alert',
                      'OnDemand',
                      'minimum_os_version',
-                     'update_available']
+                     'update_available',
+                     'localized_strings']
     for key in optional_keys:
         if key in item_pl:
             iteminfo[key] = item_pl[key]


### PR DESCRIPTION
This PR adds support for localising pkgsinfo files so the locale settings of the client machine will show the appropriate strings. This PR introduces a new pkgsinfo key `localized_strings`. The type is a dict of dicts. See the example below:

```xml
	<key>localized_strings</key>
	<dict>
		<key>nl</key>
		<dict>
			<key>category</key>
			<string>Wetenschappelijke Software</string>
			<key>description</key>
			<string>Nederlandse beschrijving</string>
			<key>display_name</key>
			<string>Nederlandse naam</string>
			<key>preinstall_alert</key>
			<dict>
				<key>alert_detail</key>
				<string>Er kan wat gebeuren</string>
				<key>alert_title</key>
				<string>Let op</string>
				<key>cancel_label</key>
				<string>Stop</string>
				<key>ok_label</key>
				<string>Ga door</string>
			</dict>
		</dict>
	</dict>
```

# Structure

The key(s) of the outer dict should match the desired locale, for instance `nl` matches the Dutch locale.
The inner dict should contain one or more of the following pkgsinfo keys: `category`,  `description` and `display_name`. The values should contain the localised strings.
There's also support for these dictionaries: `preinstall_alert`,  `preuninstall_alert`, `preupgrade_alert`.

# Language code

To get a list of language codes, you can use the following python snippet:

```python
from Foundation import NSLocale
print NSLocale.ISOLanguageCodes()
```

# Fallback language

To indicate the default language that the strings in the pkgsinfo are in, you should add the `fallback_locale` key to the `localized_strings` dict.
```xml
	<key>localized_strings</key>
	<dict>
		<key>fallback_locale</key>
		<string>en</string>
	</dict>
```