### PR TITLE
Hide sidebar when no optional installs are available

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Base.lproj/MainMenu.xib
+++ b/code/apps/Managed Software Center/Managed Software Center/Base.lproj/MainMenu.xib
@@ -45,6 +45,7 @@
             <connections>
                 <outlet property="categoriesMenuItem" destination="IjL-Sm-tWj" id="Nu2-xf-MO3"/>
                 <outlet property="findMenuItem" destination="JRN-bq-1gM" id="r2S-8Y-njg"/>
+                <outlet property="fullSidebar" destination="Z53-oE-BgS" id="6Tx-qj-TLx"/>
                 <outlet property="myItemsMenuItem" destination="1bG-B4-adC" id="PCP-Ye-eRl"/>
                 <outlet property="navigateBackButton" destination="LRY-q4-rBU" id="Z08-Ex-3t6"/>
                 <outlet property="navigateBackMenuItem" destination="4nC-yt-nEz" id="bDM-jd-pUL"/>
@@ -53,6 +54,7 @@
                 <outlet property="sidebar" destination="pGV-ZA-L14" id="rl2-BU-gEi"/>
                 <outlet property="softwareMenuItem" destination="YIg-jD-AbB" id="D6s-mC-x4d"/>
                 <outlet property="updatesMenuItem" destination="HOZ-SU-4Sm" id="UdT-3I-JpJ"/>
+                <outlet property="webViewContainer" destination="DjW-0r-xfk" id="mxV-qW-x83"/>
                 <outlet property="webViewPlaceholder" destination="Wf8-HB-bc8" id="qCG-zy-8UQ"/>
                 <outlet property="window" destination="EeR-uP-dFY" id="FfQ-Q4-xUU"/>
             </connections>
@@ -165,17 +167,17 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="0W8-g5-gCj"/>
-                            <menuItem title="Software" enabled="NO" keyEquivalent="1" id="YIg-jD-AbB">
+                            <menuItem title="Software" keyEquivalent="1" id="YIg-jD-AbB">
                                 <connections>
                                     <action selector="loadAllSoftwarePage:" target="XGW-R4-ybE" id="dt1-OC-ObZ"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Categories" enabled="NO" keyEquivalent="2" id="IjL-Sm-tWj">
+                            <menuItem title="Categories" keyEquivalent="2" id="IjL-Sm-tWj">
                                 <connections>
                                     <action selector="loadCategoriesPage:" target="XGW-R4-ybE" id="Agt-cx-joI"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="My Items" enabled="NO" keyEquivalent="3" id="1bG-B4-adC">
+                            <menuItem title="My Items" keyEquivalent="3" id="1bG-B4-adC">
                                 <connections>
                                     <action selector="loadMyItemsPage:" target="XGW-R4-ybE" id="Hec-MQ-1q1"/>
                                 </connections>

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -20,6 +20,11 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     var htmlDir = ""
     var wkContentController = WKUserContentController()
     
+    let items = [["title": "Software", "icon": "AllItemsTemplate"],
+                 ["title": "Categories", "icon": "toolbarCategoriesTemplate"],
+                 ["title": "My Items", "icon": "MyStuffTemplate"],
+                 ["title": "Updates", "icon": "updatesTemplate"]]
+    
     // status properties
     var _status_title = ""
     var stop_requested = false
@@ -38,6 +43,8 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     
     @IBOutlet weak var sidebar: NSOutlineView!
     
+    @IBOutlet weak var fullSidebar: NSVisualEffectView!
+    
     @IBOutlet weak var navigateBackMenuItem: NSMenuItem!
     @IBOutlet weak var findMenuItem: NSMenuItem!
     @IBOutlet weak var softwareMenuItem: NSMenuItem!
@@ -45,6 +52,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     @IBOutlet weak var myItemsMenuItem: NSMenuItem!
     @IBOutlet weak var updatesMenuItem: NSMenuItem!
 
+    @IBOutlet weak var webViewContainer: NSView!
     @IBOutlet weak var webViewPlaceholder: NSView!
     var webView: WKWebView!
 
