### PR TITLE
Keep content-length on network connection error so downloads can resume

### DIFF
--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -383,9 +383,10 @@ class Gurl(NSObject):
         '''NSURLSessionTaskDelegate method.'''
         if self.destination and self.destination_path:
             self.destination.close()
-            self.removeExpectedSizeFromStoredHeaders()
         if error:
             self.recordError_(error)
+        else:
+            self.removeExpectedSizeFromStoredHeaders()
         self.done = True
 
     def connection_didFailWithError_(self, _connection, error):


### PR DESCRIPTION
Gurl requires the expected content length in the xattr data in order to
consider resuming a partial download.

When there is a network connection interruption
URLSession_task_didCompleteWithError_ is called with an error.

Prior to this fix content length was always removed from the xattr data
when URLSession_task_didCompleteWithError_ was called so downloads would
never resume after a connection error.

With this fix, content length is only removed from the xattr data when
there is no error since the download would be complete and resuming
would not be necessary.

Potentially fixes #817 