### PR TITLE
Hide non-updates labels in sidebar when not applicable

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -20,11 +20,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     var htmlDir = ""
     var wkContentController = WKUserContentController()
     
-    let items = [["title": "Software", "icon": "AllItemsTemplate"],
-                 ["title": "Categories", "icon": "toolbarCategoriesTemplate"],
-                 ["title": "My Items", "icon": "MyStuffTemplate"],
-                 ["title": "Updates", "icon": "updatesTemplate"]]
-    
     // status properties
     var _status_title = ""
     var stop_requested = false
@@ -50,32 +45,51 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     @IBOutlet weak var myItemsMenuItem: NSMenuItem!
     @IBOutlet weak var updatesMenuItem: NSMenuItem!
 
-
     @IBOutlet weak var webViewPlaceholder: NSView!
     var webView: WKWebView!
-    
+
     override func windowDidLoad() {
         super.windowDidLoad()
     }
-    
+
     @objc private func onItemClicked() {
-        if 0 ... items.count ~= sidebar.clickedRow {
-            clearSearchField()
-            switch sidebar.clickedRow {
-                case 0:
-                    loadAllSoftwarePage(self)
-                case 1:
-                    loadCategoriesPage(self)
-                case 2:
-                    loadMyItemsPage(self)
-                case 3:
-                    loadUpdatesPage(self)
-                default:
-                    loadUpdatesPage(self)
+        let items = populateItems()
+        if items.count == 1 {
+            loadUpdatesPage(self)
+        } else {
+            if 0 ... items.count ~= sidebar.clickedRow {
+                clearSearchField()
+                switch sidebar.clickedRow {
+                    case 0:
+                        loadAllSoftwarePage(self)
+                    case 1:
+                        loadCategoriesPage(self)
+                    case 2:
+                        loadMyItemsPage(self)
+                    case 3:
+                        loadUpdatesPage(self)
+                    default:
+                        loadUpdatesPage(self)
+                }
             }
         }
     }
-    
+
+    func populateItems() -> [[String: String]] {
+        // create an items dict with only "Updates" if no optional_items
+        let optional_items = getOptionalInstallItems()
+        if optional_items.isEmpty {
+            let items = [["title": "Updates", "icon": "updatesTemplate"]]
+            return items
+        } else {
+            let items = [["title": "Software", "icon": "AllItemsTemplate"],
+                         ["title": "Categories", "icon": "toolbarCategoriesTemplate"],
+                         ["title": "My Items", "icon": "MyStuffTemplate"],
+                         ["title": "Updates", "icon": "updatesTemplate"]]
+            return items
+        }
+    }
+
     func appShouldTerminate() -> NSApplication.TerminateReply {
         // called by app delegate
         // when it receives applicationShouldTerminate:
@@ -116,7 +130,12 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     
     func currentPageIsUpdatesPage() -> Bool {
         // return true if current tab selected is Updates
-        return sidebar.selectedRow == 3
+        let items = populateItems()
+        if items.count == 1 {
+            return sidebar.selectedRow == 0
+        } else {
+            return sidebar.selectedRow == 3
+        }
     }
 
     func newTranslucentWindow(screen: NSScreen) -> NSWindow {
@@ -221,7 +240,16 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         // Called by app delegate from applicationDidFinishLaunching:
         enableOrDisableSoftwareViewControls()
         let optional_items = getOptionalInstallItems()
-        if optional_items.isEmpty || getUpdateCount() > 0 || !getProblemItems().isEmpty {
+        // if we have no optional_items set MSC to show updates only
+        if optional_items.isEmpty {
+            searchField.isHidden = true
+            findMenuItem.isHidden = true
+            softwareMenuItem.isHidden = true
+            categoriesMenuItem.isHidden = true
+            myItemsMenuItem.isHidden = true
+            updatesMenuItem.isHidden = true
+            loadUpdatesPage(self)
+        } else if optional_items.isEmpty || getUpdateCount() > 0 || !getProblemItems().isEmpty {
             loadUpdatesPage(self)
         } else {
             loadAllSoftwarePage(self)
@@ -244,6 +272,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     }
     
     func highlightToolbarButtons(_ nameToHighlight: String) {
+        let items = populateItems()
         for (index, item) in items.enumerated() {
             if nameToHighlight == item["title"] {
                 sidebar.selectRowIndexes(IndexSet(integer: index), byExtendingSelection: false)
@@ -769,7 +798,14 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         let updateCount = getUpdateCount()
         
         var cellView:MSCTableCellView?
-        if let view = self.sidebar.rowView(atRow: 3, makeIfNecessary: false) {
+        
+        let items = populateItems()
+
+        if items.count == 1 {
+            if let view = self.sidebar.rowView(atRow: 0, makeIfNecessary: false) {
+                cellView = view.view(atColumn: 0) as? MSCTableCellView
+            }
+        } else if let view = self.sidebar.rowView(atRow: 3, makeIfNecessary: false) {
             cellView = view.view(atColumn: 0) as? MSCTableCellView
         }
 
@@ -1500,11 +1536,13 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
 extension MainWindowController: NSOutlineViewDataSource {
     // Number of items in the sidebar
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
+        let items = populateItems()
         return items.count
     }
     
     // Items to be added to sidebar
     func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
+        let items = populateItems()
         return items[index]
     }
     

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -249,7 +249,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
             myItemsMenuItem.isHidden = true
             updatesMenuItem.isHidden = true
             loadUpdatesPage(self)
-        } else if optional_items.isEmpty || getUpdateCount() > 0 || !getProblemItems().isEmpty {
+        } else if getUpdateCount() > 0 || !getProblemItems().isEmpty {
             loadUpdatesPage(self)
         } else {
             loadAllSoftwarePage(self)


### PR DESCRIPTION
As discussed on [munki-dev](https://groups.google.com/g/munki-dev/c/jDYt4TO36-4)

This PR amends MSC to only show the updates view if no optional installs are declared, mimicking prior MSC's behaviour.

Prior to this PR, MSC would look like the below if no optional installs are declared:
<img width="1112" alt="Screenshot 2021-04-13 at 15 59 59" src="https://user-images.githubusercontent.com/2464974/117788328-3661e080-b23f-11eb-908a-5851422a5d2d.png">
<img width="1112" alt="Screenshot 2021-04-13 at 15 59 56" src="https://user-images.githubusercontent.com/2464974/117788329-37930d80-b23f-11eb-90b9-527312148eda.png">
<img width="1112" alt="Screenshot 2021-04-13 at 15 59 54" src="https://user-images.githubusercontent.com/2464974/117788333-382ba400-b23f-11eb-8468-3b26e03e31ae.png">
<img width="1112" alt="Screenshot 2021-04-13 at 16 00 01" src="https://user-images.githubusercontent.com/2464974/117788313-32ce5980-b23f-11eb-8c76-9815157c6a9a.png">

Post this PR:
<img width="1112" alt="Screenshot 2021-05-11 at 09 58 38" src="https://user-images.githubusercontent.com/2464974/117788659-7cb73f80-b23f-11eb-9ac2-d65ed5db4106.png">

If/when merged and released, I'll update: https://github.com/munki/munki/wiki/FAQ#q--i-just-set-up-munki-and-theres-nothing-available-under-software-or-categories-and-the-icons-are-greyed-out-how-do-i-make-things-available-there
