### PR TITLE
Sort the conditionals list so they always run in the same order

### DIFF
--- a/code/client/munkilib/info.py
+++ b/code/client/munkilib/info.py
@@ -674,7 +674,7 @@ def get_conditions():
     except (OSError, IOError):
         pass
     if os.path.exists(conditionalscriptdir):
-        for conditionalscript in osutils.listdir(conditionalscriptdir):
+        for conditionalscript in sorted(osutils.listdir(conditionalscriptdir)):
             if conditionalscript.startswith('.'):
                 # skip files that start with a period
                 continue


### PR DESCRIPTION
For QA systems, we want to add a conditional script that would override the conditional we already created.  For example, we have a shard conditional which assigns a number from 1 to 100, but we'd like the QA systems to **all** have a shard of 1.

listdir() returns the list in filesystem order, which is effectively random. This PR sorts the list so that conditionals run in a stable order; that is, condition script 'zzz-shard-override' would run before 'shard' regardless of the inode number, phase of the moon, or whatever the filesystem uses for "order."

CLA form submitted.
