### PR TITLE
Implemented optional_installs for localonly manifest

### DIFF
--- a/code/client/munkilib/updatecheck/core.py
+++ b/code/client/munkilib/updatecheck/core.py
@@ -173,10 +173,14 @@ def check(client_id='', localmanifestpath=None):
                 localonlyuninstalls = manifestutils.get_manifest_value_for_key(
                     localonlymanifest, 'managed_uninstalls') or []
                 for item in localonlyuninstalls:
-                    analyze.process_removal(item, cataloglist, installinfo)
+                    dummy_result = analyze.process_removal(
+                        item,
+                        cataloglist,
+                        installinfo
+                    )
 
-                localonlyoptionals = manifestutils.get_manifest_value_for_key(localonlymanifest,
-                                                                              'optional_installs') or []
+                localonlyoptionals = manifestutils.get_manifest_value_for_key(
+                    localonlymanifest, 'optional_installs') or []
                 for item in localonlyoptionals:
                     dummy_result = analyze.process_optional_install(
                         item,

--- a/code/client/munkilib/updatecheck/core.py
+++ b/code/client/munkilib/updatecheck/core.py
@@ -174,6 +174,16 @@ def check(client_id='', localmanifestpath=None):
                     localonlymanifest, 'managed_uninstalls') or []
                 for item in localonlyuninstalls:
                     analyze.process_removal(item, cataloglist, installinfo)
+
+                localonlyoptionals = manifestutils.get_manifest_value_for_key(localonlymanifest,
+                                                                              'optional_installs') or []
+                for item in localonlyoptionals:
+                    dummy_result = analyze.process_optional_install(
+                        item,
+                        cataloglist,
+                        installinfo
+                    )
+
             else:
                 display.display_debug1(
                     "LocalOnlyManifest %s is set but is not present. "


### PR DESCRIPTION
Hi everyone,
current configuration tools (chef, puppet or ansible) can be used to manage `manged_installs` and `managed_uninstalls` by manipulating the local only manifest file. 
This PR would add support for the optional install key.

For example: 
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>managed_installs</key>
	<array>
		<string>MunkiAdmin</string>
		<string>Remote Desktop</string>
		<string>OracleJava9JRE</string>
		<string>Mathematica</string>
		<string>XCode_commandline_tools</string>
		<string>Recipe Robot</string>
		<string>OracleJava8JRE</string>
		<string>uniprintd</string>
		<string>HipChat</string>
	</array>
	<key>managed_uninstalls</key>
	<array/>
	<key>optional_installs</key>
	<array>
		<string>Adobe_Premiere_Pro_CC_EN_2018</string>
		<string>MAXQDA12</string>
		<string>GoogleEarth</string>
		<string>munkimanifest</string>
	</array>
</dict>
</plist>
```
So far I tested if the logic is still working as expected for the following situations: 
* item is in localonly optional_installs **and** localonly managed installs
* item is in localonly optional_installs and managed installs (manifest on the server)
* item is in localonly optional_installs **and** optional installs (manifest on the server)

Could you please check and test it in your development environments?