### PR TITLE
Adding double quotes to variable in build script to avoid failure

### DIFF
--- a/code/tools/build_python_framework.sh
+++ b/code/tools/build_python_framework.sh
@@ -2,7 +2,7 @@
 #
 # Build script for Python 3 framework for Munki
 
-TOOLSDIR=$(dirname $0)
+TOOLSDIR=$(dirname "$0")
 REQUIREMENTS="${TOOLSDIR}/py3_requirements.txt"
 PYTHON_VERSION=3.7.4
 MUNKIROOT=$(dirname $(dirname "${TOOLSDIR}"))

--- a/code/tools/make_munki_mpkg.sh
+++ b/code/tools/make_munki_mpkg.sh
@@ -18,14 +18,14 @@ MAGICNUMBER=482
 BUILDPYTHON=NO
 
 # try to automagically find munki source root
-TOOLSDIR=$(dirname $0)
+TOOLSDIR=$(dirname "$0")
 # Convert to absolute path.
 TOOLSDIR=$(cd "$TOOLSDIR"; pwd)
-PARENTDIR=$(dirname $TOOLSDIR)
-PARENTDIRNAME=$(basename $PARENTDIR)
+PARENTDIR=$(dirname "$TOOLSDIR")
+PARENTDIRNAME=$(basename "$PARENTDIR")
 if [ "$PARENTDIRNAME" == "code" ]; then
-    GRANDPARENTDIR=$(dirname $PARENTDIR)
-    GRANDPARENTDIRNAME=$(basename $GRANDPARENTDIR)
+    GRANDPARENTDIR=$(dirname "$PARENTDIR")
+    GRANDPARENTDIRNAME=$(basename "$GRANDPARENTDIR")
     if [ "$GRANDPARENTDIRNAME" == "Munki2" ]; then
         MUNKIROOT="$GRANDPARENTDIR"
     fi


### PR DESCRIPTION
build scripts were failing when the path to the build script contained space charactar