### PR TITLE
Support repo-based makecatalogs

### DIFF
--- a/code/client/makecatalogs
+++ b/code/client/makecatalogs
@@ -96,7 +96,7 @@ def main():
 
     # Make the catalogs
     try:
-        errors = repo.makecatalogs()
+        errors = repo.makecatalogs(options, output_fn=print)
     except AttributeError:
         errors = makecatalogslib.makecatalogs(repo, options, output_fn=print)
 

--- a/code/client/makecatalogs
+++ b/code/client/makecatalogs
@@ -95,7 +95,10 @@ def main():
         exit(-1)
 
     # Make the catalogs
-    errors = makecatalogslib.makecatalogs(repo, options, output_fn=print)
+    try:
+        errors = repo.makecatalogs()
+    except AttributeError:
+        errors = makecatalogslib.makecatalogs(repo, options, output_fn=print)
 
     if errors:
         # group all errors at the end for better visibility


### PR DESCRIPTION
This PR allows a Munki repo plugin to define its own makecatalogs behavior via a `makecatalogs()` method. If not defined, Munki will use the default behavior of `makecatalogslib.makecatalogs()`, as before.
