### PR TITLE
Update build_python_framework.sh

### DIFF
--- a/code/tools/build_python_framework.sh
+++ b/code/tools/build_python_framework.sh
@@ -66,7 +66,7 @@ UNIVERSAL_COUNT=$(find "${MUNKIROOT}/Python.framework" -name "*.so" -or -name "*
 if [ "$LIB_COUNT" != "$UNIVERSAL_COUNT" ] ; then 
     echo "$LIB_COUNT libraries (*.so and *.dylib) found in the framework; only $UNIVERSAL_COUNT are universal!"
     echo "The following libraries are not universal:"
-    find Python.framework -name "*.so" -or -name "*.dylib" | xargs file | grep -v "2 architectures" | grep -v "(for architecture"
+    find "${MUNKIROOT}"/Python.framework -name "*.so" -or -name "*.dylib" | xargs file | grep -v "2 architectures" | grep -v "(for architecture"
     STATUS=1
 fi
 


### PR DESCRIPTION
Corrects the Python.framework path, and end of the script.

Before:

```
Verifying Universal2 builds...
     182 libraries (*.so and *.dylib) found in the framework; only       90 are universal!
The following libraries are not universal:
find: Python.framework: No such file or directory
```

After:

```
Verifying Universal2 builds...
     182 libraries (*.so and *.dylib) found in the framework; only       90 are universal!
The following libraries are not universal:
/Users/ben/Git/munki/Python.framework/Versions/3.9/lib/python3.9/site-packages/StoreKit/_StoreKit.abi3.so:                                                 Mach-O 64-bit bundle x86_64
</snip>
```