### PR TITLE
Munkiimport puts supported architecture into pkginfo filename

### DIFF
--- a/code/client/munkilib/admin/munkiimportlib.py
+++ b/code/client/munkilib/admin/munkiimportlib.py
@@ -112,7 +112,7 @@ def copy_pkginfo_to_repo(repo, pkginfo, subdirectory=''):
         pkginfo_ext = '.' + pkginfo_ext
     arch = determine_arch(pkginfo)
     if arch:
-        arch = f"-{arch}"
+        arch = "-%s" % arch
     pkginfo_name = '%s-%s%s%s' % (pkginfo['name'], pkginfo['version'],
                             arch, pkginfo_ext)
     pkginfo_path = os.path.join(destination_path, pkginfo_name)

--- a/code/client/munkilib/admin/munkiimportlib.py
+++ b/code/client/munkilib/admin/munkiimportlib.py
@@ -111,7 +111,9 @@ def copy_pkginfo_to_repo(repo, pkginfo, subdirectory=''):
     if pkginfo_ext and not pkginfo_ext.startswith('.'):
         pkginfo_ext = '.' + pkginfo_ext
     arch = determine_arch(pkginfo)
-    pkginfo_name = '%s-%s-%s%s' % (pkginfo['name'], pkginfo['version'],
+    if arch:
+        arch = f"-{arch}"
+    pkginfo_name = '%s-%s%s%s' % (pkginfo['name'], pkginfo['version'],
                             arch, pkginfo_ext)
     pkginfo_path = os.path.join(destination_path, pkginfo_name)
     index = 0
@@ -121,7 +123,7 @@ def copy_pkginfo_to_repo(repo, pkginfo, subdirectory=''):
         raise RepoCopyError(u'Unable to get list of current pkgsinfo: %s' % err) from err
     while pkginfo_path in pkgsinfo_list:
         index += 1
-        pkginfo_name = '%s-%s-%s__%s%s' % (pkginfo['name'], pkginfo['version'],
+        pkginfo_name = '%s-%s%s__%s%s' % (pkginfo['name'], pkginfo['version'],
                                         arch, index, pkginfo_ext)
         pkginfo_path = os.path.join(destination_path, pkginfo_name)
 

--- a/code/client/munkilib/admin/munkiimportlib.py
+++ b/code/client/munkilib/admin/munkiimportlib.py
@@ -48,6 +48,13 @@ class RepoCopyError(Exception):
     #pass
 
 
+def determine_arch(pkginfo) -> str:
+    """Determine a supported architecture string"""
+    # If there is exactly one supported architecture, return a string with it
+    if len(pkginfo.get("supported_architectures", [])) == 1:
+        return pkginfo["supported_architectures"][0]
+    return ""
+
 def copy_item_to_repo(repo, itempath, vers, subdirectory=''):
     """Copies an item to the appropriate place in the repo.
     If itempath is a path within the repo/pkgs directory, copies nothing.
@@ -103,8 +110,9 @@ def copy_pkginfo_to_repo(repo, pkginfo, subdirectory=''):
     pkginfo_ext = pref('pkginfo_extension') or ''
     if pkginfo_ext and not pkginfo_ext.startswith('.'):
         pkginfo_ext = '.' + pkginfo_ext
-    pkginfo_name = '%s-%s%s' % (pkginfo['name'], pkginfo['version'],
-                                pkginfo_ext)
+    arch = determine_arch(pkginfo)
+    pkginfo_name = '%s-%s-%s%s' % (pkginfo['name'], pkginfo['version'],
+                            arch, pkginfo_ext)
     pkginfo_path = os.path.join(destination_path, pkginfo_name)
     index = 0
     try:
@@ -113,8 +121,8 @@ def copy_pkginfo_to_repo(repo, pkginfo, subdirectory=''):
         raise RepoCopyError(u'Unable to get list of current pkgsinfo: %s' % err) from err
     while pkginfo_path in pkgsinfo_list:
         index += 1
-        pkginfo_name = '%s-%s__%s%s' % (pkginfo['name'], pkginfo['version'],
-                                        index, pkginfo_ext)
+        pkginfo_name = '%s-%s-%s__%s%s' % (pkginfo['name'], pkginfo['version'],
+                                        arch, index, pkginfo_ext)
         pkginfo_path = os.path.join(destination_path, pkginfo_name)
 
     try:


### PR DESCRIPTION
Munkiimport now puts the supported architecture into the pkginfo filename, if and only if there is one supported architecture specified.

I used EclipseTemurinJDK 11 as a test for this, as it has the same version in both x86_64 and amd64:

Here's importing the amd64 version:
```
% munkiimport --arch=arm64 /Users/nmcspadden/Library/AutoPkg/Cache/local.recipe.munki.EclipseTemurinJDK11_aarch64/downloads/adoptium-11_jdk_mac_aarch64_hotspot.pkg 
This item is similar to an existing item in the repo:
            Item name: adoptium-11_jdk_mac_x64_hotspot
         Display name: 
          Description: 
              Version: 11.0.19+7
  Installer item path: apps/adoptium-11_jdk_mac_x64_hotspot-11.0.19+7.pkg

Use existing item as a template? [y/N] y
Copying unattended_install: False
Copying unattended_uninstall: False
Copying category: 
Copying developer: 
           Item name: adoptium-11_jdk_mac_x64_hotspot
        Display name: adoptium-11_jdk_mac_x64_hotspot
         Description: 
             Version: 11.0.19+7
            Category: 
           Developer: 
  Unattended install: False
Unattended uninstall: False
            Catalogs: testing

Import this item? [y/N] y
No existing product icon found.
Attempt to create a product icon? [y/N] N
Copying adoptium-11_jdk_mac_aarch64_hotspot.pkg to repo...
Copied adoptium-11_jdk_mac_aarch64_hotspot.pkg to pkgs/apps/adoptium-11_jdk_mac_aarch64_hotspot-11.0.19+7.pkg.
Saved pkginfo to pkgsinfo/apps/adoptium-11_jdk_mac_x64_hotspot-11.0.19+7-arm64.pkginfo.
Rebuild catalogs? [y/N] y
Rebuilding catalogs at file:///Users/Shared/munki_repo...
```

Here's the x86 version:
```
% munkiimport --arch=x86_64 /Users/nmcspadden/Library/AutoPkg/Cache/local.recipe.munki.EclipseTemurinJDK11_x86/downloads/adoptium-11_jdk_mac_x64_hotspot.pkg
           Item name: adoptium-11_jdk_mac_x64_hotspot
        Display name: 
         Description: 
             Version: 11.0.19+7
            Category: 
           Developer: 
  Unattended install: False
Unattended uninstall: False
            Catalogs: testing

Import this item? [y/N] y
Upload item to subdirectory path []: apps
No existing product icon found.
Attempt to create a product icon? [y/N] N
Copying adoptium-11_jdk_mac_x64_hotspot.pkg to repo...
Copied adoptium-11_jdk_mac_x64_hotspot.pkg to pkgs/apps/adoptium-11_jdk_mac_x64_hotspot-11.0.19+7.pkg.
Saved pkginfo to pkgsinfo/apps/adoptium-11_jdk_mac_x64_hotspot-11.0.19+7-x86_64.pkginfo.
Rebuild catalogs? [y/N] y
Rebuilding catalogs at file:///Users/Shared/munki_repo...
```

End result:
```
% ls /Users/Shared/munki_repo/pkgsinfo/apps 
adoptium-11_jdk_mac_aarch64_hotspot-11.0.19+7-arm64.pkginfo	adoptium-11_jdk_mac_x64_hotspot-11.0.19+7-x86_64.pkginfo
```

Negative test where I import something without specifying an arch and the filename remains the same as always:
```
% makecatalogs --repo-url=file:///Users/Shared/munki_repo
Getting list of icons...
Getting list of pkgsinfo...
Getting list of pkgs...
Adding pkgsinfo/munkitools/munkitools_app_usage-6.3.2.4588.plist to development...
Adding pkgsinfo/munkitools/munkitools_core-6.3.2.4588.plist to development...
Adding pkgsinfo/munkitools/munkitools_launchd-3.0.3265.plist to development...
Adding pkgsinfo/munkitools/munkitools_python-3.10.11.4585.plist to development...
Adding pkgsinfo/munkitools/munkitools_admin-6.3.2.4588.plist to development...
Adding pkgsinfo/munkitools/munkitools-6.2.0.4576.plist to development...
Adding pkgsinfo/apps/adoptium-11_jdk_mac_x64_hotspot-11.0.19+7-x86_64.pkginfo to testing...
Adding pkgsinfo/apps/adoptium-11_jdk_mac_aarch64_hotspot-11.0.19+7-arm64.pkginfo to testing...
Created catalogs/all...
Created catalogs/development...
Created catalogs/testing...
nmcspadden@nmcspadden-mac admin % munkiimport /Users/nmcspadden/Library/AutoPkg/Cache/local.recipe.munki.EclipseTemurinJDK17_aarch64/downloads/adoptium-17_jdk_mac_aarch64_hotspot.pkg
           Item name: adoptium-17_jdk_mac_aarch64_hotspot
        Display name: 
         Description: 
             Version: 17.0.7+7
            Category: 
           Developer: 
  Unattended install: False
Unattended uninstall: False
            Catalogs: testing

Import this item? [y/N] y
Upload item to subdirectory path []: apps
No existing product icon found.
Attempt to create a product icon? [y/N] N
Copying adoptium-17_jdk_mac_aarch64_hotspot.pkg to repo...
Copied adoptium-17_jdk_mac_aarch64_hotspot.pkg to pkgs/apps/adoptium-17_jdk_mac_aarch64_hotspot-17.0.7+7.pkg.
Saved pkginfo to pkgsinfo/apps/adoptium-17_jdk_mac_aarch64_hotspot-17.0.7+7.pkginfo.
Rebuild catalogs? [y/N] y
Rebuilding catalogs at file:///Users/Shared/munki_repo...

% ls -l /Users/Shared/munki_repo/pkgsinfo/apps
total 24
-rw-r--r--  1 nmcspadden  wheel  1724 Jul 24 09:47 adoptium-11_jdk_mac_aarch64_hotspot-11.0.19+7-arm64.pkginfo
-rw-r--r--  1 nmcspadden  wheel  1717 Jul 24 09:48 adoptium-11_jdk_mac_x64_hotspot-11.0.19+7-x86_64.pkginfo
-rw-r--r--  1 nmcspadden  wheel  1641 Jul 24 09:57 adoptium-17_jdk_mac_aarch64_hotspot-17.0.7+7.pkginfo
```