### PR TITLE
Add amd64 to supported_architectures

### DIFF
--- a/code/client/munkilib/admin/pkginfolib.py
+++ b/code/client/munkilib/admin/pkginfolib.py
@@ -1073,7 +1073,7 @@ def add_option_groups(parser):
     additional_options.add_option(
         '--arch', '--supported_architecture', '--supported-architecture',
         action="append",
-        choices=['i386', 'x86_64', 'arm64'],
+        choices=['i386', 'x86_64', 'amd64', 'arm64'],
         metavar='ARCH',
         help=('Declares a supported architecture for the item. '
               'Can be specified multiple times to declare multiple '

--- a/code/client/munkilib/updatecheck/catalogs.py
+++ b/code/client/munkilib/updatecheck/catalogs.py
@@ -520,9 +520,10 @@ def get_item_detail(name, cataloglist, vers='',
                 item['name'], item['version'], item['supported_architectures'])
             display.display_debug1(
                 'Our architecture is %s', machine['arch'])
-            if machine['arch'] in item['supported_architectures']:
+            if (machine['arch'] in item['supported_architectures'] or
+                    (machine['arch'] == 'x86_64' and 'amd64' in item['supported_architectures'])):
                 return True
-            if ('x86_64' in item['supported_architectures'] and
+            if ({'x86_64', 'amd64'}.intersection(set(item['supported_architectures'])) and
                     machine['arch'] == 'i386' and
                     machine['x86_64_capable'] is True):
                 return True


### PR DESCRIPTION
This adds `amd64` as an equivalent option to `x86_64` in the `supported_architectures` array. It is intended as a quality of life improvement specifically related to AutoPkg.

Many software titles use `amd64` and `arm64` to differentiate architectures and AutoPkg recipes need to specify one or the other for the correct download.

However this variable cannot be reused in building Munki's `supported_architectures` array requiring the use of a second variable to specify `x86_64`.

**EXAMPLES:**
https://github.com/autopkg/gregneagle-recipes/blob/master/Podman/Podman.munki.recipe#L7-L8
https://github.com/autopkg/timsutton-recipes/blob/master/Go/Go.munki.recipe#L18-L22

By having Munki support both `x86_64` and `amd64` as equivalents, it allows the simplification of dual-architecture AutoPkg recipes.

**LOGS:**
Before change:
```
    * Processing manifest item test.amd64 for optional install
    Looking for detail for: test.amd64, version latest...
    Considering 1 items with name test.amd64 from catalog development
    Considering item test.amd64, version 0.2.8 with minimum os version required 14.0
    Our OS version is 14.5
    Considering item test.amd64, version 0.2.8 with supported architectures: (
    amd64
)
    Our architecture is x86_64
    Not found
    Rejected item test.amd64, version 0.2.8 with supported architectures: (
    amd64
). Our architecture is x86_64.

    * Processing manifest item test.arm64 for optional install
    Looking for detail for: test.arm64, version latest...
    Considering 1 items with name test.arm64 from catalog development
    Considering item test.arm64, version 0.2.8 with minimum os version required 14.0
    Our OS version is 14.5
    Considering item test.arm64, version 0.2.8 with supported architectures: (
    arm64
)
    Our architecture is x86_64
    Not found
    Rejected item test.arm64, version 0.2.8 with supported architectures: (
    arm64
). Our architecture is x86_64.

    * Processing manifest item test.x86 for optional install
    Looking for detail for: test.x86, version latest...
    Considering 1 items with name test.x86 from catalog development
    Considering item test.x86, version 0.2.8 with minimum os version required 14.0
    Our OS version is 14.5
    Considering item test.x86, version 0.2.8 with supported architectures: (
    "x86_64"
)
    Our architecture is x86_64
    Found test.x86, version 0.2.8 in catalog development
    Checking existence of /usr/local/bin/test...
    Adding test.x86 to the optional install list
```
After change:
```
    * Processing manifest item test.amd64 for optional install
    Looking for detail for: test.amd64, version latest...
    Considering 1 items with name test.amd64 from catalog development
    Considering item test.amd64, version 0.2.8 with minimum os version required 14.0
    Our OS version is 14.5
    Considering item test.amd64, version 0.2.8 with supported architectures: (
    amd64
)
    Our architecture is x86_64
    Found test.amd64, version 0.2.8 in catalog development
    Checking existence of /usr/local/bin/test...
    Adding test.amd64 to the optional install list

    * Processing manifest item test.arm64 for optional install
    Looking for detail for: test.arm64, version latest...
    Considering 1 items with name test.arm64 from catalog development
    Considering item test.arm64, version 0.2.8 with minimum os version required 14.0
    Our OS version is 14.5
    Considering item test.arm64, version 0.2.8 with supported architectures: (
    arm64
)
    Our architecture is x86_64
    Not found
    Rejected item test.arm64, version 0.2.8 with supported architectures: (
    arm64
). Our architecture is x86_64.

    * Processing manifest item test.x86 for optional install
    Looking for detail for: test.x86, version latest...
    Considering 1 items with name test.x86 from catalog development
    Considering item test.x86, version 0.2.8 with minimum os version required 14.0
    Our OS version is 14.5
    Considering item test.x86, version 0.2.8 with supported architectures: (
    "x86_64"
)
    Our architecture is x86_64
    Found test.x86, version 0.2.8 in catalog development
    Checking existence of /usr/local/bin/test...
    Adding test.x86 to the optional install list
```
makepkginfo before:
```
 % makepkginfo -f /Applications/Managed\ Software\ Center.app --arch amd64
Usage: makepkginfo [options] [/path/to/installeritem]
       makepkginfo --help for more information.

makepkginfo: error: option --arch: invalid choice: 'amd64' (choose from 'i386', 'x86_64', 'arm64')
```
makepkginfo after:
```
% makepkginfo -f /Applications/Managed\ Software\ Center.app --arch amd64
....
	</array>
	<key>supported_architectures</key>
	<array>
		<string>amd64</string>
	</array>
	<key>version</key>
... 
```