### PR TITLE
rescue admin note deletion failure

### DIFF
--- a/code/client/munkilib/admin/makecatalogslib.py
+++ b/code/client/munkilib/admin/makecatalogslib.py
@@ -200,8 +200,12 @@ def process_pkgsinfo(repo, options, output_fn=None):
             continue
 
         # don't copy admin notes to catalogs.
-        if pkginfo.get('notes'):
-            del pkginfo['notes']
+        try:
+            if pkginfo.get('notes'):
+                del pkginfo['notes']
+        except AttributeError, err:
+            errors.append("WARNING: %s admin notes may not be deleted" % pkginfo_ref)
+            continue
         # strip out any keys that start with "_"
         # (example: pkginfo _metadata)
         for key in pkginfo.keys():


### PR DESCRIPTION
When the incoming `.plist` file is in unicode, the `pkginfo.get()` function errors out because the data is not in a dict.

```
Traceback (most recent call last):  
  File "/usr/local/munki/makecatalogs", line 98, in <module>
    main()                          
  File "/usr/local/munki/makecatalogs", line 87, in main
    errors = makecatalogslib.makecatalogs(repo, options, output_fn=print_utf8)
  File "/usr/local/munki/munkilib/admin/makecatalogslib.py", line 256, in makecatalogs
    repo, options, output_fn=output_fn)
  File "/usr/local/munki/munkilib/admin/makecatalogslib.py", line 203, in process_pkgsinfo
    if pkginfo.get('notes'):        
AttributeError: 'str' object has no attribute 'get'
```

This is a quick fix to solve this issue without dealing with modifying the `readPlistLibrary` to use unicode.