### PR TITLE
add PlistReadError to except

### DIFF
--- a/code/client/munkilib/cliutils.py
+++ b/code/client/munkilib/cliutils.py
@@ -49,7 +49,7 @@ except ImportError:
     from urllib.parse import urlparse, urljoin
 from xml.parsers.expat import ExpatError
 
-from munkilib.wrappers import unicode_or_str, get_input, readPlist, writePlist
+from munkilib.wrappers import unicode_or_str, get_input, readPlist, writePlist, PlistReadError
 
 FOUNDATION_SUPPORT = True
 try:
@@ -90,7 +90,7 @@ else:
         if not pref.cache:
             try:
                 pref.cache = readPlist(PREFSPATH)
-            except (IOError, OSError, ExpatError):
+            except (IOError, OSError, ExpatError, PlistReadError):
                 pref.cache = {}
         if prefname in pref.cache:
             return pref.cache[prefname]


### PR DESCRIPTION
Trying to run repoclean on Debian buster I was running into the following issue 
```
+ python code/client/repoclean --keep 2 munki_repo/
+ yes
Traceback (most recent call last):
  File "code/client/repoclean", line 538, in <module>
    main()
  File "code/client/repoclean", line 489, in main
    parser.add_option('--plugin', default=pref('plugin'),
  File "/tmp/build/64fb2168/code/client/munkilib/cliutils.py", line 92, in pref
    pref.cache = readPlist(PREFSPATH)
  File "/tmp/build/64fb2168/code/client/munkilib/wrappers.py", line 59, in readPlist
    raise PlistReadError(err)
munkilib.wrappers.PlistReadError: [Errno 2] No such file or directory: '/root/Library/Preferences/com.googlecode.munki.munkiimport.plist'
```

There may be a more elegant fix im missing but this did the job. 