### PR TITLE
Hide titlebar baseline separator on < 10.15

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -238,6 +238,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         // adjusts window controls on newer OSs
         if #available(macOS 10.13, *) {
             let customToolbar = NSToolbar()
+            customToolbar.showsBaselineSeparator = false
             self.window?.titleVisibility = .hidden
             self.window?.toolbar = customToolbar
         }
@@ -257,6 +258,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         // adjusts window controls on newer OSs
         if #available(macOS 10.13, *) {
             let customToolbar = NSToolbar()
+            customToolbar.showsBaselineSeparator = false
             self.window?.titleVisibility = .hidden
             self.window?.toolbar = customToolbar
         }


### PR DESCRIPTION
Fix for titlebar line on macOS < 10.15 (Catalina)

![LineFix](https://user-images.githubusercontent.com/825577/171510115-8bb1b6d6-486b-4df0-9634-06add15cd9c0.jpg)

