### PR TITLE
Fix optimistic timeout value 

### DIFF
--- a/code/client/munkilib/info.py
+++ b/code/client/munkilib/info.py
@@ -447,7 +447,7 @@ def sp_application_data():
                  stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                  stderr=subprocess.PIPE)
     try:
-        output, dummy_error = proc.communicate(timeout=60)
+        output, dummy_error = proc.communicate(timeout=600)
     except TimeoutError:
         display.display_error(
             'system_profiler hung; skipping SPApplicationsDataType query')


### PR DESCRIPTION

if the timeout is hit it will not cause the **very** expensive call result and instead discard it. the higher value should ensure, the hang case is not as likely to be confused with a system with many installed apps. (the system_profiler call takes around 50 seconds on my 2015 macbook when nothing else is active)