### PR TITLE
Footer with Company Logo Fix

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/templates/list_template.html
+++ b/code/apps/Managed Software Center/Managed Software Center/templates/list_template.html
@@ -12,8 +12,8 @@
 
 </head>
 
-<body class="grouping">
-    <div id="page">
+<body class="grouping" style="height:100%">
+    <div id="page" style="height: calc(100% - 50px);">
         <div id="wrapper">
             <div id="content">
                 <div class="background"></div>
@@ -42,10 +42,9 @@
         </div>
     </div>
 
-    <footer>
+    <footer style="background-color: white;">
        ${footer}
     </footer>
 
 </body>
-
 </html>

--- a/code/apps/Managed Software Center/Managed Software Center/templates/list_template.html
+++ b/code/apps/Managed Software Center/Managed Software Center/templates/list_template.html
@@ -42,7 +42,7 @@
         </div>
     </div>
 
-    <footer style="background-color: white;">
+    <footer style="background-color: white;position: fixed;left: 50%;transform: translateX(-50%);width: 100%;bottom: 0;">
        ${footer}
     </footer>
 


### PR DESCRIPTION
We wanted to customize our footer with our company logo.  When we did this, it caused the footer to ride up to the middle of the window when using the sidebar category links.  We modified the list_template.html with the following two commits to fix this issue, and keep the footer pinned to the bottom of the window:

https://github.com/ca-miked/munki/commit/43a9d9f0123a296e02a33c491167e547fa6e89d8
https://github.com/ca-miked/munki/commit/82bf03ed96b6c481ba0690e91c78f9fc599c81b9
