### PR TITLE
Update make_munki_mpkg.sh to set no restart for launchd component package 

### DIFF
--- a/code/tools/make_munki_mpkg.sh
+++ b/code/tools/make_munki_mpkg.sh
@@ -102,7 +102,7 @@ do
         "A")
             AUTORUNPKG=YES
             ;;
-        "R") 
+        "R")
             ROSETTA2=YES
             ;;
         "T")
@@ -624,7 +624,7 @@ if [ -d "$MUNKIROOT/code/tools/pkgresources/launchd_cleanup_scripts/" ] ; then
 fi
 
 # Create package info file.
-makeinfo launchd "$PKGTMP/info" restart
+makeinfo launchd "$PKGTMP/info" norestart
 
 
 #######################
@@ -748,7 +748,7 @@ if [ "$AUTORUNPKG" == "YES" ] ; then
 
     # Create package info file.
     makeinfo autorun "$PKGTMP/info" norestart
-    
+
 fi
 
 


### PR DESCRIPTION
The munkitools_launchd.pkg component package in Munki 6.6 beta 1 is still built with a postinstall-action="restart"

This fix modifies make_munki_mpkg.sh to build it with norestart to reflect changes in Munki 6.6 to not require a restart when updating the launchd items.
