### PR TITLE
Allow for precaching of optional installs

### DIFF
--- a/code/client/munkilib/updatecheck/analyze.py
+++ b/code/client/munkilib/updatecheck/analyze.py
@@ -243,10 +243,12 @@ def process_optional_install(manifestitem, cataloglist, installinfo):
     iteminfo['uninstallable'] = (
         item_pl.get('uninstallable', False)
         and (item_pl.get('uninstall_method', '') != ''))
-    # If the item is a precache item, get that precache flag and also the basename of the installer item
+    # If the item is a precache item, get that precache flag
+    # and also the basename of the installer item
     if item_pl.get('installer_item_location') and item_pl.get('precache'):
         iteminfo['precache'] = True
-        iteminfo['installer_item'] = download.get_url_basename(item_pl['installer_item_location'])
+        iteminfo['installer_item'] = \
+            download.get_url_basename(item_pl['installer_item_location'])
     iteminfo['installer_item_size'] = \
         item_pl.get('installer_item_size', 0)
     iteminfo['installed_size'] = item_pl.get(

--- a/code/client/munkilib/updatecheck/analyze.py
+++ b/code/client/munkilib/updatecheck/analyze.py
@@ -243,6 +243,10 @@ def process_optional_install(manifestitem, cataloglist, installinfo):
     iteminfo['uninstallable'] = (
         item_pl.get('uninstallable', False)
         and (item_pl.get('uninstall_method', '') != ''))
+    # If the item is a precache item, get that precache flag and also the basename of the installer item
+    if item_pl.get('installer_item_location') and item_pl.get('precache'):
+        iteminfo['precache'] = True
+        iteminfo['installer_item'] = download.get_url_basename(item_pl['installer_item_location'])
     iteminfo['installer_item_size'] = \
         item_pl.get('installer_item_size', 0)
     iteminfo['installed_size'] = item_pl.get(

--- a/code/client/munkilib/updatecheck/core.py
+++ b/code/client/munkilib/updatecheck/core.py
@@ -377,6 +377,10 @@ def check(client_id='', localmanifestpath=None):
         cache_list.extend([item['uninstaller_item']
                            for item in installinfo.get('removals', [])
                            if item.get('uninstaller_item')])
+        # Don't delete optional installs that are designated as precache
+        cache_list.extend([item['installer_item']
+                           for item in installinfo.get('optional_installs', [])
+                           if item.get('precache')])
         cachedir = os.path.join(managed_install_dir, 'Cache')
         for item in osutils.listdir(cachedir):
             if item.endswith('.download'):


### PR DESCRIPTION
As @nmcspadden suggested, leave the delivery of the precache up to an outside mechanism and not a Munki run, but this would allow the designated optional installs (with the `precache` = `True` flag in the pkginfo) to remain in the `/Library/Managed Installs/Cache` folder even if the optional install isn't selected.