### PR TITLE
Pass pkginfo through to middleware so additional context is available

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -198,7 +198,7 @@ def header_dict_from_list(array):
 
 def get_url(url, destinationpath,
             custom_headers=None, message=None, onlyifnewer=False,
-            resume=False, follow_redirects=Falsel:
+            resume=False, follow_redirects=False):
     """Gets an HTTP or HTTPS URL and stores it in
     destination path. Returns a dictionary of headers, which includes
     http_result_code and http_result_description.

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -198,7 +198,7 @@ def header_dict_from_list(array):
 
 def get_url(url, destinationpath,
             custom_headers=None, message=None, onlyifnewer=False,
-            resume=False, follow_redirects=False):
+            resume=False, follow_redirects=Falsel:
     """Gets an HTTP or HTTPS URL and stores it in
     destination path. Returns a dictionary of headers, which includes
     http_result_code and http_result_description.
@@ -235,7 +235,8 @@ def get_url(url, destinationpath,
                'additional_headers': header_dict_from_list(custom_headers),
                'download_only_if_changed': onlyifnewer,
                'cache_data': cache_data,
-               'logging_function': display.display_debug2}
+               'logging_function': display.display_debug2,
+               'pkginfo': pkginfo}
     display.display_debug2('Options: %s' % options)
 
     # Allow middleware to modify options
@@ -342,7 +343,8 @@ def getResourceIfChangedAtomically(url,
                                    message=None,
                                    resume=False,
                                    verify=False,
-                                   follow_redirects=False):
+                                   follow_redirects=False,
+                                   pkginfo=None):
     """Gets file from a URL.
        Checks first if there is already a file with the necessary checksum.
        Then checks if the file has changed on the server, resuming or
@@ -392,7 +394,8 @@ def getResourceIfChangedAtomically(url,
         changed = getHTTPfileIfChangedAtomically(
             url, destinationpath,
             custom_headers=custom_headers,
-            message=message, resume=resume, follow_redirects=follow_redirects)
+            message=message, resume=resume, follow_redirects=follow_redirects,
+            pkginfo=pkginfo)
     elif url_parse.scheme == 'file':
         changed = getFileIfChangedAtomically(url_parse.path, destinationpath)
     else:
@@ -417,7 +420,7 @@ def getResourceIfChangedAtomically(url,
 
 def munki_resource(
         url, destinationpath, message=None, resume=False, expected_hash=None,
-        verify=False):
+        verify=False, pkginfo=None):
 
     '''The high-level function for getting resources from the Munki repo.
     Gets a given URL from the Munki server.
@@ -439,7 +442,8 @@ def munki_resource(
                                           expected_hash=expected_hash,
                                           message=message,
                                           resume=resume,
-                                          verify=verify)
+                                          verify=verify,
+                                          pkginfo=pkginfo)
 
 
 def getFileIfChangedAtomically(path, destinationpath):
@@ -499,7 +503,8 @@ def getFileIfChangedAtomically(path, destinationpath):
 def getHTTPfileIfChangedAtomically(url, destinationpath,
                                    custom_headers=None,
                                    message=None, resume=False,
-                                   follow_redirects=False):
+                                   follow_redirects=False,
+                                   pkginfo=None):
     """Gets file from HTTP URL, checking first to see if it has changed on the
        server.
 
@@ -524,7 +529,8 @@ def getHTTPfileIfChangedAtomically(url, destinationpath,
                          message=message,
                          onlyifnewer=getonlyifnewer,
                          resume=resume,
-                         follow_redirects=follow_redirects)
+                         follow_redirects=follow_redirects,
+                         pkginfo=pkginfo)
 
     except ConnectionError:
         # connection errors should be handled differently; don't re-raise

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -198,7 +198,7 @@ def header_dict_from_list(array):
 
 def get_url(url, destinationpath,
             custom_headers=None, message=None, onlyifnewer=False,
-            resume=False, follow_redirects=False):
+            resume=False, follow_redirects=False, pkginfo=None):
     """Gets an HTTP or HTTPS URL and stores it in
     destination path. Returns a dictionary of headers, which includes
     http_result_code and http_result_description.

--- a/code/client/munkilib/updatecheck/download.py
+++ b/code/client/munkilib/updatecheck/download.py
@@ -182,7 +182,8 @@ def download_installeritem(item_pl,
                                 resume=True,
                                 message=dl_message,
                                 expected_hash=expected_hash,
-                                verify=True)
+                                verify=True,
+                                pkginfo=item_pl)
 
 
 def clean_up_icons_dir(icons_to_keep):


### PR DESCRIPTION
The goal here is to enable the middleware to use more complex logic to decide which urls to pass back to munki for the download. This effectively keeps the logic out of core and prevents bloating munki itself. The original idea was to use an array of urls for PackageURL/ManifestURL/etc options, but that seemed more complicated than offloading this to the middleware.

This diff passes the contents of the pkginfo for a given installer item along to middleware via the options dictionary. This enables storing additional metadata in the pkginfo and being able to consume that data in the middleware to decide how to construct URLs among other interesting things.

This should be useful to anyone who writes middleware and enables future middleware that can do smarter things based upon the extra data being passed, including failovers, shared public repositories and other things I've not thought of yet. 