### PR TITLE
munki: rename "/usr/local/munki/python" symlink to "munki-python"

### DIFF
--- a/code/client/app_usage_monitor
+++ b/code/client/app_usage_monitor
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2017-2020 Greg Neagle.

--- a/code/client/appusaged
+++ b/code/client/appusaged
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2018-2020 Greg Neagle.

--- a/code/client/authrestartd
+++ b/code/client/authrestartd
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2017-2020 Greg Neagle.

--- a/code/client/iconimporter
+++ b/code/client/iconimporter
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2010-2020 Greg Neagle.

--- a/code/client/launchapp
+++ b/code/client/launchapp
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2010-2020 Greg Neagle.

--- a/code/client/logouthelper
+++ b/code/client/logouthelper
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2011-2020 Greg Neagle.

--- a/code/client/makepkginfo
+++ b/code/client/makepkginfo
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2008-2020 Greg Neagle.

--- a/code/client/managedsoftwareupdate
+++ b/code/client/managedsoftwareupdate
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2009-2020 Greg Neagle.

--- a/code/client/manifestutil
+++ b/code/client/manifestutil
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2011-2020 Greg Neagle.

--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2010-2020 Greg Neagle.

--- a/code/client/precache_agent
+++ b/code/client/precache_agent
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2018-2020 Greg Neagle.

--- a/code/client/ptyexec
+++ b/code/client/ptyexec
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2011-2017 Google Inc. All Rights Reserved.

--- a/code/client/removepackages
+++ b/code/client/removepackages
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2009-2020 Greg Neagle.

--- a/code/client/supervisor
+++ b/code/client/supervisor
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 # encoding: utf-8
 #
 # Copyright 2011-2013 Google Inc. All Rights Reserved.

--- a/code/pkgtemplate/Resources_no_python/English.lproj/Description.plist
+++ b/code/pkgtemplate/Resources_no_python/English.lproj/Description.plist
@@ -5,6 +5,6 @@
 	<key>IFPkgDescriptionTitle</key>
 	<string>System Python link</string>
 	<key>IFPkgDescriptionDescription</key>
-	<string>Creates symlink to system Python at /usr/local/munki/python. Available for install if you choose not to install Munki's embedded Python.</string>
+	<string>Creates symlink to system Python at /usr/local/munki/munki-python. Available for install if you choose not to install Munki's embedded Python.</string>
 </dict>
 </plist>

--- a/code/tools/make_munki_mpkg.sh
+++ b/code/tools/make_munki_mpkg.sh
@@ -539,7 +539,7 @@ chmod -R 755 "$PYTHONROOT/usr"
 # Copy framework
 cp -R "$MUNKIROOT/Python.framework" "$PYTHONROOT/usr/local/munki/"
 # Create symlink
-ln -s Python.framework/Versions/3.7/bin/python3 "$PYTHONROOT/usr/local/munki/python"
+ln -s Python.framework/Versions/3.7/bin/python3 "$PYTHONROOT/usr/local/munki/munki-python"
 # Set permissions.
 chmod -R go-w "$PYTHONROOT/usr/local/munki"
 chmod +x "$PYTHONROOT/usr/local/munki"
@@ -560,7 +560,7 @@ mkdir -m 1775 "$NOPYTHONROOT"
 mkdir -p "$NOPYTHONROOT/usr/local/munki"
 chmod -R 755 "$NOPYTHONROOT/usr"
 # Create symlink
-ln -s /usr/bin/python "$NOPYTHONROOT/usr/local/munki/python"
+ln -s /usr/bin/python "$NOPYTHONROOT/usr/local/munki/munki-python"
 # Set permissions.
 chmod -R go-w "$NOPYTHONROOT/usr/local/munki"
 chmod +x "$NOPYTHONROOT/usr/local/munki"

--- a/code/tools/make_munki_mpkg_DEP.sh
+++ b/code/tools/make_munki_mpkg_DEP.sh
@@ -550,7 +550,7 @@ chmod -R 755 "$PYTHONROOT/usr"
 # Copy framework
 cp -R "$MUNKIROOT/Python.framework" "$PYTHONROOT/usr/local/munki/"
 # Create symlink
-ln -s Python.framework/Versions/3.7/bin/python3 "$PYTHONROOT/usr/local/munki/python"
+ln -s Python.framework/Versions/3.7/bin/python3 "$PYTHONROOT/usr/local/munki/munki-python"
 # Set permissions.
 chmod -R go-w "$PYTHONROOT/usr/local/munki"
 chmod +x "$PYTHONROOT/usr/local/munki"
@@ -571,7 +571,7 @@ mkdir -m 1775 "$NOPYTHONROOT"
 mkdir -p "$NOPYTHONROOT/usr/local/munki"
 chmod -R 755 "$NOPYTHONROOT/usr"
 # Create symlink
-ln -s /usr/bin/python "$NOPYTHONROOT/usr/local/munki/python"
+ln -s /usr/bin/python "$NOPYTHONROOT/usr/local/munki/munki-python"
 # Set permissions.
 chmod -R go-w "$NOPYTHONROOT/usr/local/munki"
 chmod +x "$NOPYTHONROOT/usr/local/munki"


### PR DESCRIPTION
Avoid masking the system /usr/bin/python by calling our symlink
"munki-python" instead of "python".

Closes #996