### PR TITLE
Encode pkginfo path as UTF-8 before outputting

### DIFF
--- a/code/client/munkilib/admin/makecatalogslib.py
+++ b/code/client/munkilib/admin/makecatalogslib.py
@@ -228,7 +228,7 @@ def process_pkgsinfo(repo, options, output_fn=None):
                 catalogs[catalogname] = []
             catalogs[catalogname].append(pkginfo)
             if output_fn:
-                output_fn("Adding %s to %s..." % (pkginfo_ref, catalogname))
+                output_fn("Adding %s to %s..." % (pkginfo_ref.encode('UTF-8'), catalogname))
 
     # look for catalog names that differ only in case
     duplicate_catalogs = []


### PR DESCRIPTION
`makecatalogslib` can cause AutoPkg's MakeCatalogsProcessor to choke on non-ASCII characters in file/folder names within the Munki repo. (Might be related to this downstream issue: https://github.com/autopkg/autopkg/issues/604)

### Steps to reproduce

- Munki tools 4.0.1
- AutoPkg 1.4.1 or 2.0 RC1

1. Create a pkginfo file at a path that contains a non-ASCII character. (I created one called Ümlaut-1.0.plist)
2. Run `makecatalogs` and observe that catalogs are rebuilt successfully.
3. Run an AutoPkg recipe that results in importing new software to the Munki repo, and observe that although catalogs are rebuilt successfully, the MakeCatalogs processor fails with a `UnicodeEncodeError`. See abridged output below:

```
...snip...
The following recipes failed:
    MakeCatalogs.munki
        Error in local.munki.MakeCatalogs: Processor: MakeCatalogsProcessor: Error: makecatalogs failed: 
        Traceback (most recent call last):
          File "/usr/local/munki/makecatalogs", line 109, in <module>
            main()
          File "/usr/local/munki/makecatalogs", line 98, in main
            errors = makecatalogslib.makecatalogs(repo, options, output_fn=print)
          File "/usr/local/munki/munkilib/admin/makecatalogslib.py", line 258, in makecatalogs
            repo, options, output_fn=output_fn)
          File "/usr/local/munki/munkilib/admin/makecatalogslib.py", line 231, in process_pkgsinfo
            output_fn("Adding %s to %s..." % (pkginfo_ref, catalogname))
        UnicodeEncodeError: 'ascii' codec can't encode character u'\u0308' in position 22: ordinal not in range(128)

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path               Pkg Repo Path            
    ----     -------  --------  ------------               -------------            
    Firefox  72.0.1   testing   apps/Firefox-72.0.1.plist  apps/Firefox-72.0.1.dmg  
```
(Note that it doesn't matter which product is imported into Munki; Firefox is used here as an example.)

### Verifying proposed change

When the steps above are run on the modified makecatalogslib.py, here is the abridged AutoPkg output:

```
Processing MakeCatalogs.munki...
MakeCatalogsProcessor
{'Input': {'MUNKI_REPO': '~/munki_repo'}}
MakeCatalogsProcessor: Munki catalogs rebuilt!
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/local.munki.MakeCatalogs/receipts/MakeCatalogs-receipt-20200111-193001.plist

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path               Pkg Repo Path            
    ----     -------  --------  ------------               -------------            
    Firefox  72.0.1   testing   apps/Firefox-72.0.1.plist  apps/Firefox-72.0.1.dmg  
```