### PR TITLE
Remove .lower() from  check_mode() in pkginfolib

### DIFF
--- a/code/client/munkilib/admin/pkginfolib.py
+++ b/code/client/munkilib/admin/pkginfolib.py
@@ -710,7 +710,7 @@ def makepkginfo(installeritem, options):
 
 def check_mode(option, opt, value, parser):
     '''Callback to check --mode options'''
-    modes = value.lower().replace(',', ' ').split()
+    modes = value.replace(',', ' ').split()
     value = None
     rex = re.compile("[augo]+[=+-][rstwxXugo]+")
     for mode in modes:


### PR DESCRIPTION
Fix #866