### PR TITLE
Add --show-config-plist option

### DIFF
--- a/code/client/managedsoftwareupdate.py
+++ b/code/client/managedsoftwareupdate.py
@@ -660,6 +660,9 @@ def main():
         '--show-config', action='store_true',
         help='Print the current configuration and exit.')
     config_options.add_option(
+        '--show-config-plist', action='store_true',
+        help='Print the current configuration as a plist and exit.')
+    config_options.add_option(
         '--id', default=u'',
         help='String to use as ClientIdentifier for this run only.')
     config_options.add_option(
@@ -721,6 +724,11 @@ def main():
 
     if options.show_config:
         prefs.print_config()
+        sys.exit(0)
+
+
+    if options.show_config_plist:
+        prefs.print_config_plist()
         sys.exit(0)
 
     if options.set_bootstrap_mode:

--- a/code/client/munkilib/prefs.py
+++ b/code/client/munkilib/prefs.py
@@ -43,6 +43,8 @@ from Foundation import kCFPreferencesCurrentHost
 from .constants import BUNDLE_ID
 from .wrappers import is_a_string
 
+from . import FoundationPlist
+
 #####################################################
 # managed installs preferences/metadata
 #####################################################
@@ -278,6 +280,27 @@ def get_config_level(domain, pref_name, value):
         return '[default]'
     return '[unknown]'
 
+
+def print_config_plist():
+    '''Prints the current Munki configuration in plist format'''
+    output = []
+    for pref_name in sorted(DEFAULT_PREFS):
+        if pref_name == 'LastNotifiedDate':
+            # skip it
+            continue
+        else:
+            value = pref(pref_name)
+            where = get_config_level(BUNDLE_ID, pref_name, value)
+        if value is None:
+            value = "None"
+        
+        if where.startswith('[') and where.endswith(']'):
+            where = where[1:-1]
+
+        item = {'preference': pref_name, 'value': value, 'source': where}
+        output.append(item)
+    
+    print(FoundationPlist.writePlistToString(output).decode('UTF-8'))
 
 def print_config():
     '''Prints the current Munki configuration'''


### PR DESCRIPTION
This adds an option to `managedsoftwareupdate` that will allow the operator to display the current Munki configuration as a plist.