### PR TITLE
added skips for Synology index (@eaDir) files.

### DIFF
--- a/code/client/munkilib/admin/makecatalogslib.py
+++ b/code/client/munkilib/admin/makecatalogslib.py
@@ -49,6 +49,9 @@ def hash_icons(repo, output_fn=None):
     if '_icon_hashes.plist' in icon_list:
         icon_list.remove('_icon_hashes.plist')
     for icon_ref in icon_list:
+        # Skipping Synology index files
+        if '@eaDir' in icon_ref:
+            continue
         if output_fn:
             output_fn("Hashing %s..." % (icon_ref))
         # Try to read the icon file
@@ -186,6 +189,10 @@ def process_pkgsinfo(repo, options, output_fn=None):
 
     # Walk through the pkginfo files
     for pkginfo_ref in pkgsinfo_list:
+        # Skipping Synology index files
+        if '@eaDir' in pkginfo_ref:
+            continue
+        
         # Try to read the pkginfo file
         try:
             data = repo.get(pkginfo_ref)


### PR DESCRIPTION
When hosting a Munki repo on a Synology and running `makecatalogs`, it hashes the index resources that Synology creates for the icons and generates a lot of unexpected errors, as `makecatalogs` attempts to read the index files that Synology generated for the pkginfo files.

This ends up generating a lot of noise that makes it harder to catch errors that might pop up. All of these index files are stored in `@eaDir` folders. To silence these I added two `if` checks to see if `@eaDir` is in the path. If it is, it just continues to the next looped file. I've tested this locally and it appears to work.