### PR TITLE
Add QuitButtonTimeout preference

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -568,7 +568,7 @@ class MSCAlertController: NSObject {
         alert.informativeText = alertDetail
         var quitButton = NSApplication.ModalResponse.alertFirstButtonReturn
         var updateButton = NSApplication.ModalResponse.alertSecondButtonReturn
-        let quitButtonTimeout = pref("quitButtonTimeout") as? Float ?? 5.0
+        let quitButtonTimeout = pref("QuitButtonTimeout") as? Float ?? 5.0
         if !shouldAggressivelyNotifyAboutMunkiUpdates() && !thereAreUpdatesToBeForcedSoon() {
             alert.addButton(withTitle: NSLocalizedString("Quit", comment: "Quit button title"))
             alert.addButton(withTitle: NSLocalizedString("Update now", comment: "Update Now button title"))

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -568,6 +568,7 @@ class MSCAlertController: NSObject {
         alert.informativeText = alertDetail
         var quitButton = NSApplication.ModalResponse.alertFirstButtonReturn
         var updateButton = NSApplication.ModalResponse.alertSecondButtonReturn
+        let quitButtonTimeout = pref("quitButtonTimeout") as? Float ?? 5.0
         if !shouldAggressivelyNotifyAboutMunkiUpdates() && !thereAreUpdatesToBeForcedSoon() {
             alert.addButton(withTitle: NSLocalizedString("Quit", comment: "Quit button title"))
             alert.addButton(withTitle: NSLocalizedString("Update now", comment: "Update Now button title"))
@@ -578,7 +579,7 @@ class MSCAlertController: NSObject {
             // initially disable the Quit button
             self.quitButton = alert.buttons[1]
             alert.buttons[1].isEnabled = false
-            let timer1 = Timer.scheduledTimer(timeInterval: 5.0,
+            let timer1 = Timer.scheduledTimer(timeInterval: quitButtonTimeout,
                                               target: self,
                                               selector: #selector(self.activateQuitButton),
                                               userInfo: nil,


### PR DESCRIPTION
This adds a QuitButtonTimeout preference so that one can make the timeout for the QuitButton longer or shorter depending upon the current state of the machine.

This is useful for situations where people are ignoring the updates despite the 5 second timeout and will be meant to increase awareness around the necessity of the update.