### PR TITLE
Removing references to Managed Software Update in MunkiStatus

### DIFF
--- a/code/apps/MunkiStatus/MunkiStatus/da.lproj/MainMenu.strings
+++ b/code/apps/MunkiStatus/MunkiStatus/da.lproj/MainMenu.strings
@@ -41,7 +41,7 @@
 "1B8-Pq-rf7.title" = "Vis log";
 
 /* Class = "NSWindow"; title = "Managed Software Center"; ObjectID = "1Nd-E7-vfR"; */
-"1Nd-E7-vfR.title" = "Managed Software Update";
+"1Nd-E7-vfR.title" = "Managed Software Center";
 
 /* Class = "NSMenuItem"; title = "Delete"; ObjectID = "202"; */
 "202.title" = "Slet";

--- a/code/apps/MunkiStatus/MunkiStatus/fi.lproj/MainMenu.strings
+++ b/code/apps/MunkiStatus/MunkiStatus/fi.lproj/MainMenu.strings
@@ -41,7 +41,7 @@
 "1B8-Pq-rf7.title" = "Näytä loki";
 
 /* Class = "NSWindow"; title = "Managed Software Center"; ObjectID = "1Nd-E7-vfR"; */
-"1Nd-E7-vfR.title" = "Managed Software Update";
+"1Nd-E7-vfR.title" = "Managed Software Center";
 
 /* Class = "NSMenuItem"; title = "Delete"; ObjectID = "202"; */
 "202.title" = "Poista";


### PR DESCRIPTION
Noticed this while poking around for rebranding purposes. A couple of the MainMenu.strings for MunkiStatus still have the window title "Managed Software Update" even though their localised translation is now "Managed Software Center".

N.B. I believe this is the only bit of MunkiStatus that is actually user-facing. There are other problems in the localised MainMenu.strings files which all refer to Managed Software Center or its translations rather than MunkiStatus, but not sure if it's worth correcting if user will never see them?
