### PR TITLE
gitattributes: add .gitattributes for munki-python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# https://github.com/github/linguist/blob/master/docs/overrides.md
+# https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
+ 
+# munki-python
+code/client/*  linguist-language=Python

--- a/code/client/munkiimport
+++ b/code/client/munkiimport
@@ -1,4 +1,5 @@
 #!/usr/local/munki/munki-python
+# -*- python -*-
 # encoding: utf-8
 #
 # Copyright 2010-2021 Greg Neagle.


### PR DESCRIPTION
Add `.gitattributes` for `munki-python` files.
The `#!/usr/local/munki/munki-python` shebang doesn't highlight on GitHub, so use the gitattributes feature.

See also
- GitHub doc:
	- https://github.com/github/linguist/blob/master/docs/overrides.md
- highlighted:
	- https://github.com/zchee/munki/blob/gitattributes-munki-python/code/client/makepkginfo
	- https://github.com/zchee/munki/blob/gitattributes-munki-python/code/client/munkiimport