### PR TITLE
Suspend display sleep during bootstrap

### DIFF
--- a/code/apps/MunkiStatus/MunkiStatus.xcodeproj/project.pbxproj
+++ b/code/apps/MunkiStatus/MunkiStatus.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		51899A9F2DCE7FBD00A3C95C /* Power.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51899A9E2DCE7FB200A3C95C /* Power.swift */; };
+		51899AA12DCE820900A3C95C /* DisplayAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51899AA02DCE820200A3C95C /* DisplayAssertion.swift */; };
 		9B28B78821E3B88F002C58D2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9B28B78A21E3B88F002C58D2 /* InfoPlist.strings */; };
 		C0168E9020B1E1D80027BD78 /* LogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0168E8F20B1E1D80027BD78 /* LogViewController.swift */; };
 		C04F824E20BB157800F9C57D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = C04F825020BB157800F9C57D /* Localizable.strings */; };
@@ -21,6 +23,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		51899A9E2DCE7FB200A3C95C /* Power.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Power.swift; sourceTree = "<group>"; };
+		51899AA02DCE820200A3C95C /* DisplayAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayAssertion.swift; sourceTree = "<group>"; };
 		9B28B78921E3B88F002C58D2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		9B28B78B21E3B892002C58D2 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		9B28B78C21E3B894002C58D2 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -108,6 +112,8 @@
 		C0544D4A20AF0EDA00DC86F6 /* MunkiStatus */ = {
 			isa = PBXGroup;
 			children = (
+				51899AA02DCE820200A3C95C /* DisplayAssertion.swift */,
+				51899A9E2DCE7FB200A3C95C /* Power.swift */,
 				C04F825C20BB15F500F9C57D /* Localization.swift */,
 				C0787F7A2315C6210054D130 /* main.swift */,
 				C0168E8F20B1E1D80027BD78 /* LogViewController.swift */,
@@ -239,9 +245,11 @@
 				C0A7938020B0EA7800F56DD5 /* Utils.swift in Sources */,
 				C04F825D20BB15F500F9C57D /* Localization.swift in Sources */,
 				C0787F7B2315C6210054D130 /* main.swift in Sources */,
+				51899A9F2DCE7FBD00A3C95C /* Power.swift in Sources */,
 				C0F4B7B52C24F9EE00B421D9 /* BlurredBackgroundController.swift in Sources */,
 				C0544D4C20AF0EDA00DC86F6 /* AppDelegate.swift in Sources */,
 				C0A7937E20AFAE0300F56DD5 /* MunkiStatusViewController.swift in Sources */,
+				51899AA12DCE820900A3C95C /* DisplayAssertion.swift in Sources */,
 				C0168E9020B1E1D80027BD78 /* LogViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/code/apps/MunkiStatus/MunkiStatus/AppDelegate.swift
+++ b/code/apps/MunkiStatus/MunkiStatus/AppDelegate.swift
@@ -29,6 +29,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if atLoginWindow() {
             blurBackground()
         }
+        // If bootstrapping, and on AC or battery over 50% (Intel) 30% (Apple Silicon) assert NoDisplaySleep
+        if isBootstrapping() && atLoginWindow() {
+            createNoDisplaySleepAssertion()
+        }
         // Prevent automatic relaunching at login on Lion+
         if NSApp.responds(to: #selector(NSApplication.disableRelaunchOnLogin)) {
             NSApp.disableRelaunchOnLogin()
@@ -36,7 +40,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
-        // Insert code here to tear down your application
+        // Release display sleep assertion if it exists
+        releaseDisplaySleepAssertion()
     }
     
     func blurBackground() {

--- a/code/apps/MunkiStatus/MunkiStatus/DisplayAssertion.swift
+++ b/code/apps/MunkiStatus/MunkiStatus/DisplayAssertion.swift
@@ -1,0 +1,48 @@
+//
+//  DisplayAssertion.swift
+//  MunkiStatus
+//
+//  Created by Christopher A Grande on 5/9/25.
+//  Copyright © 2025 The Munki Project. All rights reserved.
+//
+
+import IOKit.pwr_mgt
+
+var displaySleepAssertionID: IOPMAssertionID?
+
+func createNoDisplaySleepAssertion() {
+    let threshold = isAppleSilicon() ? 30 : 50
+    if onACPower() || getBatteryPercentage() >= threshold {
+        var assertionID: IOPMAssertionID = 0
+        let reasonForActivity = "Prevent display sleep during Munki bootstrapping" as CFString
+        
+        let result = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep as CFString,
+                                                 IOPMAssertionLevel(kIOPMAssertionLevelOn),
+                                                 reasonForActivity,
+                                                 &assertionID)
+        if result == kIOReturnSuccess {
+            displaySleepAssertionID = assertionID
+            print("NoDisplaySleep assertion created with ID: \(assertionID)")
+        } else {
+            print("Failed to create NoDisplaySleep assertion. Error code: \(result)")
+        }
+    } else {
+        print("Display sleep assertion not created, not enough battery power.")
+    }
+}
+
+func releaseDisplaySleepAssertion() {
+    guard let assertionID = displaySleepAssertionID else {
+        print("No assertion to release.")
+        return
+    }
+
+    let result = IOPMAssertionRelease(assertionID)
+
+    if result == kIOReturnSuccess {
+        print("NoDisplaySleep assertion released.")
+        displaySleepAssertionID = nil
+    } else {
+        print("Failed to release NoDisplaySleep assertion. Error code: \(result)")
+    }
+}

--- a/code/apps/MunkiStatus/MunkiStatus/Power.swift
+++ b/code/apps/MunkiStatus/MunkiStatus/Power.swift
@@ -1,0 +1,38 @@
+//
+//  power.swift
+//  From Managed Software Center
+//
+//  Created by Greg Neagle on 7/16/18.
+//  Copyright © 2018-2025 The Munki Project. All rights reserved.
+//
+
+import Foundation
+import IOKit.ps
+
+func onACPower() -> Bool {
+    // Returns a boolean to indicate if the machine is on AC power
+    let snapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
+    let powerSource = IOPSGetProvidingPowerSourceType(snapshot).takeRetainedValue()
+    return powerSource as String == kIOPSACPowerValue
+}
+
+func onBatteryPower() -> Bool {
+    // Returns a boolean to indicate if the machine is on battery power
+    let snapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
+    let powerSource = IOPSGetProvidingPowerSourceType(snapshot).takeRetainedValue()
+    return powerSource as String == kIOPSBatteryPowerValue
+}
+
+func getBatteryPercentage() -> Int {
+    // Returns battery charge percentage (0-100)
+    let snapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
+    let sources = IOPSCopyPowerSourcesList(snapshot).takeRetainedValue() as Array
+    for source in sources {
+        if let description = IOPSGetPowerSourceDescription(snapshot, source).takeUnretainedValue() as? [String: Any] {
+            if description["Type"] as? String == kIOPSInternalBatteryType {
+                return description[kIOPSCurrentCapacityKey] as? Int ?? 0
+            }
+        }
+    }
+    return 0
+}

--- a/code/apps/MunkiStatus/MunkiStatus/Utils.swift
+++ b/code/apps/MunkiStatus/MunkiStatus/Utils.swift
@@ -37,6 +37,27 @@ func atLoginWindow() -> Bool {
     return (consoleuser! == "loginwindow")
 }
 
+func isBootstrapping() -> Bool {
+    let fm = FileManager.default
+    let path = "/Users/Shared/.com.googlecode.munki.checkandinstallatstartup"
+    if fm.fileExists(atPath: path) {
+        print("Bootstrap run in progress")
+        return true
+    }
+    return false
+}
+
+func isAppleSilicon() -> Bool {
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let machine = withUnsafePointer(to: &systemInfo.machine) {
+        $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+            String(cString: $0)
+        }
+    }
+    return machine.starts(with: "arm64")
+}
+
 func exec(_ command: String, args: [String]?) -> String {
     // runs a UNIX command and returns stdout as a string
     let proc = Process()


### PR DESCRIPTION
Adding support for #1117

Caffeinator now asserts `NoDisplaySleepAssertion` instead of `NoIdleSleepAssertion` if the `SuspendDisplaySleepDuringBootstrap` setting is set to True (default is False), Munki is running in bootstrap mode, and is currently at the loginwindow.

One edge case I'd like the fix is with `SuspendDisplaySleepDuringBootstrap` set the update check will still set the `NoIdleSleepAssertion` every time, even on battery. Since the update check was just gated by `powermgr.onACPower`.