### PR TITLE
Fix #1183

### DIFF
--- a/code/client/app_usage_monitor
+++ b/code/client/app_usage_monitor
@@ -35,6 +35,11 @@ import select
 import socket
 import sys
 
+# builtin super doesn't work with Cocoa classes in recent PyObjC releases.
+# pylint: disable=redefined-builtin,no-name-in-module
+from objc import super
+# pylint: enable=redefined-builtin,no-name-in-module
+
 try:
     # Apple frameworks
     from AppKit import NSWorkspace
@@ -43,7 +48,6 @@ try:
     from Foundation import NSDistributedNotificationCenter
     from Foundation import NSObject
     from Foundation import NSRunLoop
-    from objc import super
 except ImportError:
     logging.critical("PyObjC wrappers for Apple frameworks are missing.")
     sys.exit(-1)

--- a/code/client/app_usage_monitor
+++ b/code/client/app_usage_monitor
@@ -43,6 +43,7 @@ try:
     from Foundation import NSDistributedNotificationCenter
     from Foundation import NSObject
     from Foundation import NSRunLoop
+    from objc import super
 except ImportError:
     logging.critical("PyObjC wrappers for Apple frameworks are missing.")
     sys.exit(-1)
@@ -114,7 +115,7 @@ class NotificationHandler(NSObject):
 
     def init(self):
         """NSObject-compatible initializer"""
-        self = super(NotificationHandler, self).init()
+        self = super().init()
         if self is None:
             return None
 


### PR DESCRIPTION
PyObjC now requires the use of `objc.super` instead of `builtin.super` when calling superclass methods in a Cocoasubclass, which `app_usage_monitor.NotificationHandler` is.
https://github.com/ronaldoussoren/pyobjc/blob/master/docs/changelog.rst#version-92

The original issue: https://github.com/ronaldoussoren/pyobjc/issues/549

This PR updates the `super` call to make it more idiomatic python3 (i.e. argument-less) and imports the `objc.super` to mask the builtin one for this class.

I checked the rest of the module, and no other `super` usage exists, so this should be safe.
