### PR TITLE
Display force_install_after_date in managedsoftwareupdate summary (if applicable)

### DIFF
--- a/code/client/munkilib/installinfo.py
+++ b/code/client/munkilib/installinfo.py
@@ -249,12 +249,11 @@ def display_update_info():
         if item.get('RestartAction') == 'RequireLogout':
             display.display_info('       *Logout required')
             reports.report['LogoutRequired'] = True
-        '''Displays force install deadline if present'''
-        if item.get('force_install_after_date'):
-            force_install_after_date = (
-                    info.subtract_tzoffset_from_date(item.get('force_install_after_date', '')))
-            display.display_info('       *Must be installed by %s',
-                    force_install_after_date)
+         '''Displays force install deadline if present'''
+         if item.get('force_install_after_date'):
+             force_install_after_date = str(item['force_install_after_date'])[0:-6]
+             display.display_info('       *Must be installed by %s',
+                     force_install_after_date)
 
     installinfo = get_installinfo()
     installcount = len(installinfo.get('managed_installs', []))

--- a/code/client/munkilib/installinfo.py
+++ b/code/client/munkilib/installinfo.py
@@ -249,12 +249,6 @@ def display_update_info():
         if item.get('RestartAction') == 'RequireLogout':
             display.display_info('       *Logout required')
             reports.report['LogoutRequired'] = True
-        '''Displays force install deadline if present'''
-        if item.get('force_install_after_date'):
-            force_install_after_date = (
-                    info.subtract_tzoffset_from_date(item.get('force_install_after_date', '')))
-            display.display_info('       *Must be installed by %s',
-                    force_install_after_date)
 
     installinfo = get_installinfo()
     installcount = len(installinfo.get('managed_installs', []))

--- a/code/client/munkilib/installinfo.py
+++ b/code/client/munkilib/installinfo.py
@@ -249,11 +249,11 @@ def display_update_info():
         if item.get('RestartAction') == 'RequireLogout':
             display.display_info('       *Logout required')
             reports.report['LogoutRequired'] = True
-         '''Displays force install deadline if present'''
-         if item.get('force_install_after_date'):
-             force_install_after_date = str(item['force_install_after_date'])[0:-6]
-             display.display_info('       *Must be installed by %s',
-                     force_install_after_date)
+        '''Displays force install deadline if present'''
+        if item.get('force_install_after_date'):
+         force_install_after_date = str(item['force_install_after_date'])[0:-6]
+         display.display_info('       *Must be installed by %s',
+                 force_install_after_date)
 
     installinfo = get_installinfo()
     installcount = len(installinfo.get('managed_installs', []))

--- a/code/client/munkilib/installinfo.py
+++ b/code/client/munkilib/installinfo.py
@@ -249,6 +249,12 @@ def display_update_info():
         if item.get('RestartAction') == 'RequireLogout':
             display.display_info('       *Logout required')
             reports.report['LogoutRequired'] = True
+        '''Displays force install deadline if present'''
+        if item.get('force_install_after_date'):
+            force_install_after_date = (
+                    info.subtract_tzoffset_from_date(item.get('force_install_after_date', '')))
+            display.display_info('       *Must be installed by %s',
+                    force_install_after_date)
 
     installinfo = get_installinfo()
     installcount = len(installinfo.get('managed_installs', []))


### PR DESCRIPTION
## Proposed Change
If a `force_install_after_date` is in place for a pending item, display it in the summary after a `managedsoftwareupdate` run.

~~This is a fairly simple change. I tried to use existing code for consistency, but I'm not sure how I feel about `+0000` appearing in the output. Would love to hear Greg's thoughts on that, and I could add more commits to adjust the format of the printed date if that makes sense.~~

Greg did a few iterations of how to deal with the time zone removal for UTC to reflect local time, and so this PR's final code reflects that. More details in the comments below.

## Rationale
I was trying to help someone on the MacAdmins Slack troubleshoot a `force_install_after_date`. My first inclination was to go with the standard troubleshooting step of `sudo managedsoftwareupdate -vvv`, but then I dug through the code and saw that the `force_install_after_date` is shown only [in Managed Software Center](https://github.com/munki/munki/blob/36769cdbbcdfa7392854ff2e60d615f83e524afc/code/apps/Managed%20Software%20Center/Managed%20Software%20Center/mschtml.swift#L837-L838) and handled by [logouthelper](https://github.com/munki/munki/blob/36769cdbbcdfa7392854ff2e60d615f83e524afc/code/client/logouthelper), but it isn't really shown in regular `-vvv` output.

Having it in the `managedsoftwareupdate` output (`-vvv` or not) would help identify something even as simple as a Munki admin forgetting to run `makecatalogs` after changing a pkginfo file. It would also be more consistent with what's displayed in Managed Software Center, since the `managedsoftwareupdate` summary already includes whether a restart or logout is required.

## Testing Done
This doesn't really change what displays in Managed Software Center, of course, because that's evaluated separately in Swift.
<img width="997" alt="Screenshot 2024-06-24 at 17 16 45" src="https://github.com/munki/munki/assets/13055957/c3534821-83be-47d2-abd8-54e2ab64f59a">

### Before PR
#### force only
```
    The following items will be installed or upgraded:
        + Slack-4.39.88
            App for chatting with co-workers about stuff
```
#### force and logout required
```
    The following items will be installed or upgraded:
        + Slack-4.39.88
            App for chatting with co-workers about stuff
           *Logout required
```
#### force and restart required
```
    The following items will be installed or upgraded:
        + Slack-4.39.88
            App for chatting with co-workers about stuff
           *Restart required
```
### After PR
#### no force
Nothing's changed here:
```
    The following items will be installed or upgraded:
        + Slack-4.39.88
            App for chatting with co-workers about stuff
```
#### force only
Displays right below description
```
    The following items will be installed or upgraded:
        + Slack-4.39.88
            App for chatting with co-workers about stuff
           *Must be installed by 2024-07-01 11:00:00
```
#### force and logout required
Displays below logout being required
```
    The following items will be installed or upgraded:
        + Slack-4.39.88
            App for chatting with co-workers about stuff
           *Logout required
           *Must be installed by 2024-07-01 11:00:00
```
#### force and restart required
Displays below restart being required
```
    The following items will be installed or upgraded:
        + Slack-4.39.88
            App for chatting with co-workers about stuff
           *Restart required
           *Must be installed by 2024-07-01 11:00:00
```