### PR TITLE
Fix for indeterminate progress bar “rolling shutter” effect

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/updates.css
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/updates.css
@@ -578,7 +578,7 @@ div.progress > span.indeterminate > span {
     color-stop(.76, transparent), to(transparent)
     );
     z-index: 1;
-    -webkit-background-size: 20px 20px;
+    -webkit-background-size: 21px 21px;
     -webkit-animation: barber-pole 2s linear infinite;
     -webkit-border-radius: 4px;
     overflow: hidden;
@@ -586,10 +586,10 @@ div.progress > span.indeterminate > span {
 
 @-webkit-keyframes barber-pole {
     0% {
-        background-position: 0 20px;
+        background-position: 0 21px;
     }
     100% {
-        background-position: 20px 0;
+        background-position: 21px 0;
     }
 }
 


### PR DESCRIPTION
Small fix for the indeterminate progress bar, removes the 1px "rolling shutter" effect on the left side of the blue sections.

![shutter](https://user-images.githubusercontent.com/825577/50182880-7dea1980-02de-11e9-88d3-7f6201033cf3.gif)
changed to:
![fixed](https://user-images.githubusercontent.com/825577/50182886-82aecd80-02de-11e9-9fd9-48cbe81a08f3.gif)
