### PR TITLE
Munki uninstall script—forget receipt for app_usage

### DIFF
--- a/code/tools/uninstall_munki.sh
+++ b/code/tools/uninstall_munki.sh
@@ -18,4 +18,5 @@ pkgutil --forget com.googlecode.munki.core
 pkgutil --forget com.googlecode.munki.admin
 pkgutil --forget com.googlecode.munki.app
 pkgutil --forget com.googlecode.munki.launchd
+pkgutil --forget com.googlecode.munki.app_usage
 pkgutil --forget com.googlecode.munki


### PR DESCRIPTION
Adds a line to forget the receipt for the app_usage pkg