### PR TITLE
Fix issue with receiptinfo having a null `product_version`

### DIFF
--- a/code/client/munkilib/pkgutils.py
+++ b/code/client/munkilib/pkgutils.py
@@ -871,7 +871,7 @@ def getPackageMetaData(pkgitem):
 
     cataloginfo = {}
     cataloginfo['name'] = nameAndVersion(shortname)[0]
-    cataloginfo['version'] = receiptinfo.get("product_version", metaversion)
+    cataloginfo['version'] = receiptinfo.get("product_version", None) or metaversion
     for key in ('display_name', 'RestartAction', 'description'):
         if key in installerinfo:
             cataloginfo[key] = installerinfo[key]

--- a/code/client/munkilib/pkgutils.py
+++ b/code/client/munkilib/pkgutils.py
@@ -871,7 +871,7 @@ def getPackageMetaData(pkgitem):
 
     cataloginfo = {}
     cataloginfo['name'] = nameAndVersion(shortname)[0]
-    cataloginfo['version'] = receiptinfo.get("product_version", None) or metaversion
+    cataloginfo['version'] = receiptinfo.get("product_version") or metaversion
     for key in ('display_name', 'RestartAction', 'description'):
         if key in installerinfo:
             cataloginfo[key] = installerinfo[key]


### PR DESCRIPTION
Certain packages have a product_version that is nil (None). The .get default will pass the null along, breaking serialization.

