### PR TITLE
Fix repoclean so that catalog ordering does not matter for grouping

### DIFF
--- a/code/client/repoclean
+++ b/code/client/repoclean
@@ -223,7 +223,7 @@ class RepoCleaner(object):
                 if pkginfo.get(key):
                     value = pkginfo[key]
                     if key == 'catalogs':
-                        value = ', '.join(value)
+                        value = ', '.join(sorted(value))
                     if key == 'receipts':
                         value = ', '.join(
                             [item.get('packageid', '') for item in value])


### PR DESCRIPTION
When determining the grouping of different packages to mark them for deletion, repoclean considers the included catalogs for each pkginfo. However, it considers them in a way where different orderings of catalogs will put packages into different groups. I assume that the ordering of catalogs should not matter for this purpose.

This patch simply sorts the catalogs so that the ordering is consistent.

Before Patch:

```
name: MunkiReport
catalogs: production, development, testing, unstable
minimum_os_version: 10.5.0
receipts: com.github.munkireport
versions:
     2.10.1 (pkgsinfo/munkireport/MunkiReport-2.10.1.plist) 
     2.8.5 (pkgsinfo/munkireport/MunkiReport-2.8.5.plist) 

name: MunkiReport
catalogs: unstable, development, production, testing
minimum_os_version: 10.5.0
receipts: com.github.munkireport
versions:
     3.2.2 (pkgsinfo/administration/munkireport/MunkiReport-3.2.2.plist) 

name: MunkiReport
catalogs: unstable, development, testing, production
minimum_os_version: 10.5.0
receipts: com.github.munkireport
versions:
     2.15.2.1 (pkgsinfo/munkireport/munkireport-2.15.2.plist) 
     2.15.2 (pkgsinfo/administration/munkireport/MunkiReport-2.15.2.plist) 
```

After Patch:

```
name: MunkiReport
catalogs: development, production, testing, unstable
minimum_os_version: 10.5.0
receipts: com.github.munkireport
versions:
     3.2.2 (pkgsinfo/administration/munkireport/MunkiReport-3.2.2.plist) 
     2.15.2.1 (pkgsinfo/munkireport/munkireport-2.15.2.plist) 
     2.15.2 (pkgsinfo/administration/munkireport/MunkiReport-2.15.2.plist) [to be DELETED]
     2.10.1 (pkgsinfo/munkireport/MunkiReport-2.10.1.plist) [to be DELETED]
     2.8.5 (pkgsinfo/munkireport/MunkiReport-2.8.5.plist) [to be DELETED]
```