### PR TITLE
Cleanup legacy munki python in preinstall

### DIFF
--- a/code/pkgtemplate/Scripts_python/postinstall
+++ b/code/pkgtemplate/Scripts_python/postinstall
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# removes old versions when installing/upgrading the Python framework.
-# will need to be updated if/when we move to Python 3.9
-
-/bin/rm -rf "$3/usr/local/munki/Python.framework/Versions/3.7"
-/bin/rm -f "$3/usr/local/munki/python"

--- a/code/pkgtemplate/Scripts_python/preinstall
+++ b/code/pkgtemplate/Scripts_python/preinstall
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# removes old versions when installing/upgrading the Python framework.
+# will need to be updated if/when we move to Python 3.9
+
+MUNKI_DIR="usr/local/munki"
+# Only clean up legacy python if both legacy and new python exist.
+# Because we are doing this in a preinstall, it means the new python was
+# installed in a prior run and therefore this *should* be safe to do now.
+if [ -L "$3/$MUNKI_DIR/python" ] && [ -L "$3/$MUNKI_DIR/munki-python" ]; then
+  echo "Cleaning up legacy munki python"
+  /bin/rm -f "$3/$MUNKI_DIR/python"
+  /bin/rm -rf "$3/$MUNKI_DIR/Python.framework/Versions/3.7"
+fi


### PR DESCRIPTION
This diff is meant to address #1014 and moves the legacy munki python cleanup to the preinstall instead of the postinstall. This only cleans up the old python if the new `munki-python` symlink exists on disk.

This ensures we only cleanup after we've had a full munki run to install the new `munki-python`. The biggest negative is that the old python and symlink will kick around until Munki is updated again. If one wants it cleaned up sooner, a `nopkg` style pkgsinfo could clean it up on next munki run or some other config management tool (Puppet, Saltstack, Chef, etc).

Here is the test plan for this diff:

**Initial install 5.0 => 5.1**

Before:
```
ls -lsa munki
total 480
 0 drwxr-xr-x  21 root  wheel    672 Sep 10 13:37 .
 0 drwxr-xr-x  24 root  wheel    768 Sep 10 13:37 ..
 0 drwxr-xr-x   6 root  wheel    192 Sep 10 13:37 Python.framework
16 -rwxr-xr-x   1 root  wheel   8124 Jul  7 11:24 app_usage_monitor
24 -rwxr-xr-x   1 root  wheel  12208 Jul  7 11:24 appusaged
40 -rwxr-xr-x   1 root  wheel  16560 Jul  7 11:24 authrestartd
24 -rwxr-xr-x   1 root  wheel  11095 Jul  7 11:24 iconimporter
 8 -rwxr-xr-x   1 root  wheel   2515 Jul  7 11:24 launchapp
16 -rwxr-xr-x   1 root  wheel   8072 Jul  7 11:24 logouthelper
 8 -rwxr-xr-x   1 root  wheel   3632 Jul  7 11:24 makecatalogs
16 -rwxr-xr-x   1 root  wheel   4925 Jul  7 11:24 makepkginfo
96 -rwxr-xr-x   1 root  wheel  49127 Jul  7 11:24 managedsoftwareupdate
80 -rwxr-xr-x   1 root  wheel  40951 Jul  7 11:24 manifestutil
56 -rwxr-xr-x   1 root  wheel  25039 Jul  7 11:24 munkiimport
 0 drwxr-xr-x  43 root  wheel   1376 Sep 10 13:37 munkilib
 8 -rwxr-xr-x   1 root  wheel   1612 Jul  7 11:24 precache_agent
 8 -rwxr-xr-x   1 root  wheel   3510 Jul  7 11:24 ptyexec
 0 lrwxr-xr-x   1 root  wheel     41 Sep 10 13:37 python -> Python.framework/Versions/3.7/bin/python3
 8 -rwxr-xr-x   1 root  wheel   3536 Jul  7 11:24 removepackages
48 -rwxr-xr-x   1 root  wheel  23338 Jul  7 11:24 repoclean
```

