### PR TITLE
Deduplicate list of conflicting apps in MSC alert

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -301,7 +301,7 @@ class MSCAlertController: NSObject {
                 "in use:\n\n%@",
                 comment: "Other Users Blocking Apps Running detail")
             alert.informativeText = String(
-                format: formatString, other_users_apps.joined(separator: "\n"))
+                format: formatString, Array(Set(other_users_apps)).joined(separator: "\n"))
         } else {
             alert.messageText = NSLocalizedString(
                 "Conflicting applications running",
@@ -311,7 +311,7 @@ class MSCAlertController: NSObject {
                 "proceeding with installation or removal:\n\n%@",
                 comment: "Blocking Apps Running detail")
             alert.informativeText = String(
-                format: formatString, my_apps.joined(separator: "\n"))
+                format: formatString, Array(Set(my_apps)).joined(separator: "\n"))
         }
         alert.addButton(withTitle: NSLocalizedString("OK", comment: "OK button title"))
         alert.beginSheetModal(for: mainWindow, completionHandler: { (modalResponse) -> Void in


### PR DESCRIPTION
Tested modified MSC successfully on my 10.14.3 Mac, built from the `Munki3dev` branch and using iTerm (multiple tabs open) as the conflicting app.

Before change:

![image](https://user-images.githubusercontent.com/7801391/52374838-24b38200-2a13-11e9-9d80-c9b4e75cd7aa.png)

After change:

![image](https://user-images.githubusercontent.com/7801391/52374843-28df9f80-2a13-11e9-83c6-036110ac64c9.png)

This deduplication was [already present](https://github.com/munki/munki/blob/451de28cb90ef701a894011dc74e4b93e84cc252/code/apps/Managed%20Software%20Center/Managed%20Software%20Center/AlertController.py#L324) in the Python version of MSC, but appears not to have made the jump to Swift.