### PR TITLE
Add build script scaffold for swift munki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ code/apps/munkishim/build/
 # ignore any pkgs build by tool scripts
 munkitools*.pkg
 Python.framework
+
+# ignore paths related to building swift munki
+code/cli/munki/build/

--- a/code/tools/build_swift_munki.zsh
+++ b/code/tools/build_swift_munki.zsh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+
+check_exit_code() {
+    if [ "$1" != "0" ]; then
+        echo "$2: $1" 1>&2
+        exit 1
+    fi
+}
+
+SWIFT_MUNKI_DIR="./cli/munki"
+
+# Build makecatalogs
+xcodebuild -project "$SWIFT_MUNKI_DIR/munki.xcodeproj" -scheme makecatalogs build
+check_exit_code "$?" "Error building makecatalogs"
+
+# Build makepkginfo
+xcodebuild -project "$SWIFT_MUNKI_DIR/munki.xcodeproj" -scheme makepkginfo build
+check_exit_code "$?" "Error building makepkginfo"


### PR DESCRIPTION
Scaffold for a swift munki build script. 

Meant to be run from the code directory: 

```
cd code
./tools/build_swift_munki.zsh
```

Then, build artifacts can be found in:
```
 ls cli/munki/build/Products/Debug 
ArgumentParser.o                        ArgumentParserToolInfo.swiftmodule      makecatalogs.swiftmodule
ArgumentParser.swiftmodule              PackageFrameworks                       makepkginfo
ArgumentParserToolInfo.o                makecatalogs                            makepkginfo.swiftmodule
```

I looked at Nudge and somehow its building to `./build` instead and I cannot figure out for the life of me how @erikng got that to work. Not sure if Xcode 16.2 thing or if I'm missing something obvious.