### PR TITLE
Differentiate between version.plist not existing and being unreadable

### DIFF
--- a/code/tools/make_munki_mpkg.sh
+++ b/code/tools/make_munki_mpkg.sh
@@ -153,12 +153,17 @@ if [[ "$CONFPKG" == "YES" ]] ; then
     fi
 fi
 
-
-# Get the munki version
-MUNKIVERS=$(defaults read "$MUNKIROOT/code/client/munkilib/version" CFBundleShortVersionString)
-if [ "$?" != "0" ]; then
-    echo "$MUNKIROOT/code/client/munkilib/version is missing!" 1>&2
-    echo "Perhaps $MUNKIROOT does not contain the munki source?" 1>&2
+VERSIONFILE="$MUNKIROOT/code/client/munkilib/version"
+# Check to see if file exists
+if [ -f "$VERSIONFILE.plist" ]; then
+    # Get the munki version
+    MUNKIVERS=$(defaults read "$VERSIONFILE" CFBundleShortVersionString)
+    if [ "$?" != "0" ]; then
+        echo "$VERSIONFILE can not be read" 1>&2
+        exit 1
+    fi
+else
+    echo "$VERSIONFILE Missing" 1>&2
     exit 1
 fi
 

--- a/code/tools/make_munki_mpkg.sh
+++ b/code/tools/make_munki_mpkg.sh
@@ -159,11 +159,11 @@ if [ -f "$VERSIONFILE.plist" ]; then
     # Get the munki version
     MUNKIVERS=$(defaults read "$VERSIONFILE" CFBundleShortVersionString)
     if [ "$?" != "0" ]; then
-        echo "$VERSIONFILE can not be read" 1>&2
+        echo "${VERSIONFILE}.plist can not be read" 1>&2
         exit 1
     fi
 else
-    echo "$VERSIONFILE Missing" 1>&2
+    echo "${VERSIONFILE}.plist Missing" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
Added some logic to clarify if version.plist doesn't exist, or if it simply cannot be read. When running make_munki_mpkg.sh in a PPPC protected directory the output would state the file did not exist. However, the file did exist, but was unable to be read because of PPPC.

Any feedback appreciated.

If accepted I would appreciate the "hacktoberfest-accepted" label for [Hacktoberfest](https://hacktoberfest.digitalocean.com)