### PR TITLE
When checking for com.apple.quarantine xattr when copying from dmg, do not follow symlink

### DIFF
--- a/code/client/munkilib/installer/dmg.py
+++ b/code/client/munkilib/installer/dmg.py
@@ -106,7 +106,8 @@ def create_missing_dirs(destpath):
 def remove_quarantine_from_item(some_path):
     '''Removes com.apple.quarantine from some_path'''
     try:
-        if "com.apple.quarantine" in xattr.xattr(some_path).list():
+        if "com.apple.quarantine" in xattr.xattr(some_path).list(
+                                          options=xattr.XATTR_NOFOLLOW):
             xattr.xattr(some_path).remove("com.apple.quarantine",
                                           options=xattr.XATTR_NOFOLLOW)
     except BaseException as err:


### PR DESCRIPTION
When checking for com.apple.quarantine if the xattr.list() hits a symlink it tries to follow it - raising a _Error removing com.apple.quarantine..._ warning.

Setting XATTR_NOFOLLOW on list() to stop behavior. 