### PR TITLE
MWA2APIRepo decodes a byte buffer before it should

### DIFF
--- a/code/client/munkilib/munkirepo/MWA2APIRepo.py
+++ b/code/client/munkilib/munkirepo/MWA2APIRepo.py
@@ -104,7 +104,6 @@ class MWA2APIRepo(Repo):
                                 stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output, err = proc.communicate()
-        output = output.decode('UTF-8')
         err = err.decode('UTF-8')
         if DEBUG:
             # save our curl_directives for debugging


### PR DESCRIPTION
When using `munkiimport` with the MWA2API repo plugin, the following error occurs:

```python
Traceback (most recent call last):
  File "/usr/local/munki/munkiimport", line 607, in <module>
    main()
  File "/usr/local/munki/munkiimport", line 387, in main
    matchingpkginfo = munkiimportlib.find_matching_pkginfo(repo, pkginfo)
  File "/usr/local/munki/munkilib/admin/munkiimportlib.py", line 234, in find_matching_pkginfo
    catdb = make_catalog_db(repo)
  File "/usr/local/munki/munkilib/admin/munkiimportlib.py", line 142, in make_catalog_db
    catalogitems = FoundationPlist.readPlistFromString(plist)
  File "/usr/local/munki/munkilib/FoundationPlist.py", line 92, in readPlistFromString
    plistData = NSData.dataWithBytes_length_(data, len(data))
TypeError: Expecting byte-buffer, got str
```
The problem appear to be the following: The return value of `_curl()` is provided to `readPlistFromString()`. This is currently resulting in an error, as `readPlistFromString()` expects a byte buffer, however `_curl()` returns a string. One example of this can be observed within `itemlist()`.

This PR removes the `.decode()` operation from `_curl()` so that `readPlistFromString()` receives a byte buffer.