### PR TITLE
fix: Remove OpenSSL import in keychain.py

### DIFF
--- a/code/client/munkilib/keychain.py
+++ b/code/client/munkilib/keychain.py
@@ -27,7 +27,6 @@ import base64
 import hashlib
 import os
 import subprocess
-from OpenSSL.crypto import load_certificate, FILETYPE_PEM
 
 from . import display
 from . import osutils
@@ -151,11 +150,16 @@ def get_client_cert_common_name():
     cert_info = get_munki_client_cert_info()
     client_cert_path = cert_info['client_cert_path']
     if client_cert_path and os.path.exists(client_cert_path):
-        fileobj = open(client_cert_path)
-        data = fileobj.read()
-        fileobj.close()
-        x509 = load_certificate(FILETYPE_PEM, data)
-        common_name = x509.get_subject().commonName
+        cmd = ['/usr/bin/openssl', 'x509', '-noout', '-subject', '-in',
+               client_cert_path]
+        proc = subprocess.Popen(cmd,
+                                bufsize=-1, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        (out, err) = proc.communicate()
+        if out:
+            for i in out.split('/'):
+                if i.startswith('CN='):
+                    common_name = i[3:].rstrip()
     return common_name
 
 


### PR DESCRIPTION
In Mojave 10.14 Apple has updated the openssl version to a newer release
of LibreSSL (2.6.4) that no longer contains the proper Symbols for SSLv3.
This causes import errors in the OpenSSL module that ships with 10.14.

To resolve the import errors we now shell out to openssl to get the
client cert common name. This has been hand tested with the following
macOS/openssl versions:

- 10.12 - 0.9.8zh 14 Jan 2016
- 10.13 - LibreSSL 2.2.7
- 10.14b1 - LibreSSL 2.6.4

Fix: #855

For testing, I verified with two certs with the following formating:

```
subject= /UID=RP82Y2QL76/CN=Developer ID Installer: Clayton Burlison (RP82Y2QL76)/OU=RP82Y2QL76/O=Clayton Burlison/C=US

and 

subject= /CN=DESKTOP-FB2JSN1
```

both properly report the correct common name. I haven't tested
this in the context of a munki run to valid client certs work on 10.14
but the function is simply replacing the OpenSSL library so it
should work.

[test_certs.zip](https://github.com/munki/munki/files/2074633/test_certs.zip)
