### PR TITLE
Add preference to ignore middleware

### DIFF
--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -118,7 +118,11 @@ def import_middleware():
 
 
 middleware = None
-import_middleware()
+ignore_middleware = prefs.pref('IgnoreMiddleware')
+if ignore_middleware is not True:
+        # If we haven't explicitly said to ignore middleware,
+        # the preference decides
+        import_middleware()
 
 
 class Error(Exception):

--- a/code/client/munkilib/fetch.py
+++ b/code/client/munkilib/fetch.py
@@ -119,10 +119,10 @@ def import_middleware():
 
 middleware = None
 ignore_middleware = prefs.pref('IgnoreMiddleware')
-if ignore_middleware is not True:
-        # If we haven't explicitly said to ignore middleware,
-        # the preference decides
-        import_middleware()
+if not ignore_middleware:
+    # If we haven't explicitly said to ignore middleware,
+    # the preference decides
+    import_middleware()
 
 
 class Error(Exception):

--- a/code/client/munkilib/prefs.py
+++ b/code/client/munkilib/prefs.py
@@ -65,6 +65,7 @@ DEFAULT_PREFS = {
     'FollowHTTPRedirects': 'none',
     'HelpURL': None,
     'IconURL': None,
+    'IgnoreMiddleware': False,
     'IgnoreSystemProxies': False,
     'InstallRequiresLogout': False,
     'InstallAppleSoftwareUpdates': False,


### PR DESCRIPTION
This PR adds the preference IgnoreMiddleware. This could be helpful when moving away from using middleware because of a chicken & egg scenario where your new SoftwareRepoURL no longer needs middleware. 