### PR TITLE
pkgsinfoutil

### DIFF
--- a/code/client/pkgsinfoutil
+++ b/code/client/pkgsinfoutil
@@ -1,0 +1,417 @@
+#!/usr/local/munki/munki-python
+# encoding: utf-8
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+pkgsinfoutil
+
+Created by Steve Kueng on 2024-04-01.
+"""
+from __future__ import absolute_import, print_function
+
+
+import optparse
+import os
+import readline
+import shlex
+import sys
+import subprocess
+import tempfile
+
+# our libs
+from munkilib.admin.common import list_items_of_kind
+from munkilib.admin import makecatalogslib
+from munkilib.cliutils import ConfigurationSaveError
+from munkilib.cliutils import configure as _configure
+from munkilib.cliutils import libedit
+from munkilib.cliutils import get_version, pref, path2url
+from munkilib.wrappers import (get_input, readPlistFromString)
+
+from munkilib import munkirepo
+
+
+
+def cleanup_and_exit(exitcode):
+    """Give the user the chance to unmount the repo when we exit"""
+    result = 0
+    # TODO: handle mounted repo
+    #if repo and repo.mounted and repo.WE_MOUNTED_THE_REPO:
+    #    answer = raw_input('Unmount the repo fileshare? [y/n] ')
+    #    if answer.lower().startswith('y'):
+    #        result = repo.unmount()
+    exit(exitcode or result)
+
+
+##### subcommand functions #####
+
+class MyOptParseError(Exception):
+    '''Exception for our custom option parser'''
+    pass
+
+
+class MyOptParseExit(Exception):
+    '''Raised when optparse calls self.exit() so we can handle it instead
+    of exiting'''
+    pass
+
+
+class MyOptionParser(optparse.OptionParser):
+    '''Custom option parser that overrides the error handler and
+    the exit handler so printing help doesn't exit the interactive
+    pseudo-shell'''
+    def error(self, msg):
+        """error(msg : string)
+
+        """
+        self.print_usage(sys.stderr)
+        raise MyOptParseError('option error: %s' % msg)
+
+    def exit(self, status=0, msg=None):
+        if msg:
+            sys.stderr.write(msg)
+        raise MyOptParseExit
+
+
+def version(repo, args):
+    '''Prints version number'''
+    # we ignore repo arg but subcommand dispatcher sends it to all
+    # subcommands
+    if len(args) != 0:
+        print('Usage: version', file=sys.stderr)
+        return 22 # Invalid argument
+    print(get_version())
+    return 0
+
+
+def configure(repo, args):
+    '''Allow user to configure tool options'''
+    # we ignore the repo arg, but all the other subcommands require it
+    if len(args):
+        print('Usage: configure', file=sys.stderr)
+        return 22 # Invalid argument
+    prompt_list = [
+        ('repo_url', 'Repo URL (example: afp://munki.example.com/repo)'),
+        ('plugin', 'Munki repo plugin (defaults to FileRepo)')
+    ]
+    try:
+        _configure(prompt_list)
+        return 0
+    except ConfigurationSaveError:
+        return 1 # Operation not permitted
+
+
+def get_pkginfo_names(repo):
+    '''Returns a list of pkginfo names''' 
+    return [str(i).removeprefix('pkgsinfo/') for i in list_items_of_kind(repo, 'pkgsinfo')]
+
+
+def edit_pkginfo(repo, args):
+    '''Edits the pkginfo for a package.'''
+    parser = MyOptionParser()
+    parser.set_usage(
+        '''edit-pkginfo PKGNAME
+       Edits the pkginfo for a package''')
+    try:
+        options, arguments = parser.parse_args(args)
+    except MyOptParseError as errmsg:
+        print(str(errmsg), file=sys.stderr)
+        return 22
+    except MyOptParseExit:
+        return 0
+    
+    if len(arguments) != 1:
+        parser.print_usage(sys.stderr)
+        return 7
+    pkgname = arguments[0]
+
+    editor = pref('editor')
+    if not editor:
+        print('No editor defined. Run %s --configure to define one.'
+              % os.path.basename(__file__), file=sys.stderr)
+        return 1
+    
+    filedesc, filepath = tempfile.mkstemp()
+    # we just want the path; close the file descriptor
+    os.close(filedesc)
+    try:
+        repo.get_to_local_file(os.path.join('pkgsinfo', pkgname), filepath)
+    except munkirepo.RepoError as err:
+        print(u'Error getting pkginfo: %s' % err, file=sys.stderr)
+        return 1
+    
+    if editor.endswith('.app'):
+        cmd = ['/usr/bin/open', '-a', editor, filepath]
+    else:
+        cmd = [editor, filepath]
+    try:
+        dummy_returncode = subprocess.check_call(cmd)
+    except (OSError, subprocess.CalledProcessError) as err:
+        print('Problem running editor %s: %s.' % (editor, err),
+                file=sys.stderr)
+        os.remove(filepath)
+        return 1
+    else:
+        if editor.endswith('.app'):
+            # wait for user to finish with GUI editor.
+            answer = 'no'
+            while not answer.lower().startswith('y'):
+                answer = get_input('Pkginfo editing complete? [y/N]: ')
+        try:
+            repo.put_from_local_file(os.path.join('pkgsinfo', pkgname), filepath)
+        except munkirepo.RepoError as err:
+            print(u'Problem writing pkginfo: %s' % err,
+                    file=sys.stderr)
+            os.remove(filepath)
+            return 1
+        os.remove(filepath)
+        
+        answer = get_input('Rebuild catalogs now? [y/N]: ')
+        if answer.lower().startswith('y'):
+            make_catalogs(repo)
+        return 0
+
+
+def delete_pkginfo(repo, args):
+    '''Deletes the pkginfo for a package.'''
+    parser = MyOptionParser()
+    parser.set_usage(
+        '''delete-pkginfo PKGNAME
+       Deletes the pkginfo for a package''')
+    try:
+        options, arguments = parser.parse_args(args)
+    except MyOptParseError as errmsg:
+        print(str(errmsg), file=sys.stderr)
+        return 22
+    except MyOptParseExit:
+        return 0
+    
+    if len(arguments) != 1:
+        parser.print_usage(sys.stderr)
+        return 7
+    pkgname = arguments[0]
+
+    answer = get_input('Are you sure you want to delete %s? [y/N]: ' % pkgname)
+    if not answer.lower().startswith('y'):
+        return 0
+    
+    answer = get_input('also delete installer item? [y/N]: ')
+    if answer.lower().startswith('y'):
+        try:
+            data = repo.get(os.path.join('pkgsinfo', pkgname))
+            pkginfo = readPlistFromString(data)
+        except munkirepo.RepoError as err:
+            print(u'Error reading pkginfo: %s' % err, file=sys.stderr)
+            return 1
+        try:
+            repo.delete(os.path.join('pkgs', pkginfo['installer_item_location']))
+        except munkirepo.RepoError as err:
+            print(u'Error deleting installer item: %s' % err, file=sys.stderr)
+            return 1
+
+    try:
+        repo.delete(os.path.join('pkgsinfo', pkgname))
+    except munkirepo.RepoError as err:
+        print(u'Error deleting pkginfo: %s' % err, file=sys.stderr)
+        return 1
+    
+    answer = get_input('Rebuild catalogs now? [y/N]: ')
+    if answer.lower().startswith('y'):
+        make_catalogs(repo)
+    return 0
+
+
+def make_catalogs(repo, args=None):
+    """Rebuild our catalogs"""
+    errors = makecatalogslib.makecatalogs(repo, {}, output_fn=print)
+    if errors:
+        print('\nThe following issues occurred while building catalogs:\n')
+        for error in errors:
+            print(error)
+
+
+def refresh_cache(repo, args):
+    '''Refreshes the repo data if changes were made while manifestutil was
+    running. Updates manifests, catalogs, and packages.'''
+    parser = MyOptionParser()
+    parser.set_usage('''refresh-cache
+        Refreshes the repo data''')
+    try:
+        _, arguments = parser.parse_args(args)
+    except MyOptParseError as errmsg:
+        print(str(errmsg), file=sys.stderr)
+        return 22 # Invalid argument
+    except MyOptParseExit:
+        return 0
+
+    if len(arguments) != 0:
+        parser.print_usage(sys.stderr)
+        return 22 # Invalid argument
+    CMD_ARG_DICT['pkgs'] = get_pkginfo_names(repo)
+
+##### end subcommand functions
+
+def show_help():
+    '''Prints available subcommands'''
+    print("Available sub-commands:")
+    subcommands = list(CMD_ARG_DICT['cmds'].keys())
+    subcommands.sort()
+    for item in subcommands:
+        print('\t%s' % item)
+    return 0
+
+
+def tab_completer(text, state):
+    '''Called by the readline lib to calculate possible completions'''
+    array_to_match = None
+    if readline.get_begidx() == 0:
+        # since we are at the start of the line
+        # we are matching commands
+        array_to_match = 'cmds'
+        match_list = list(CMD_ARG_DICT.get('cmds', {}).keys())
+    else:
+        # we are matching args
+        cmd_line = readline.get_line_buffer()[0:readline.get_begidx()]
+        cmd = shlex.split(cmd_line)[-1]
+        array_to_match = CMD_ARG_DICT.get('cmds', {}).get(cmd)
+        if array_to_match:
+            match_list = CMD_ARG_DICT[array_to_match]
+        else:
+            array_to_match = CMD_ARG_DICT.get('options', {}).get(cmd)
+            if array_to_match:
+                match_list = CMD_ARG_DICT[array_to_match]
+            else:
+                array_to_match = 'options'
+                match_list = list(CMD_ARG_DICT.get('options', {}).keys())
+
+    matches = [item for item in match_list
+               if item.upper().startswith(text.upper())]
+    try:
+        return matches[state]
+    except IndexError:
+        return None
+
+
+def set_up_tab_completer():
+    '''Starts our tab-completer when running interactively'''
+    readline.set_completer(tab_completer)
+    if libedit:
+        # readline module was compiled against libedit
+        readline.parse_and_bind("bind ^I rl_complete")
+    else:
+        readline.parse_and_bind("tab: complete")
+
+
+def handle_subcommand(repo, args):
+    '''Does all our subcommands'''
+    # check if any arguments are passed.
+    # if not, list subcommands.
+    if len(args) < 1:
+        show_help()
+        return 2
+
+    # strip leading hyphens and
+    # replace embedded hyphens with underscores
+    # so '--add-pkg' becomes 'add_pkg'
+    # and 'new-manifest' becomes 'new_manifest'
+    subcommand = args[0].lstrip('-').replace('-', '_')
+
+    # special case the exit command
+    if subcommand == 'exit':
+        cleanup_and_exit(0)
+
+    if (subcommand not in ['version', 'configure', 'help']
+            and '-h' not in args and '--help' not in args):
+        if not repo:
+            repo = connect_to_repo()
+
+    try:
+        # find function to call by looking in the global name table
+        # for a function with a name matching the subcommand
+        subcommand_function = globals()[subcommand]
+    except MyOptParseExit:
+        return 0
+    except (TypeError, KeyError):
+        print('Unknown subcommand: %s' % args[0], file=sys.stderr)
+        show_help()
+        return 2
+    else:
+        return subcommand_function(repo, args[1:])
+
+
+def connect_to_repo():
+    '''Connects to the Munki repo'''
+    repo_url = pref('repo_url')
+    repo_path = pref('repo_path')
+    repo_plugin = pref('plugin')
+    if not repo_url and repo_path:
+        repo_url = path2url(repo_path)
+    if not repo_url:
+        print((
+            u'No repo URL defined. Run %s --configure to define one.'
+            % os.path.basename(__file__)), file=sys.stderr)
+        exit(-1)
+    try:
+        repo = munkirepo.connect(repo_url, repo_plugin)
+    except munkirepo.RepoError as err:
+        print(u'Repo error: %s' % err, file=sys.stderr)
+        exit(-1)
+    return repo
+
+
+CMD_ARG_DICT = {}
+
+def main():
+    '''Our main routine'''
+    repo = None
+
+    cmds = {'edit-pkginfo':              'pkgs',
+            'delete-pkginfo':            'pkgs',
+            'make-catalogs':             'default',
+            'refresh-cache':             'default',
+            'exit':                      'default',
+            'help':                      'default',
+            'configure':                 'default',
+            'version':                   'default'
+           }
+    CMD_ARG_DICT['cmds'] = cmds
+
+    if len(sys.argv) > 1:
+        # some commands or options were passed at the command line
+        cmd = sys.argv[1].lstrip('-')
+        retcode = handle_subcommand(repo, sys.argv[1:])
+        cleanup_and_exit(retcode)
+    else:
+        # if we get here, no options or commands,
+        # so let's enter interactive mode
+        # must have an available repo for interactive mode
+        repo = connect_to_repo()
+        # build the rest of our dict to enable tab completion
+
+        CMD_ARG_DICT['default'] = []
+        CMD_ARG_DICT['pkgs'] = get_pkginfo_names(repo)
+
+        set_up_tab_completer()
+        print('Entering interactive mode... (type "help" for commands)')
+        while 1:
+            try:
+                cmd = get_input('> ')
+            except (KeyboardInterrupt, EOFError):
+                # React to Control-C and Control-D
+                print() # so we finish off the raw_input line
+                cleanup_and_exit(0)
+            args = shlex.split(cmd)
+            handle_subcommand(repo, args)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
If you want to edit existing pkginfo files on a repo outside the local device (e.g. on azure or S3), this is currently only possible by directly accessing the repo.
I have written my own util for this purpose, which, like the manifestutil for manifests, allows the editing and deletion of pkginfo files. It is a copy of the mainfestutil and uses the same repo plugins as well as the editor option from munkiimport.

I have also thought about creating a "munkirepoutil" and combining all functions in one tool.