### PR TITLE
Add 2022 M2 Air and 13" Pro to machine_type

### DIFF
--- a/code/client/munkilib/info.py
+++ b/code/client/munkilib/info.py
@@ -885,9 +885,14 @@ def predicate_info_object():
     build = machine['os_build_number']
     info_object['os_build_last_component'] = pkgutils.MunkiLooseVersion(
         build).version[-1]
-    if 'Book' in machine.get('machine_model', ''):
+    machine_model = machine.get('machine_model', '')
+    if 'Book' in machine_model:
         info_object['machine_type'] = 'laptop'
-    else:
+    # Mac14,2: 2022 M2 13" MacBook Air
+    # Mac14,7: 2022 M2 13" MacBook Pro
+    elif machine_model in ['Mac14,2', 'Mac14,7']:
+        info_object['machine_type'] = 'laptop'
+    else
         info_object['machine_type'] = 'desktop'
     return info_object
 

--- a/code/client/munkilib/info.py
+++ b/code/client/munkilib/info.py
@@ -910,12 +910,7 @@ def predicate_info_object():
     build = machine['os_build_number']
     info_object['os_build_last_component'] = pkgutils.MunkiLooseVersion(
         build).version[-1]
-    machine_model = machine.get('machine_model', '')
-    if 'Book' in machine_model:
-        info_object['machine_type'] = 'laptop'
-    # Mac14,2: 2022 M2 13" MacBook Air
-    # Mac14,7: 2022 M2 13" MacBook Pro
-    elif machine_model in ['Mac14,2', 'Mac14,7']:
+    if 'Book' in info_object['product_name']:
         info_object['machine_type'] = 'laptop'
     else:
         info_object['machine_type'] = 'desktop'

--- a/code/client/munkilib/info.py
+++ b/code/client/munkilib/info.py
@@ -892,7 +892,7 @@ def predicate_info_object():
     # Mac14,7: 2022 M2 13" MacBook Pro
     elif machine_model in ['Mac14,2', 'Mac14,7']:
         info_object['machine_type'] = 'laptop'
-    else
+    else:
         info_object['machine_type'] = 'desktop'
     return info_object
 

--- a/code/client/munkilib/info.py
+++ b/code/client/munkilib/info.py
@@ -40,6 +40,7 @@ import LaunchServices
 # pylint: disable=E0611
 from Foundation import NSMetadataQuery, NSPredicate, NSRunLoop
 from Foundation import NSBundle, NSDate, NSTimeZone
+from Foundation import NSString, NSUTF8StringEncoding
 # pylint: enable=E0611
 
 # our libs
@@ -645,6 +646,29 @@ def get_serial_number():
     )
 
     return serial
+
+def product_name():
+    """Returns the product name from IORegistry"""
+    IOKit_bundle = NSBundle.bundleWithIdentifier_("com.apple.framework.IOKit")
+
+    functions = [
+        ("IOServiceGetMatchingService", b"II@"),
+        ("IOServiceNameMatching", b"@*"),
+        ("IORegistryEntryCreateCFProperty", b"@I@@I"),
+    ]
+    objc.loadBundleFunctions(IOKit_bundle, globals(), functions)
+
+    kIOMasterPortDefault = 0
+    kCFAllocatorDefault = None
+
+    product = IOServiceGetMatchingService(
+        kIOMasterPortDefault, IOServiceNameMatching(b"product")
+    )
+    product_name_data = IORegistryEntryCreateCFProperty(
+        product, "product-name", kCFAllocatorDefault, 0
+    )
+
+    return NSString.alloc().initWithData_encoding_(product_name_data[0:-1], NSUTF8StringEncoding)
 
 
 def hardware_model():

--- a/code/client/munkilib/info.py
+++ b/code/client/munkilib/info.py
@@ -754,6 +754,7 @@ def getMachineFacts():
     machine['ipv4_address'] = get_ip_addresses('IPv4')
     machine['ipv6_address'] = get_ip_addresses('IPv6')
     machine['serial_number'] = get_serial_number() or 'UNKNOWN'
+    machine['product_name'] = product_name() or 'UNKNOWN'
     ibridge_info = get_ibridge_info()
     machine['ibridge_model_name'] = ibridge_info.get(
         'ibridge_model_name', 'NO IBRIDGE CHIP')


### PR DESCRIPTION
This commit adds the NewWorld names for the 2022 M2 MacBook Air and 13" Pro, so they are correctly identified as 'laptop'.

