### PR TITLE
Skip middleware import if path isn't a directory.

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -76,6 +76,10 @@ def import_middleware():
     the module is loaded under the 'middleware' name'''
     required_function_name = 'process_request_options'
     munki_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    if not os.path.isdir(munki_dir):
+        display.display_detail(
+            'Ignoring %s because it is not a directory' % munki_dir)
+        return
     for filename in os.listdir(munki_dir):
         if (filename.startswith('middleware')
                 and os.path.splitext(filename)[1] == '.py'):


### PR DESCRIPTION
If munkilib is embedded in certain self-contained python binary formats
(e.g. https://github.com/google/subpar), the path returned by
os.path.dirname(__file__) may not actually be an existing path.

To work around this, check if munki_dir is actually a directory before
importing middleware.