### PR TITLE
Update pkgutils.py

### DIFF
--- a/code/client/munkilib/pkgutils.py
+++ b/code/client/munkilib/pkgutils.py
@@ -518,7 +518,8 @@ def getFlatPackageInfo(pkgpath):
 
         productversion = None
         for toc_entry in [item for item in toc
-                          if item.startswith('Distribution')]:
+                          if item.startswith('Distribution') and not
+                          item.startswith('Distribution.pkg')]:
             # Extract the Distribution file
             cmd_extract = ['/usr/bin/xar', '-xf', abspkgpath, toc_entry]
             result = subprocess.call(cmd_extract)


### PR DESCRIPTION
We hit an error when trying to import the PKG available from - https://www.meta.com/en-gb/help/quest/569381194082673/

The issue seems to stem from the fact that the flat.pkg contains a component PKG called Distribution, as per the below when unpacked:

![Screenshot 2025-03-26 at 14 30 29](https://github.com/user-attachments/assets/ba7c9c34-b8cc-4939-a071-9ae62deadf61)

Which, when importing results an error like what is shown below:

```
% /usr/local/munki/munkiimport /Users/ben.toms/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Meta\ Quest\ Remote\ Desktop/downloads/MetaQuestRemoteDesktop.pkg --repo_url=file:///Users/Shared/munki_repo
/tmp/munki-r3vj45uj/tmp21p5nwqd/Distribution.pkg
Traceback (most recent call last):
  File "/usr/local/munki/munkiimport", line 608, in <module>
    main()
  File "/usr/local/munki/munkiimport", line 379, in main
    pkginfo = pkginfolib.makepkginfo(installer_item, options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/munkilib/admin/pkginfolib.py", line 449, in makepkginfo
    pkginfo = get_catalog_info_from_path(installeritem, options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/munkilib/admin/pkginfolib.py", line 83, in get_catalog_info_from_path
    cataloginfo = pkgutils.getPackageMetaData(pkgpath)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/munkilib/pkgutils.py", line 873, in getPackageMetaData
    receiptinfo = getReceiptInfo(pkgitem)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/munkilib/pkgutils.py", line 667, in getReceiptInfo
    info = getFlatPackageInfo(pkgname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/munkilib/pkgutils.py", line 529, in getFlatPackageInfo
    productversion = getProductVersionFromDist(distributionabspath)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/munkilib/pkgutils.py", line 366, in getProductVersionFromDist
    dom = minidom.parse(filename)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/Python.framework/Versions/3.12/lib/python3.12/xml/dom/minidom.py", line 1990, in parse
    return expatbuilder.parse(file)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/munki/Python.framework/Versions/3.12/lib/python3.12/xml/dom/expatbuilder.py", line 907, in parse
    with open(file, 'rb') as fp:
         ^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: '/tmp/munki-r3vj45uj/tmp21p5nwqd/Distribution.pkg'
```

This PR resolves this, by amending the check that expands the Distribution items to ignore items that start with `Distribution.pkg`.