### PR TITLE
Add support for client cert package

### DIFF
--- a/code/tools/make_munki_mpkg.sh
+++ b/code/tools/make_munki_mpkg.sh
@@ -953,13 +953,15 @@ for pkg in $ALLPKGS ; do
             ;;
         "bootstrap")
             ver="1.0"
+            SCRIPTS=""
             ;;
         "config")
             ver="1.0"
+            SCRIPTS=""
             ;;
         "clientcert")
             ver="1.0"
-            SCRIPTS="${MUNKIROOT}/code/tools/pkgresources/Scripts_nothing"
+            SCRIPTS=""
             ;;
         "rosetta2")
             ver="1.0"

--- a/code/tools/make_munki_mpkg_from_git.sh
+++ b/code/tools/make_munki_mpkg_from_git.sh
@@ -36,12 +36,14 @@ Usage: $(basename "$0") [-b branch ] [-r revision] [<make_munki_mpkg.sh options>
     -S cert_cn  Sign apps with a Developer ID Application certificate from
                 keychain. Provide the certificate's Common Name.
                 Ex: "Developer ID Application: Munki (U8PN57A5N2)"
+    -T pemfile  Include a pkg to install a client certificate for server mTLS
+                mutual authentication, at /Library/Managed Installs/certs/.
 
 EOF
 }
 
 ADDITIONALARGS=""
-while getopts "b:r:i:o:n:c:s:S:pBmhR" option
+while getopts "b:r:i:o:n:c:s:S:T:pBmhR" option
 do
     case $option in
         "b")
@@ -79,6 +81,9 @@ do
             ;;
         "R")
             ADDITIONALARGS="${ADDITIONALARGS} -R"
+            ;;
+        "T")
+            ADDITIONALARGS="${ADDITIONALARGS} -T \"$OPTARG\""
             ;;
         "h" | *)
             usage

--- a/code/tools/pkgresources/Scripts_nothing/postinstall
+++ b/code/tools/pkgresources/Scripts_nothing/postinstall
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# currently does nothing at all
+exit 0

--- a/code/tools/pkgresources/Scripts_nothing/postinstall
+++ b/code/tools/pkgresources/Scripts_nothing/postinstall
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# currently does nothing at all
-exit 0


### PR DESCRIPTION
Adds -T flag to make_munki_pkg build scripts to include a component package containing a client certificate for server mTLS, installed at /Library/Managed Installs/certs/client.pem