@@ -53,11 +61,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     }
 
     @objc private func onItemClicked() {
-        let items = populateItems()
-        if items.count == 1 {
-            loadUpdatesPage(self)
-        } else {
-            if 0 ... items.count ~= sidebar.clickedRow {
+        if 0 ... items.count ~= sidebar.clickedRow {
                 clearSearchField()
                 switch sidebar.clickedRow {
                     case 0:
@@ -70,26 +74,10 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
                         loadUpdatesPage(self)
                     default:
                         loadUpdatesPage(self)
-                }
             }
         }
     }
-
-    func populateItems() -> [[String: String]] {
-        // create an items dict with only "Updates" if no optional_items
-        let optional_items = getOptionalInstallItems()
-        if optional_items.isEmpty {
-            let items = [["title": "Updates", "icon": "updatesTemplate"]]
-            return items
-        } else {
-            let items = [["title": "Software", "icon": "AllItemsTemplate"],
-                         ["title": "Categories", "icon": "toolbarCategoriesTemplate"],
-                         ["title": "My Items", "icon": "MyStuffTemplate"],
-                         ["title": "Updates", "icon": "updatesTemplate"]]
-            return items
-        }
-    }
-
+    
     func appShouldTerminate() -> NSApplication.TerminateReply {
         // called by app delegate
         // when it receives applicationShouldTerminate:
@@ -130,7 +118,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     
     func currentPageIsUpdatesPage() -> Bool {
         // return true if current tab selected is Updates
-        let items = populateItems()
         if items.count == 1 {
             return sidebar.selectedRow == 0
         } else {
@@ -188,7 +175,8 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         }
         self.forceFrontmost = false
         // enable/disable controls as needed
-        enableOrDisableSoftwareViewControls()
+        updatesAndOptionalWindowMode()
+        determineIfUpdateOnlyWindowOrUpdateAndOptionalWindowMode()
     }
     
     func makeUsObnoxious() {
@@ -209,12 +197,8 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         }
         
         // disable all of the other controls
-        searchField.isEnabled = false
-//        findMenuItem.isEnabled = false
-//        softwareMenuItem.isEnabled = false
-//        categoriesMenuItem.isEnabled = false
-//        myItemsMenuItem.isEnabled = false
-        self.sidebar.isEnabled = false
+        updatesOnlyWindowMode()
+        loadUpdatesPage(self)
         
         // set flag to cause us to always be brought to front
         self.forceFrontmost = true
@@ -240,25 +224,69 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         return false
     }
     
+    func updatesOnlyWindowMode() {
+        findMenuItem.isHidden = true
+        softwareMenuItem.isHidden = true
+        categoriesMenuItem.isHidden = true
+        myItemsMenuItem.isHidden = true
+        updatesMenuItem.isHidden = true
+        fullSidebar.isHidden = true
+        webViewContainer.frame.origin.x = -1
+        webViewContainer.frame.size.width = self.window!.frame.width
+        navigateBackButton.frame.origin.x = 90
+        // adjusts window controls on newer OSs
+        if #available(macOS 10.13, *) {
+            let customToolbar = NSToolbar()
+            self.window?.titleVisibility = .hidden
+            self.window?.toolbar = customToolbar
+        }
+        loadUpdatesPage(self)
+    }
+    
+    func updatesAndOptionalWindowMode() {
+        findMenuItem.isHidden = false
+        softwareMenuItem.isHidden = false
+        categoriesMenuItem.isHidden = false
+        myItemsMenuItem.isHidden = false
+        updatesMenuItem.isHidden = false
+        fullSidebar.isHidden = false
+        webViewContainer.frame.origin.x = 220
+        navigateBackButton.frame.origin.x = 17
+        webViewContainer.frame.size.width = self.window!.frame.width - fullSidebar.frame.width
+        // adjusts window controls on newer OSs
+        if #available(macOS 10.13, *) {
+            let customToolbar = NSToolbar()
+            self.window?.titleVisibility = .hidden
+            self.window?.toolbar = customToolbar
+        }
+    }
+    
+    func moveDirectlyToUpdatesPageIfNeeded() {
+        if getUpdateCount() > 0 || !getProblemItems().isEmpty {
+            loadUpdatesPage(self)
+        }
+    }
+    
+    func determineIfUpdateOnlyWindowOrUpdateAndOptionalWindowMode() {
+        // if we have no optional_items set MSC to show updates only
+        // if updates available go right to update screen
+        if optionalInstallsExist() {
+            updatesAndOptionalWindowMode()
+            moveDirectlyToUpdatesPageIfNeeded()
+        } else {
+            updatesOnlyWindowMode()
+        }
+    }
+    
+    
     func loadInitialView() {
         // Called by app delegate from applicationDidFinishLaunching:
-        enableOrDisableSoftwareViewControls()
-        let optional_items = getOptionalInstallItems()
-        // if we have no optional_items set MSC to show updates only
-        if optional_items.isEmpty {
-            searchField.isHidden = true
-            findMenuItem.isHidden = true
-            softwareMenuItem.isHidden = true
-            categoriesMenuItem.isHidden = true
-            myItemsMenuItem.isHidden = true
-            updatesMenuItem.isHidden = true
-            loadUpdatesPage(self)
-        } else if getUpdateCount() > 0 || !getProblemItems().isEmpty {
-            loadUpdatesPage(self)
-        } else {
+        if optionalInstallsExist() {
             loadAllSoftwarePage(self)
+        } else {
+            loadUpdatesPage(self)
         }
-        displayUpdateCount()
+        determineIfUpdateOnlyWindowOrUpdateAndOptionalWindowMode()
         cached_self_service = SelfService()
     }
 
@@ -276,7 +304,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     }
     
     func highlightToolbarButtons(_ nameToHighlight: String) {
-        let items = populateItems()
         for (index, item) in items.enumerated() {
             if nameToHighlight == item["title"] {
                 sidebar.selectRowIndexes(IndexSet(integer: index), byExtendingSelection: false)
@@ -288,16 +315,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         self.searchField.stringValue = ""
     }
     
-    func enableOrDisableSoftwareViewControls() {
-        // Disable or enable the controls that let us view optional items
-        let enabled_state = optionalInstallsExist()
-        //enableOrDisableToolbarItems(enabled_state)
-        searchField.isEnabled = enabled_state
-        findMenuItem.isEnabled = enabled_state
-        softwareMenuItem.isEnabled = enabled_state
-        categoriesMenuItem.isEnabled = enabled_state
-        myItemsMenuItem.isEnabled = enabled_state
-    }
     
     func munkiStatusSessionEnded(withStatus sessionResult: Int, errorMessage: String) {
         // Called by StatusController when a Munki session ends
@@ -411,7 +428,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         // pending updates may have changed
         _alertedUserToOutstandingUpdates = false
         // enable/disable controls as needed
-        enableOrDisableSoftwareViewControls()
+        determineIfUpdateOnlyWindowOrUpdateAndOptionalWindowMode()
         // what page are we currently viewing?
         let page_url = webView.url
         let filename = page_url?.lastPathComponent ?? ""
@@ -802,8 +819,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         let updateCount = getUpdateCount()
         
         var cellView:MSCTableCellView?
-        
-        let items = populateItems()
 
         if items.count == 1 {
             if let view = self.sidebar.rowView(atRow: 0, makeIfNecessary: false) {
@@ -1540,13 +1555,11 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
 extension MainWindowController: NSOutlineViewDataSource {
     // Number of items in the sidebar
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
-        let items = populateItems()
         return items.count
     }
     
     // Items to be added to sidebar
     func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
-        let items = populateItems()
         return items[index]
     }
     


### PR DESCRIPTION
Change to the Managed Software Center application to fully collapse the sidebar when no optional installs are available.

Interface will dynamically update after a Munki run, no longer requiring the application to be quit and be relaunched if the status of optional installs changes.

"Obnoxious" mode uses the Updates only mode to direct attention to just to the updates requiring install.

On Big Sur and newer, the window controls have also been updated to be slightly inset from the windows edge.

![UpdateAndOptionalUpdate](https://user-images.githubusercontent.com/825577/131166531-5dd5f0ec-96bb-4d07-aa46-0b4d0745ebf4.png)
