### PR TITLE
Fix Client Certificate keychain search for Ventura  

### DIFF
--- a/code/client/munkilib/keychain.py
+++ b/code/client/munkilib/keychain.py
@@ -371,7 +371,7 @@ def remove_from_keychain_list(keychain_path):
                         for x in output.split('\n') if x.strip()]
     if keychain_path in search_keychains:
         # Keychain is in the search path
-        display.display_debug1(
+        display.display_debug2(
             'Removing %s from search path...', keychain_path)
         filtered_keychains = [keychain for keychain in search_keychains
                               if keychain != keychain_path]
@@ -451,7 +451,7 @@ def client_certs_newer_than_keychain():
 def debug_output():
     '''Debugging output for keychain'''
     try:
-        display.display_debug2('***Keychain list***')
+        display.display_debug2('***Keychain search list for common domain***')
         display.display_debug2(security('list-keychains', '-d', 'common'))
         display.display_debug2('***Default keychain info***')
         display.display_debug2(security('default-keychain', '-d', 'common'))


### PR DESCRIPTION
This fixes a problem where Munki can't search for the Client Certificate in the munki.keychain in macOS Ventura.

In grul.py NSURLAuthenticationMethodClientCertificate handler, the SecItemCopyMatching function doesn't find the client cert, since the munki.keychain is added to the keychain search list for the User domain, and Ventura isn't allowing Munki launchd jobs to access this domain.

Apple's guidance is launch daemons don't have access to keychains in the User context, so somewhat surprising this worked on earlier macOS versions; apparently Ventura is now enforcing this.

https://developer.apple.com/documentation/security/secpreferencesdomain

This PR address this problem by adding munki.keychain to the Common domain keychain search list, rather than the User domain. The Common domain search list is for all users and the system. And if there's a problem searching the keychain or if a matching client cert can't be found, added code to fail more gracefully.

Tested in Ventura public release (22A380), Monterey, Big Sur, Catalina, Mojave
