### PR TITLE
Add raised exception to manifest retrieval output

### DIFF
--- a/code/client/munkilib/updatecheck/core.py
+++ b/code/client/munkilib/updatecheck/core.py
@@ -80,9 +80,9 @@ def check(client_id='', localmanifestpath=None):
         else:
             try:
                 mainmanifestpath = manifestutils.get_primary_manifest(client_id)
-            except manifestutils.ManifestException:
+            except manifestutils.ManifestException as err:
                 display.display_error(
-                    'Could not retrieve managed install primary manifest.')
+                    'Could not retrieve managed install primary manifest.: %s', err)
                 raise
 
         if processes.stop_requested():


### PR DESCRIPTION
When running `managedsoftwareupdate` without an internet connection, the below error will happen:

```
ERROR: Could not retrieve managed install primary manifest.
```

This is a rare, but possible situation. Other Munki libraries add the raised exception to the output (ex: download.py). This PR includes a change that will add the raised exception to the manifest retrieval in `core.py`. Below is an example of the output could look like with these changes:

```
ERROR: Could not retrieve managed install primary manifest.: (-1009, "The Internet connection appears to be offline.")
```

For Munki administrators, this will be helpful when trying to diagnose why a system was unable to retrieve the manifest via log files.