### PR TITLE
Update pkginfolib.py - Fix incomplete metadata extraction for audio plugins and other bundles

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -936,12 +936,28 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
     func load_page(_ url_fragment: String) {
         // Tells the WebView to load the appropriate page
         msc_debug_log("load_page request for \(url_fragment)")
+
+        let baseURL = URL(fileURLWithPath: htmlDir).standardizedFileURL
+        let requestURL = baseURL.appendingPathComponent(url_fragment).standardizedFileURL
         
-        let html_file = NSString.path(withComponents: [htmlDir, url_fragment])
-        let request = URLRequest(url: URL(fileURLWithPath: html_file),
-                                 cachePolicy: .reloadIgnoringLocalCacheData,
-                                 timeoutInterval: TimeInterval(10.0))
+        let baseComponents = baseURL.pathComponents
+        let requestComponents = requestURL.pathComponents
+
+        guard requestComponents.starts(with: baseComponents) else {
+            msc_debug_log("Attempt to access file outside htmlDir: \(url_fragment)")
+            let errorURL = baseURL.appendingPathComponent("error.html")
+            webView.load(URLRequest(url: errorURL))
+            return
+        }
+        
+        let request = URLRequest(
+            url: requestURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 10.0
+        )
+        
         webView.load(request)
+        
         if url_fragment == "updates.html" {
             if !_update_in_progress && NSApp.isActive {
                 // clear all earlier update notifications


### PR DESCRIPTION
Hi, Greg 

I found when creating Install Arrays for Audio Plugins only the CFBundleVersion and CFBundleShortVersionString would get populated. This PR updates `pkginfolib.py` so that they're handled in the same way as Application Bundles. 

Thanks! 


## Problem Summary

The `getiteminfo()` function in `pkginfolib.py` currently provides inconsistent metadata extraction between applications (.app files) and other bundle types (audio plugins like .vst, .component, .aaxplugin, .vst3).

**Current behavior:**
- ✅ **Applications (.app)**: Extract comprehensive metadata including `CFBundleName`, `CFBundleIdentifier`, `CFBundleShortVersionString`, `CFBundleVersion`, and `LSMinimumSystemVersion`
- ❌ **Other bundles**: Only extract `CFBundleShortVersionString` and `CFBundleVersion`

This results in incomplete installs arrays for audio plugins and other bundle types, missing critical metadata for proper tracking and identification.

## Impact

Audio plugin packages (and other non-application bundles) generate installs array entries like this:

**Before (incomplete):**
```xml
<dict>
    <key>CFBundleVersion</key>
    <string>4.5</string>
    <key>path</key>
    <string>/Library/Audio/Plug-Ins/VST/BC Chorus 4 VST(Mono).vst</string>
    <key>type</key>
    <string>bundle</string>
    <key>version_comparison_key</key>
    <string>CFBundleVersion</string>
</dict>
```

**After (complete):**
```xml
<dict>
    <key>CFBundleIdentifier</key>
    <string>com.bluecataudio.bc-chorus-4-vst-mono-</string>
    <key>CFBundleVersion</key>
    <string>4.5</string>
    <key>minosversion</key>
    <string>10.9</string>
    <key>path</key>
    <string>/Library/Audio/Plug-Ins/VST/BC Chorus 4 VST(Mono).vst</string>
    <key>type</key>
    <string>bundle</string>
    <key>version_comparison_key</key>
    <string>CFBundleVersion</string>
</dict>
```

## Root Cause

In the `getiteminfo()` function, the bundle handling section only extracts version-related keys:

```python
# Current problematic code
for key in ['CFBundleShortVersionString', 'CFBundleVersion']:
    if key in plist:
        infodict[key] = plist[key]
```

While the application handling section extracts comprehensive metadata:

```python
# Application code (working correctly)
for key in ['CFBundleName', 'CFBundleIdentifier',
            'CFBundleShortVersionString', 'CFBundleVersion']:
    if key in plist:
        infodict[key] = plist[key]
# Plus LSMinimumSystemVersion handling
```

## Solution

Align bundle metadata extraction with application metadata extraction by expanding the bundle handling section to extract the same keys and minimum OS version information.

## Files Changed

- `code/client/munkilib/pkginfolib.py` - Modified `getiteminfo()` function

## Changes Made

**Modified bundle handling section in `getiteminfo()` function:**

```python
elif (os.path.exists(os.path.join(itempath, 'Contents', 'Info.plist')) or
      os.path.exists(os.path.join(itempath, 'Resources', 'Info.plist'))):
    infodict['type'] = 'bundle'
    infodict['path'] = itempath
    plist = pkgutils.getBundleInfo(itempath)
    # Extract the same keys as applications
    for key in ['CFBundleName', 'CFBundleIdentifier',
                'CFBundleShortVersionString', 'CFBundleVersion']:
        if key in plist:
            infodict[key] = plist[key]
    # Also extract minimum OS version info like applications
    if 'LSMinimumSystemVersion' in plist:
        infodict['minosversion'] = plist['LSMinimumSystemVersion']
    elif 'LSMinimumSystemVersionByArchitecture' in plist:
        # just grab the highest version if more than one is listed
        versions = [item[1] for item in
                    plist['LSMinimumSystemVersionByArchitecture'].items()]
        highest_version = str(max([pkgutils.MunkiLooseVersion(version)
                                   for version in versions]))
        infodict['minosversion'] = highest_version
    elif 'SystemVersionCheck:MinimumSystemVersion' in plist:
        infodict['minosversion'] = \
            plist['SystemVersionCheck:MinimumSystemVersion']
```

## Benefits

1. **Consistent metadata extraction**: All bundle types now get the same comprehensive metadata as applications
2. **Better plugin tracking**: Audio plugins (.vst, .component, .aaxplugin, .vst3) now have unique identifiers
3. **Improved OS compatibility**: Minimum OS version detection for all bundle types
4. **Enhanced debugging**: More metadata available for troubleshooting installs array issues
5. **Future-proof**: Any bundle type with standard Info.plist structure will benefit

## Affected Bundle Types

This fix applies to all bundle types that aren't applications, including:
- Audio Unit Components (`.component`)
- VST Plugins (`.vst`)
- VST3 Plugins (`.vst3`)
- AAX Plugins (`.aaxplugin`)
- Other macOS bundles with Info.plist files

## Testing

Verified with Blue Cat Audio plugins that all plugin formats now extract:
- `CFBundleIdentifier` (when present)
- `CFBundleName` (when present, particularly in AAX plugins)
- `LSMinimumSystemVersion` converted to `minosversion`
- Existing version extraction continues to work
- Some AutoPkg Recipe's that can be used for testing
-- https://github.com/autopkg/dataJAR-recipes/tree/master/Blue%20Cat%20Chorus
-- https://github.com/autopkg/dataJAR-recipes/tree/master/Blue%20Cat%20Flanger
-- https://github.com/autopkg/dataJAR-recipes/tree/master/Blue%20Cat%20Free%20Amp
-- https://github.com/autopkg/dataJAR-recipes/tree/master/Blue%20Cat%20Freeceiver
-- https://github.com/autopkg/dataJAR-recipes/tree/master/Blue%20Cat%20FreqAnalyst
-- https://github.com/autopkg/dataJAR-recipes/tree/master/Blue%20Cat%20Gain%20Suite
-- https://github.com/autopkg/dataJAR-recipes/tree/master/Blue%20Cat%20Phaser
-- https://github.com/autopkg/dataJAR-recipes/tree/master/Blue%20Cat%20Triple%20EQ