After:
```
 ls -lsa munki
total 480
 0 drwxr-xr-x  22 root  wheel    704 Sep 10 13:40 .
 0 drwxr-xr-x  24 root  wheel    768 Sep 10 13:37 ..
 0 drwxr-xr-x   6 root  wheel    192 Sep 10 13:40 Python.framework
16 -rwxr-xr-x   1 root  wheel   8130 Sep 10 13:36 app_usage_monitor
24 -rwxr-xr-x   1 root  wheel  12214 Sep 10 13:36 appusaged
40 -rwxr-xr-x   1 root  wheel  16566 Sep 10 13:36 authrestartd
24 -rwxr-xr-x   1 root  wheel  11101 Sep 10 13:36 iconimporter
 8 -rwxr-xr-x   1 root  wheel   2521 Sep 10 13:36 launchapp
16 -rwxr-xr-x   1 root  wheel   8078 Sep 10 13:36 logouthelper
 8 -rwxr-xr-x   1 root  wheel   3733 Sep 10 13:36 makecatalogs
16 -rwxr-xr-x   1 root  wheel   4931 Sep 10 13:36 makepkginfo
96 -rwxr-xr-x   1 root  wheel  49133 Sep 10 13:36 managedsoftwareupdate
80 -rwxr-xr-x   1 root  wheel  40957 Sep 10 13:36 manifestutil
 0 lrwxr-xr-x   1 root  wheel     45 Sep 10 13:40 munki-python -> Python.framework/Versions/Current/bin/python3
56 -rwxr-xr-x   1 root  wheel  25045 Sep 10 13:36 munkiimport
 0 drwxr-xr-x  43 root  wheel   1376 Sep 10 13:40 munkilib
 8 -rwxr-xr-x   1 root  wheel   1618 Sep 10 13:36 precache_agent
 8 -rwxr-xr-x   1 root  wheel   3516 Sep 10 13:36 ptyexec
 0 lrwxr-xr-x   1 root  wheel     41 Sep 10 13:37 python -> Python.framework/Versions/3.7/bin/python3
 8 -rwxr-xr-x   1 root  wheel   3542 Sep 10 13:36 removepackages
48 -rwxr-xr-x   1 root  wheel  23338 Sep 10 13:36 repoclean
```

No errors during install


**Re-installing 5.1 (Triggering via `pkgutil --forget com.googlecode.munki.python`)**

No errors, `/usr/local/munki` after install:

```
ls -lsa munki
total 480
 0 drwxr-xr-x  21 root  wheel    672 Sep 10 13:41 .
 0 drwxr-xr-x  24 root  wheel    768 Sep 10 13:37 ..
 0 drwxr-xr-x   6 root  wheel    192 Sep 10 13:41 Python.framework
16 -rwxr-xr-x   1 root  wheel   8130 Sep 10 13:36 app_usage_monitor
24 -rwxr-xr-x   1 root  wheel  12214 Sep 10 13:36 appusaged
40 -rwxr-xr-x   1 root  wheel  16566 Sep 10 13:36 authrestartd
24 -rwxr-xr-x   1 root  wheel  11101 Sep 10 13:36 iconimporter
 8 -rwxr-xr-x   1 root  wheel   2521 Sep 10 13:36 launchapp
16 -rwxr-xr-x   1 root  wheel   8078 Sep 10 13:36 logouthelper
 8 -rwxr-xr-x   1 root  wheel   3733 Sep 10 13:36 makecatalogs
16 -rwxr-xr-x   1 root  wheel   4931 Sep 10 13:36 makepkginfo
96 -rwxr-xr-x   1 root  wheel  49133 Sep 10 13:36 managedsoftwareupdate
80 -rwxr-xr-x   1 root  wheel  40957 Sep 10 13:36 manifestutil
 0 lrwxr-xr-x   1 root  wheel     45 Sep 10 13:41 munki-python -> Python.framework/Versions/Current/bin/python3
56 -rwxr-xr-x   1 root  wheel  25045 Sep 10 13:36 munkiimport
 0 drwxr-xr-x  43 root  wheel   1376 Sep 10 13:41 munkilib
 8 -rwxr-xr-x   1 root  wheel   1618 Sep 10 13:36 precache_agent
 8 -rwxr-xr-x   1 root  wheel   3516 Sep 10 13:36 ptyexec
 8 -rwxr-xr-x   1 root  wheel   3542 Sep 10 13:36 removepackages
48 -rwxr-xr-x   1 root  wheel  23338 Sep 10 13:36 repoclean
24 -rwxr-xr-x   1 root  wheel  11988 Sep 10 13:36 supervisor
```
 