### PR TITLE
Fixing makedirs umask problem

### DIFF
--- a/code/client/munkilib/installer/dmg.py
+++ b/code/client/munkilib/installer/dmg.py
@@ -174,7 +174,9 @@ def validate_source_and_destination(mountpoint, item):
         # write access to the parent directory from writing their own payloads
         # to this directory
         try:
+            original_umask = os.umask(0)
             os.makedirs(full_destpath, 0o0700)
+            os.umask(original_umask)
         except OSError, err:
             display.display_error(
                 "Error creating %s: %s", full_destpath, err)


### PR DESCRIPTION
os.makedirs honors the umask of the current process so it may write the directory with incorrect permissions which causes issues down the line when the directory is checked for permission of 700.  This fix is to make sure the umask is set to 0 and then reset the umask after the directory is created.

https://stackoverflow.com/questions/5231901/permission-problems-when-creating-a-dir-with-os-makedirs-in-python