### PR TITLE
custom sidebar item

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -1088,7 +1088,8 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
                 decisionHandler(.cancel)
                 return
             }
-            if scheme == "mailto" || scheme == "http" || scheme == "https" {
+            
+            if scheme == "mailto" {
                 // open link in default mail client since WKWebView doesn't
                 // forward these links natively
                 NSWorkspace.shared.open(url)

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -296,8 +296,8 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         // Called by app delegate from applicationDidFinishLaunching:
         
         // add custom link if nessesary
-        if let CustonMenuItem = pref("CustonMenuItem") as? Dictionary<String, String> {
-            if let title = CustonMenuItem["title"], let icon = CustonMenuItem["icon"] {
+        if let CustonSidebarItem = pref("CustonSidebarItem") as? Dictionary<String, String> {
+            if let title = CustonSidebarItem["title"], let icon = CustonSidebarItem["icon"] {
                 sidebar_items.append( ["title": title, "icon": icon])
                 self.sidebar.reloadData()
             }
@@ -1646,8 +1646,8 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         // Called by Navigate menu item'''
         clearSearchField()
         var page = "updates.html"
-        if let CustonMenuItem = pref("CustonMenuItem") as? Dictionary<String, String> {
-            if let link = CustonMenuItem["link"] {
+        if let CustonSidebarItem = pref("CustonSidebarItem") as? Dictionary<String, String> {
+            if let link = CustonSidebarItem["link"] {
                 page = link
             }
         }


### PR DESCRIPTION
we use Munki in combination with Intune.
To make it easier for users, I would like to integrate the company portal web directly into Munki.
As a possible solution I have built a custom sidebar item.
The title, icon and link of the custom sidebar item can be configured via ManagedInstalls.plist


ManagedInstalls.plist:
{
    AppleSoftwareUpdatesOnly = 0;
    CustonSidebarItem =     {
        icon = desktopcomputer;
        link = "https://portal.manage.microsoft.com/devices";
        title = "My Devices";
    };
    FollowHTTPRedirects = none;
    IgnoreMiddleware = 0;
    IgnoreSystemProxies = 0;
    InstallAppleSoftwareUpdates = 0;
    LastCheckDate = "2024-04-01 14:56:58 +0000";
    LastCheckResult = 0;
    LogFile = "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log";
    LogToSyslog = 0;
    LoggingLevel = 1;
    ManagedInstallDir = "/Library/Managed Installs";
    OldestUpdateDays = 0;
    PendingUpdateCount = 0;
    UseClientCertificate = 0;
}

defaults write /Library/Preferences/ManagedInstalls.plist CustonSidebarItem '<dict><key>title</key><string>My Device</string><key>icon</key><string>desktopcomputer</string><key>link</key><string>https://portal.manage.microsoft.com/devices</string></dict></dict>' 


![SCR-20240401-pxyq](https://github.com/munki/munki/assets/5426904/6df7bcc2-d909-4c9a-a4c8-213710df916d)
