### PR TITLE
Custom sidebar localized_strings

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController+NSOutlineView.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController+NSOutlineView.swift
@@ -54,11 +54,6 @@ extension MainWindowController: NSOutlineViewDelegate {
 
         let isSelected = (sidebarList.row(forItem: item) == sidebarList.selectedRow)
 
-        if let localized_title = sidebarItem.localized_title {
-            let availableLocales = localized_title.keys
-            // TODO: actually use the localized titles
-        }
-
         view.title.stringValue = sidebarItem.title.localized(withComment: "\(sidebarItem.title) label")
         view.title.textColor = isSelected ? .controlAccentColor : .labelColor
 

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -23,7 +23,6 @@ enum SidebarPage: String {
 }
 
 class MainWindowController: NSWindowController {
-    
     var mainWindowConfigurationComplete = false
     var _alertedUserToOutstandingUpdates = false
     var _update_in_progress = false
@@ -43,7 +42,6 @@ class MainWindowController: NSWindowController {
     var forceFrontmost = false
     
     // Cocoa UI binding properties
-    
     @IBOutlet weak var sidebarViewController: SidebarViewController!
     @IBOutlet weak var mainContentViewController: MainContentViewController!
     @IBOutlet weak var toolbar: NSToolbar!
@@ -124,14 +122,29 @@ class MainWindowController: NSWindowController {
         // because SF Symbols only supported on 11.0 or later
         var sidebarItems: [SidebarItem] = []
         if #available(macOS 11.0, *) {
-            if let configItems = pref("CustomSidebarItems") as? [[String: String]] {
+            if let configItems = pref("CustomSidebarItems") as? [[String: Any]] {
                 for item in configItems {
-                    guard let title = item["title"],
-                          let icon = item["icon"],
-                          let page = item["page"] else {
+                    guard let title = item["title"] as? String,
+                          let icon = item["icon"] as? String,
+                          let page = item["page"] as? String else {
                         continue
                     }
-                    sidebarItems.append(SidebarItem(title: title, icon: icon, page: page))
+
+                    var finalTitle = title
+                    var finalPage = page
+                    if let localizedStrings = item["localized_strings"] as? [String: Any],
+                       let langCode = Locale.current.languageCode {
+                        if let dict = localizedStrings[langCode] as? [String: String] {
+                            if let localizedTitle = dict["title"] {
+                                finalTitle = localizedTitle
+                            }
+                            if let localizedPage = dict["page"] {
+                                finalPage = localizedPage
+                            }
+                        }
+                    }
+
+                    sidebarItems.append(SidebarItem(title: finalTitle, icon: icon, page: finalPage))
                 }
             }
         }

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -13,7 +13,6 @@ struct SidebarItem {
     let title: String
     let icon: String
     let page: String
-    let localized_title: [String: String]?
 }
 
 class MainWindowController: NSWindowController {
@@ -168,12 +167,25 @@ class MainWindowController: NSWindowController {
                   let page = item["page"] as? String else {
                 continue
             }
-            let localized_title = item["localized_title"] as? [String: String]
+            
+            var finalTitle = title
+            var finalPage = page
+            if let localizedStrings = item["localized_strings"] as? [String: Any],
+               let langCode = Locale.current.languageCode {
+                if let dict = localizedStrings[langCode] as? [String: String] {
+                    if let localizedTitle = dict["title"] {
+                        finalTitle = localizedTitle
+                    }
+                    if let localizedPage = dict["page"] {
+                        finalPage = localizedPage
+                    }
+                }
+            }
+
             sidebarItems.append(SidebarItem(
-                title: title,
+                title: finalTitle,
                 icon: icon,
-                page: page,
-                localized_title: localized_title
+                page: finalPage
             ))
         }
         // update Navigate menu to reflect the sidebar contents


### PR DESCRIPTION
I have played around with the localized titel. The configuration is now built in such a way that both title and page can be defined alternatively.
Also another link can be given -> here example with Google:

```
 <dict>
        <key>title</key>
        <string>My Homepage</string>
        <key>icon</key>
        <string>book.pages</string>
        <key>page</key>
        <string>https://google.com</string>
        <key>localized_strings</key>
        <dict>
            <key>de</key>
            <dict>
                <key>title</key>
                <string>Meine Webseite</string>
                <key>page</key>
                <string>https://google.de</string>
            </dict>
        </dict>
    </dict>
```

<img width="747" height="436" alt="image" src="https://github.com/user-attachments/assets/3ff7ef47-e1f6-42a0-8715-fde3eabc713a" />
