### PR TITLE
Fix for rolling shutter regression on barber-pole animation.

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/updates.css
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/updates.css
@@ -578,7 +578,7 @@ div.progress > span.indeterminate > span {
     color-stop(.76, transparent), to(transparent)
     );
     z-index: 1;
-    -webkit-background-size: 20px 20px;
+    -webkit-background-size: 21px 21px;
     -webkit-animation: barber-pole 2s linear infinite;
     -webkit-border-radius: 4px;
     overflow: hidden;
@@ -586,10 +586,10 @@ div.progress > span.indeterminate > span {
 
 @-webkit-keyframes barber-pole {
     0% {
-        background-position: 0 20px;
+        background-position: 0 21px;
     }
     100% {
-        background-position: 20px 0;
+        background-position: 21px 0;
     }
 }
 

--- a/code/apps/pyobjc/Managed Software Center/Managed Software Center/WebResources/updates.css
+++ b/code/apps/pyobjc/Managed Software Center/Managed Software Center/WebResources/updates.css
@@ -78,7 +78,7 @@ div.installations th:last-child {
     -webkit-border-top-right-radius: 5px
 }
 .installation td {
-    border-top: 1px solid #fff;
+    /* border-top: 1px solid #fff; */
     border-bottom: 1px solid #d9d9d9;
     padding: 0 10px
 }
@@ -578,7 +578,7 @@ div.progress > span.indeterminate > span {
     color-stop(.76, transparent), to(transparent)
     );
     z-index: 1;
-    -webkit-background-size: 20px 20px;
+    -webkit-background-size: 21px 21px;
     -webkit-animation: barber-pole 2s linear infinite;
     -webkit-border-radius: 4px;
     overflow: hidden;
@@ -586,10 +586,10 @@ div.progress > span.indeterminate > span {
 
 @-webkit-keyframes barber-pole {
     0% {
-        background-position: 0 20px;
+        background-position: 0 21px;
     }
     100% {
-        background-position: 20px 0;
+        background-position: 21px 0;
     }
 }
 


### PR DESCRIPTION
Fixed regression from #892 when the two copies of updates.css were synced up in commit aed4b4b.

Also copied the line fix from ffb2dc9 for #922 to the pyobjc updates.css.

_Updated from #931 - which had spurious commits._ 