### PR TITLE
Scaling showcase banner images

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/base.css
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/base.css
@@ -1111,7 +1111,9 @@ p:not(.data-text-truncate-opened)[data-text-truncate-lines='20'] {
 }
 
 div.showcase {
-    height: 200px;
+    height: 0;
+    width: 100%;
+    padding-top: 17.42%;
     margin: 0;
     opacity: 1;
     overflow: hidden;
@@ -1135,7 +1137,8 @@ div.showcase, div.showcase>div.stage, div.showcase>div.stage * {
 
 div.stage>img {
     position: absolute;
-    height: 200px;
+    height: 100%;
+    top: 0;
     left: 0;
     /*background-color: #000;*/
     text-align: left;


### PR DESCRIPTION
This PR makes changes to the base.css which allows the banner image container to scale the image based on the size of the MSC.app window. I used the default Munki banners without changing their size for testing. The changes have been tested on 5.2.0.4237 running 10.14.4, 10.15.7 and 11.0.1

Current Behavior:

![Current Behavior](https://user-images.githubusercontent.com/815125/99978614-29763100-2d74-11eb-8226-8c50d924abe8.gif)


New Behavior:

![New Behavior](https://user-images.githubusercontent.com/815125/99982299-604e4600-2d78-11eb-9738-447b81810745.gif)
