### PR TITLE
Fix path traversal in load_page

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -936,12 +936,28 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     func load_page(_ url_fragment: String) {
         // Tells the WebView to load the appropriate page
         msc_debug_log("load_page request for \(url_fragment)")
+
+        let baseURL = URL(fileURLWithPath: htmlDir).standardizedFileURL
+        let requestURL = baseURL.appendingPathComponent(url_fragment).standardizedFileURL
         
-        let html_file = NSString.path(withComponents: [htmlDir, url_fragment])
-        let request = URLRequest(url: URL(fileURLWithPath: html_file),
-                                 cachePolicy: .reloadIgnoringLocalCacheData,
-                                 timeoutInterval: TimeInterval(10.0))
+        let baseComponents = baseURL.pathComponents
+        let requestComponents = requestURL.pathComponents
+
+        guard requestComponents.starts(with: baseComponents) else {
+            msc_debug_log("Attempt to access file outside htmlDir: \(url_fragment)")
+            let errorURL = baseURL.appendingPathComponent("error.html")
+            webView.load(URLRequest(url: errorURL))
+            return
+        }
+        
+        let request = URLRequest(
+            url: requestURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 10.0
+        )
+        
         webView.load(request)
+        
         if url_fragment == "updates.html" {
             if !_update_in_progress && NSApp.isActive {
                 // clear all earlier update notifications


### PR DESCRIPTION
This PR resolves a fairly minor/low risk path traversal issue in `load_page` by resolving both the base directory and requested path to their canonical form (`.standardizedFileURL`) and verifying via `pathComponents.starts(with:)` that the request remains within the base directory.

If this needs any changes or you think something should be different here  please let me know. I tried to keep this one short and sweet, and after fuzzing a bit to try to find some combo of obscure characters that could somehow get around this check I was unable, so this should fix this for good.