### PR TITLE
Spelling fixes for Munki 7 branch

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center.xcodeproj/project.pbxproj
+++ b/code/apps/Managed Software Center/Managed Software Center.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		56C33E772173DC8E00D727DC /* MSCTableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56C33E762173DC8E00D727DC /* MSCTableRowView.swift */; };
 		56C33E812174D7A200D727DC /* MSCTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56C33E802174D7A200D727DC /* MSCTableCellView.swift */; };
-		8428C7E42E0CB41F00D83D41 /* SidebarViewControiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8428C7E32E0CB41F00D83D41 /* SidebarViewControiller.swift */; };
+		8428C7E42E0CB41F00D83D41 /* SidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8428C7E32E0CB41F00D83D41 /* SidebarViewController.swift */; };
 		8428C7E62E0CB44200D83D41 /* MainContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8428C7E52E0CB44200D83D41 /* MainContentViewController.swift */; };
 		8428C7E82E0CB55000D83D41 /* MainSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8428C7E72E0CB55000D83D41 /* MainSplitViewController.swift */; };
 		8428C7EA2E0CB59200D83D41 /* MainWindowController+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8428C7E92E0CB59200D83D41 /* MainWindowController+Toolbar.swift */; };
@@ -84,7 +84,7 @@
 		56C33E7821740B6F00D727DC /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		56C33E7921740D9B00D727DC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		56C33E802174D7A200D727DC /* MSCTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSCTableCellView.swift; sourceTree = "<group>"; };
-		8428C7E32E0CB41F00D83D41 /* SidebarViewControiller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewControiller.swift; sourceTree = "<group>"; };
+		8428C7E32E0CB41F00D83D41 /* SidebarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewController.swift; sourceTree = "<group>"; };
 		8428C7E52E0CB44200D83D41 /* MainContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContentViewController.swift; sourceTree = "<group>"; };
 		8428C7E72E0CB55000D83D41 /* MainSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSplitViewController.swift; sourceTree = "<group>"; };
 		8428C7E92E0CB59200D83D41 /* MainWindowController+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainWindowController+Toolbar.swift"; sourceTree = "<group>"; };
@@ -295,7 +295,7 @@
 				C0546BD520FBE61A003FE5A6 /* MSCAlertController.swift */,
 				C0546BDB20FE961E003FE5A6 /* MSCPasswordAlertController.swift */,
 				C012D5332C25121F004FDB5A /* BlurredBackgroundController.swift */,
-				8428C7E32E0CB41F00D83D41 /* SidebarViewControiller.swift */,
+				8428C7E32E0CB41F00D83D41 /* SidebarViewController.swift */,
 				8428C7E52E0CB44200D83D41 /* MainContentViewController.swift */,
 				8428C7E72E0CB55000D83D41 /* MainSplitViewController.swift */,
 				8428C7EF2E0DABC700D83D41 /* LogWindowController.swift */,
@@ -479,7 +479,7 @@
 				849BF6382E104F74004A020D /* MainWindowController+NSOutlineView.swift in Sources */,
 				C0E2599E210AD8CE00C3A3D9 /* Socket.swift in Sources */,
 				C01603D120D0A7FA00DEF9E4 /* SelfService.swift in Sources */,
-				8428C7E42E0CB41F00D83D41 /* SidebarViewControiller.swift in Sources */,
+				8428C7E42E0CB41F00D83D41 /* SidebarViewController.swift in Sources */,
 				C04F82A120BB77CF00F9C57D /* FoundationPlist.swift in Sources */,
 				C0BCAD7D2442A0B3001D2FDD /* appleupdates.swift in Sources */,
 				C04CA61E20E6ADA100711461 /* MainWindowController.swift in Sources */,

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -145,7 +145,7 @@ class MSCAlertController: NSObject {
             alert.informativeText = NSLocalizedString(
                 "Your administrator has restricted installation of these updates. Contact your administrator for assistance.",
                 comment: "Apple Software Updates Unable detail")
-            // disable insstall now button
+            // disable install now button
             alert.buttons[0].isEnabled = false
         } else {
             // prompt user to install using System Preferences

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainContentViewController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainContentViewController.swift
@@ -1,5 +1,5 @@
 //
-//  MainContentViewControiller.swift
+//  MainContentViewController.swift
 //  Managed Software Center
 //
 //  Created by Greg Neagle on 6/25/25.

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController+Toolbar.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController+Toolbar.swift
@@ -54,15 +54,15 @@ extension MainWindowController: NSToolbarDelegate {
                 pageLoadProgress!.controlSize = .small
                 pageLoadProgress!.isDisplayedWhenStopped = false
             }
-            let progressSoinner = customToolbarItem(
+            let progressSpinner = customToolbarItem(
                 itemForItemIdentifier: NSToolbarItem.Identifier.progressIndicatorItem.rawValue,
                 label: "Progress",
                 paletteLabel: "Progress",
                 toolTip: "Shows page load progress",
                 itemContent: pageLoadProgress!
             )
-            progressSoinner?.isBordered = false
-            return progressSoinner
+            progressSpinner?.isBordered = false
+            return progressSpinner
         case .navigationGoBackItem:
             let toolbarItem = customToolbarItem(
                 itemForItemIdentifier: NSToolbarItem.Identifier.navigationGoBackItem.rawValue,

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -75,7 +75,7 @@ class MainWindowController: NSWindowController {
         let mainContentItem = NSSplitViewItem(viewController: mainContentViewController)
         // TODO: remove this after Xcode 26 ships and if/when require Xcode 26+ to build
         // we use this stupid condition because PermissionKit was introduced in the macOS 26 SDK
-        // and there's no other straightforward way to do conditional compliation based on SDK
+        // and there's no other straightforward way to do conditional compilation based on SDK
         // availability
         #if canImport(PermissionKit)
         if #available(macOS 26.0, *) {
@@ -426,7 +426,7 @@ class MainWindowController: NSWindowController {
             }
         } else {
             // if there are non-munki:// items in the sidebar,
-            // make sure the sidebar is visbile
+            // make sure the sidebar is visible
             hideMunkiNavigateMenuItems(false)
             // ensure sidebar is visible
             guard let firstSplitView = splitViewController.splitViewItems.first else { return }
@@ -696,7 +696,7 @@ class MainWindowController: NSWindowController {
             /*
             // TODO: remove this when Xcode 26 ships and we require it to build
             // we use this stupid condition because PermissionKit was introduced in the macOS 26 SDK
-            // and there's no other straightforward way to do conditional compliation based on SDK
+            // and there's no other straightforward way to do conditional compilation based on SDK
             // availability
             #if canImport(PermissionKit)
             if #available(macOS 26.0, *) {
@@ -1050,7 +1050,7 @@ class MainWindowController: NSWindowController {
     }
     
     func displayUpdatesProgressSpinner(_ shouldDisplay: Bool) {
-        // check if update sidebar item avalible
+        // check if update sidebar item available
         guard let cellView = updatesSidebarItemView() else {
             return
         }

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/SidebarViewController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/SidebarViewController.swift
@@ -1,5 +1,5 @@
 //
-//  SidebarViewControiller.swift
+//  SidebarViewController.swift
 //  Managed Software Center
 //
 //  Created by Greg Neagle on 6/25/25.

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -1411,7 +1411,7 @@ func dependentItems(_ item_name: String) -> [String] {
     // optional item
     if !Cache.shared.keys.contains("optional_installs_with_dependencies") {
         let self_service_installs = SelfService().installs
-        if let optional_installs = cachedInstallInfo()["optional_instslls"] as? [PlistDict] {
+        if let optional_installs = cachedInstallInfo()["optional_installs"] as? [PlistDict] {
             Cache.shared["optional_installs_with_dependencies"] = (
                 optional_installs.filter(
                     {

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiURL.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiURL.swift
@@ -16,7 +16,7 @@ enum MunkiURL: String {
     case updates = "munki://updates"
 }
 
-/// "Normalzes" several string formats into a standard munki:// URL
+/// "Normalizes" several string formats into a standard munki:// URL
 func munkiURL(from urlString: String) -> String {
     let basename = (urlString as NSString).lastPathComponent
     return "munki://" + ((basename as NSString).deletingPathExtension)

--- a/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/updates.js
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/updates.js
@@ -63,9 +63,9 @@ function registerWindowClicks() {
                 // clicked a More link
                 item_description = e.target.parentNode.getElementsByClassName('description')[0];
                 item_version_and_size = e.target.parentNode.parentNode.getElementsByClassName('version_and_size')[0];
-                modal_descritption = document.getElementById("fullDescription")
+                modal_description = document.getElementById("fullDescription")
                 modal_version_and_size = document.getElementById("versionAndSize")
-                modal_descritption.innerHTML = item_description.innerHTML
+                modal_description.innerHTML = item_description.innerHTML
                 modal_version_and_size.innerHTML = item_version_and_size.innerHTML
                 modal = document.getElementById("moreInfoModal");
                 modal.style.display = "block";

--- a/code/apps/Managed Software Center/Managed Software Center/msclib.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/msclib.swift
@@ -127,7 +127,7 @@ func linkOrCopy(_ sourcePath: String, _ destPath: String) {
     if prefer_symlink {
         do {
             // symlinks sort of invert the idea of source and destination.
-            // in this case, sourcePath is the orignal content in its "real" location
+            // in this case, sourcePath is the original content in its "real" location
             // and destPath is where the symlink itself resides
             try FileManager.default.createSymbolicLink(atPath: destPath, withDestinationPath: sourcePath)
         } catch {

--- a/code/cli/munki/appusaged/main.swift
+++ b/code/cli/munki/appusaged/main.swift
@@ -227,7 +227,7 @@ func main() async -> Int32 {
 
     // get socket file descriptor from launchd
     guard let socketFD = try? getSocketFd(APPNAME) else {
-        munkiLog("Could not get socket decriptor from launchd", logFile: APPUSAGED_LOGFILENAME)
+        munkiLog("Could not get socket descriptor from launchd", logFile: APPUSAGED_LOGFILENAME)
         usleep(1_000_000 * 10)
         return -1
     }

--- a/code/cli/munki/authrestartd/main.swift
+++ b/code/cli/munki/authrestartd/main.swift
@@ -322,7 +322,7 @@ func main() async -> Int32 {
 
     // get socket file descriptor from launchd
     guard let socketFD = try? getSocketFd(APPNAME) else {
-        munkiLog("Could not get socket decriptor from launchd", logFile: LOGFILENAME)
+        munkiLog("Could not get socket descriptor from launchd", logFile: LOGFILENAME)
         usleep(1_000_000 * 10)
         return -1
     }

--- a/code/cli/munki/authrestartd/main.swift
+++ b/code/cli/munki/authrestartd/main.swift
@@ -46,7 +46,7 @@ class FDEUtil {
         }
     }
 
-    /// Convenience method: logs a message, then returns it so we can thow an error
+    /// Convenience method: logs a message, then returns it so we can throw an error
     /// with the same message
     func logAndReturn(_ message: String) -> String {
         server.log(message)

--- a/code/cli/munki/installhelper/main.swift
+++ b/code/cli/munki/installhelper/main.swift
@@ -18,7 +18,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// original Python implmentation by Ben Toms @ Jamf (dataJAR)
+// original Python implementation by Ben Toms @ Jamf (dataJAR)
 
 import Foundation
 import SystemConfiguration
@@ -417,7 +417,7 @@ func main() {
     rotateLog(LOGFILENAME, ifLargerThan: 1_000_000)
     log("Starting \(APP_NAME) \(APP_VERSION)")
 
-    // get our launch group from either the enviroment or the first argument
+    // get our launch group from either the environment or the first argument
     var group = "<none>"
     var manualLaunch = true
     let env = ProcessInfo.processInfo.environment

--- a/code/cli/munki/logouthelper/main.swift
+++ b/code/cli/munki/logouthelper/main.swift
@@ -121,7 +121,7 @@ func main() -> Int32 {
     var logoutTimeOverride: Date?
     var logoutTime = Date.distantFuture
 
-    // minimium notification of 60 minutes + 3 seconds
+    // minimum notification of 60 minutes + 3 seconds
     let minimumNotificationMinutes = Double(MANDATORY_NOTIFICATIONS.max() ?? 60)
     let minimumNotificationsLogoutTime = Date().addingTimeInterval(60 * minimumNotificationMinutes + 30)
 

--- a/code/cli/munki/managedsoftwareupdate/msuutils.swift
+++ b/code/cli/munki/managedsoftwareupdate/msuutils.swift
@@ -220,7 +220,7 @@ func notifyUserOfUpdates(force: Bool = false) {
         // doesn't require exactly 24 hours to elapse
         // subtract 6 hours
         // IOW, if we notify today at 4pm, we don't really want to wait
-        // until after 4pm tomorrow to notifiy again.
+        // until after 4pm tomorrow to notify again.
         Double((daysBetweenNotifications * 24 * 60 * 60) - (6 * 60 * 60))
     } else {
         0.0

--- a/code/cli/munki/manifestutil/MUdisplayManifest.swift
+++ b/code/cli/munki/manifestutil/MUdisplayManifest.swift
@@ -124,7 +124,7 @@ extension ManifestUtil {
     }
 }
 
-/// Prints contents of a given manifest, expanding included maniifests
+/// Prints contents of a given manifest, expanding included manifests
 extension ManifestUtil {
     struct ExpandIncludedManifests: AsyncParsableCommand {
         static var configuration = CommandConfiguration(

--- a/code/cli/munki/manifestutil/MUmanifestEditing.swift
+++ b/code/cli/munki/manifestutil/MUmanifestEditing.swift
@@ -296,7 +296,7 @@ extension ManifestUtil {
     }
 }
 
-/// Add an inlcuded_manifest to a manifest
+/// Add an included_manifest to a manifest
 extension ManifestUtil {
     struct AddIncludedManifest: AsyncParsableCommand {
         static var configuration = CommandConfiguration(

--- a/code/cli/munki/manifestutil/MUmanifestFileOperations.swift
+++ b/code/cli/munki/manifestutil/MUmanifestFileOperations.swift
@@ -57,7 +57,7 @@ func copyOrRenameManifest(repo: Repo, sourceName: String, destinationName: Strin
     do {
         let data = try await repo.get("manifests/\(sourceName)")
         try await repo.put("manifests/\(destinationName)", content: data)
-        // TODO: on a case-insenstive file system this can end up deleting the file
+        // TODO: on a case-insensitive file system this can end up deleting the file
         // (If you rename "test" to "TEST", then delete "test" you actually delete "TEST")
         if deleteSource {
             try await repo.delete("manifests/\(sourceName)")

--- a/code/cli/munki/manifestutil/MUrunInteractive.swift
+++ b/code/cli/munki/manifestutil/MUrunInteractive.swift
@@ -77,7 +77,7 @@ class TabCompleter {
     /// this is a singleton, so only one instance, please
     private init() {}
 
-    /// retreive our lists of repo items and store them
+    /// retrieve our lists of repo items and store them
     func cache(manifestsOnly: Bool = false) async {
         debugLog("Caching completion data. manifestsOnly: \(manifestsOnly)")
         if let repo = RepoConnection.shared.repo {

--- a/code/cli/munki/munkiCLItesting/versionutilsTests.swift
+++ b/code/cli/munki/munkiCLItesting/versionutilsTests.swift
@@ -26,7 +26,7 @@ struct MunkiVersionTests {
         #expect(version1 == version2)
     }
 
-    /// Test that less-than comparision is numeric and not alpha
+    /// Test that less-than comparison is numeric and not alpha
     @Test func versionsCompareFoo() async throws {
         let version1 = MunkiVersion("1.2")
         let version2 = MunkiVersion("1.10")

--- a/code/cli/munki/munkiimport/munkiimport.swift
+++ b/code/cli/munki/munkiimport/munkiimport.swift
@@ -167,7 +167,7 @@ struct MunkiImport: AsyncParsableCommand {
         guard let repoURL = munkiImportOptions.repoURL,
               let plugin = munkiImportOptions.plugin
         else {
-            // won"t happen because we validated it earlier
+            // won't happen because we validated it earlier
             throw ExitCode(1)
         }
 

--- a/code/cli/munki/shared/UNIXProcessInfo.swift
+++ b/code/cli/munki/shared/UNIXProcessInfo.swift
@@ -114,7 +114,7 @@ func parseArgumentData(_ data: Data) throws -> [String] {
     //
     // <https://opensource.apple.com/source/adv_cmds/adv_cmds-176/ps/print.c.auto.html>
 
-    // returns a list of strings: [0] is the execuatable path,
+    // returns a list of strings: [0] is the executable path,
     // the rest is `argv[0]` through `argv[argc - 1]
 
     // Parse `argc`.  We’re assuming the value is little endian here, which is

--- a/code/cli/munki/shared/admin/makecatalogslib.swift
+++ b/code/cli/munki/shared/admin/makecatalogslib.swift
@@ -103,7 +103,7 @@ struct CatalogsMaker {
         return iconHashes
     }
 
-    /// Returns a case-insentitive match for installer_item from pkgsList, if any
+    /// Returns a case-insensitive match for installer_item from pkgsList, if any
     func caseInsensitivePkgsListContains(_ installer_item: String) -> String? {
         for repo_pkg in pkgsList {
             if installer_item.lowercased() == repo_pkg.lowercased() {

--- a/code/cli/munki/shared/admin/munkiimportlib.swift
+++ b/code/cli/munki/shared/admin/munkiimportlib.swift
@@ -358,10 +358,10 @@ func getIconIdentifier(_ pkginfo: PlistDict) -> String {
 
 /// Returns true if there is an icon for this item in the repo
 func iconIsInRepo(_ repo: Repo, pkginfo: PlistDict) async -> Bool {
-    let iconIdentifer = getIconIdentifier(pkginfo)
+    let iconIdentifier = getIconIdentifier(pkginfo)
     do {
         let iconList = try await listItemsOfKind(repo, "icons")
-        return iconList.contains(iconIdentifer)
+        return iconList.contains(iconIdentifier)
     } catch let error as MunkiError {
         printStderr("Unable to get list of icons: \(error.description)")
         return false

--- a/code/cli/munki/shared/admin/pkginfolib.swift
+++ b/code/cli/munki/shared/admin/pkginfolib.swift
@@ -85,7 +85,7 @@ func createInstallsItem(_ itempath: String) -> PlistDict {
             if let minOSVers = plist["LSMinimumSystemVersion"] as? String {
                 info["minosversion"] = minOSVers
             } else if let minOSVersByArch = plist["LSMinimumSystemVersionByArchitecture"] as? [String: String] {
-                // get the highest/latest of all the minmum os versions
+                // get the highest/latest of all the minimum os versions
                 let minOSVersions = minOSVersByArch.values
                 let versions = minOSVersions.map { MunkiVersion($0) }
                 if let maxVersion = versions.max() {
@@ -249,7 +249,7 @@ func createPkgInfoForDragNDrop(_ mountpoint: String, options: PkginfoOptions) th
 /// Mounts a disk image if it"s not already mounted
 /// Builds pkginfo for the first installer item found at the root level,
 /// or a specific one if specified by options.pkgname or options.item
-/// Unmounts the disk image if it wasn"t already mounted
+/// Unmounts the disk image if it wasn't already mounted
 func createPkgInfoFromDmg(_ dmgpath: String,
                           options: PkginfoOptions) throws -> PlistDict
 {

--- a/code/cli/munki/shared/admin/pkginfolib.swift
+++ b/code/cli/munki/shared/admin/pkginfolib.swift
@@ -544,7 +544,7 @@ func makepkginfo(_ filepath: String?,
         }
     }
     if let minimumMunkiVersion = options.other.minimumMunkiVersion {
-        pkginfo["miminum_munki_version"] = minimumMunkiVersion
+        pkginfo["minimum_munki_version"] = minimumMunkiVersion
     }
     if options.other.onDemand {
         pkginfo["OnDemand"] = true

--- a/code/cli/munki/shared/admin/readline.swift
+++ b/code/cli/munki/shared/admin/readline.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// This is a function that is called by our custom signal handlers that react to SIGINT or SIGTERM.
-/// Wtihout this, the terminal can be a mess if someone hits Control-C to interrupt the process while
+/// Without this, the terminal can be a mess if someone hits Control-C to interrupt the process while
 /// `readline` is waiting for input
 func cleanupReadline() {
     if rl_line_buffer != nil {
@@ -29,7 +29,7 @@ func cleanupReadline() {
 /// to insert the prompt and default text _after_ we fire up _readline_. Like I said, a nasty hack.
 func getInput(prompt: String? = nil, defaultText: String? = nil) -> String? {
     // A really awful hack to get default text since
-    // the readline implmentation is so broken
+    // the readline implementation is so broken
     let queue = OperationQueue()
     let insertOperation = BlockOperation {
         usleep(10000) // 0.01 seconds

--- a/code/cli/munki/shared/appleupdates.swift
+++ b/code/cli/munki/shared/appleupdates.swift
@@ -121,7 +121,7 @@ func filterOutMajorOSUpgrades(_ appleUpdates: [PlistDict]) -> [PlistDict] {
     // There's a couple of strategies we could use here:
     //
     //  1) Match update names that start with "macOS" and end with a version
-    //     number matching the uupdate version, then compare the first part
+    //     number matching the update version, then compare the first part
     //     of that version against the currently installed OS. IOW,
     //     if we are currently running 13.6.9, an update to 14.6.1 or 15.0
     //     would be a major update. This could break if Apple changes its

--- a/code/cli/munki/shared/authrestart.swift
+++ b/code/cli/munki/shared/authrestart.swift
@@ -106,7 +106,7 @@ func getAuthRestartKey(quiet: Bool = false) -> String? {
           let recoveryKey = recoveryKeyDict["RecoveryKey"] as? String
     else {
         if !quiet {
-            Authrestart.logger.error("Could not retreive recovery key from \(recoveryKeyPlist).")
+            Authrestart.logger.error("Could not retrieve recovery key from \(recoveryKeyPlist).")
         }
         return nil
     }

--- a/code/cli/munki/shared/authrestart.swift
+++ b/code/cli/munki/shared/authrestart.swift
@@ -195,7 +195,7 @@ func doAuthorizedOrNormalRestart(
             // notify that it did then perform a normal restart
             Authrestart.logger.warning("Authorized Restart failed. Performing normal restart...")
         } else {
-            // we sucessfully triggered an authrestart
+            // we successfully triggered an authrestart
             return
         }
     }

--- a/code/cli/munki/shared/authrestartclient.swift
+++ b/code/cli/munki/shared/authrestartclient.swift
@@ -83,7 +83,7 @@ class AuthRestartClient {
         return result.hasPrefix("OK")
     }
 
-    /// Returns Ttue if we are ready to attempt an auth restart
+    /// Returns True if we are ready to attempt an auth restart
     func verifyCanAttemptAuthRestart() throws -> Bool {
         let request = ["task": "verify_can_attempt_auth_restart"]
         let result = try process(request)

--- a/code/cli/munki/shared/bootstrapping.swift
+++ b/code/cli/munki/shared/bootstrapping.swift
@@ -104,7 +104,7 @@ func setBootstrapMode() throws {
         atPath: CHECKANDINSTALLATSTARTUPFLAG, contents: nil
     ) {
         resetFDEAutoLogin()
-        throw MunkiError("Could not reate bootstrapping flag file")
+        throw MunkiError("Could not create bootstrapping flag file")
     }
 }
 

--- a/code/cli/munki/shared/facts.swift
+++ b/code/cli/munki/shared/facts.swift
@@ -220,8 +220,8 @@ func predicateInfoObject() async -> PlistDict {
 }
 
 /// Evaluates predicate against the info object; returns a boolean
-/// Calls out to an Objective-C function because NSPrediacte methods can
-/// raise NSExecption, whcih Swift cannot catch
+/// Calls out to an Objective-C function because NSPredicate methods can
+/// raise NSException, which Swift cannot catch
 func predicateEvaluatesAsTrue(
     _ predicateString: String,
     infoObject: PlistDict,

--- a/code/cli/munki/shared/installer/installer.swift
+++ b/code/cli/munki/shared/installer/installer.swift
@@ -197,7 +197,7 @@ func installItem(_ item: PlistDict) async -> (Int, Bool) {
     if item["preinstall_script"] is String {
         let retcode = await runEmbeddedScript(name: "preinstall_script", pkginfo: item)
         if retcode != 0 {
-            // if preinstall_script fails, do not proceeed
+            // if preinstall_script fails, do not proceed
             return (retcode, false)
         }
     }
@@ -437,7 +437,7 @@ func uninstallItem(_ item: PlistDict) async -> (Int, Bool) {
     if item["preuninstall_script"] is String {
         let retcode = await runEmbeddedScript(name: "preuninstall_script", pkginfo: item)
         if retcode != 0 {
-            // if preuninstall_script fails, do not proceeed
+            // if preuninstall_script fails, do not proceed
             return (retcode, false)
         }
     }

--- a/code/cli/munki/shared/installer/rmpkgs.swift
+++ b/code/cli/munki/shared/installer/rmpkgs.swift
@@ -575,7 +575,7 @@ func removePackages(
             throw MunkiError("No matching pkgs found in database")
         }
     } catch {
-        display.error("Error retreiving pkg keys: \(error)")
+        display.error("Error retrieving pkg keys: \(error)")
         return -4
     }
     if stopRequested() {

--- a/code/cli/munki/shared/munkilog.swift
+++ b/code/cli/munki/shared/munkilog.swift
@@ -124,7 +124,7 @@ func munkiLogRotateMainLog() {
 }
 
 /// A nicer abstraction for the various Munki logging functions.
-/// The "classic" UNIX logging levels each have a method, though tradtionally Munki has
+/// The "classic" UNIX logging levels each have a method, though traditionally Munki has
 /// not used many of these levels.
 class MunkiLogger {
     // an easy way to get the standard logger. can't use the name "default"
@@ -183,14 +183,14 @@ class MunkiLogger {
         debug1(message)
     }
 
-    /// These aren't traditional UNIX logging levels, but Munki has traditonally used them
+    /// These aren't traditional UNIX logging levels, but Munki has traditionally used them
     func debug1(_ message: String) {
         if level > 1 {
             munkiLog("DEBUG1: \(message)", logFile: logname)
         }
     }
 
-    /// These aren't traditional UNIX logging levels, but Munki has traditonally used them
+    /// These aren't traditional UNIX logging levels, but Munki has traditionally used them
     func debug2(_ message: String) {
         if level > 2 {
             munkiLog("DEBUG2: \(message)", logFile: logname)

--- a/code/cli/munki/shared/munkirepo/FileRepo.swift
+++ b/code/cli/munki/shared/munkirepo/FileRepo.swift
@@ -262,7 +262,7 @@ class FileRepo: Repo {
     }
 
     /// Returns the filesystem path to the item in the repo
-    /// Non-filesystem Repo sublcasses should implement this but return nil
+    /// Non-filesystem Repo subclasses should implement this but return nil
     func pathFor(_ identifier: String) -> String? {
         return fullPath(identifier)
     }

--- a/code/cli/munki/shared/munkirepo/GitFileRepo.swift
+++ b/code/cli/munki/shared/munkirepo/GitFileRepo.swift
@@ -41,7 +41,7 @@ class GitFileRepo: FileRepo {
         return runCLI(cmd, arguments: args)
     }
 
-    /// Returns True if file referred to by identifer will be ignored by Git
+    /// Returns True if file referred to by identifier will be ignored by Git
     /// (usually due to being in a .gitignore file)
     func isGitIgnored(_ identifier: String) -> Bool {
         let results = runGit(
@@ -51,7 +51,7 @@ class GitFileRepo: FileRepo {
         return results.exitcode == 0
     }
 
-    /// Returns True if file referred to by identifer is in a Git repo, false otherwise.
+    /// Returns True if file referred to by identifier is in a Git repo, false otherwise.
     func isInGitRepo(_ identifier: String) -> Bool {
         let results = runGit(
             args: ["-C", parentDir(identifier),

--- a/code/cli/munki/shared/network/urls.swift
+++ b/code/cli/munki/shared/network/urls.swift
@@ -17,7 +17,7 @@ func composedURLWithBase(_ baseURLString: String, adding path: String) -> String
 /// Returns a URL to something in a Munki repo.
 /// If type is empty, returns the base URL for the Munki repo.
 /// If type is one of the supported types, returns the type-specific URL.
-/// If type is specifiied and resource is also specifiied, a full URL to the resource is
+/// If type is specified and resource is also specified, a full URL to the resource is
 /// constructed and returned
 func munkiRepoURL(_ type: String = "", resource: String = "") -> String? {
     // we could use composedURLWithBase, but that doesn't handle

--- a/code/cli/munki/shared/osinstaller/osinstallerinfo.swift
+++ b/code/cli/munki/shared/osinstaller/osinstallerinfo.swift
@@ -18,7 +18,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// functions for retreiving info about osinstallers
+// functions for retrieving info about osinstallers
 // may not call display* functions or munkilog* functions
 
 import Foundation
@@ -148,7 +148,7 @@ func makeStartOSInstallPkgInfo(mountpoint: String, item: String) throws -> Plist
     let minimumOSVersion = "10.9"
     if version.hasPrefix("10.14") {
         // https://support.apple.com/en-us/HT201475
-        // use inital values
+        // use initial values
     } else if version.hasPrefix("11.") {
         // https://support.apple.com/en-us/HT211238
         installedSize = Int(35.5 * 1024 * 1024)
@@ -207,7 +207,7 @@ func makeStageOSInstallerPkgInfo(_ appPath: String) throws -> PlistDict {
     let minimumOSVersion = "10.9"
     if version.hasPrefix("11.") {
         // https://support.apple.com/en-us/HT211238
-        // use intial values
+        // use initial values
     } else if version.hasPrefix("12.") {
         // https://support.apple.com/en-us/HT212551
         installedSize = Int(26 * 1024 * 1024)

--- a/code/cli/munki/shared/updatecheck/catalogs.swift
+++ b/code/cli/munki/shared/updatecheck/catalogs.swift
@@ -463,7 +463,7 @@ func getItemDetail(
             display.debug1("Our Munki version is \(munkiVersion)")
             if MunkiVersion(munkiVersion) < MunkiVersion(minimumMunkiVersion) {
                 rejectedItems.append(
-                    "Rejected item \(name), version \(version) with minumum Munki version required \(minimumMunkiVersion). Our Munki version is \(munkiVersion)."
+                    "Rejected item \(name), version \(version) with minimum Munki version required \(minimumMunkiVersion). Our Munki version is \(munkiVersion)."
                 )
                 return false
             }

--- a/code/cli/munki/shared/updatecheck/catalogs.swift
+++ b/code/cli/munki/shared/updatecheck/catalogs.swift
@@ -653,7 +653,7 @@ func getCatalogs(_ catalogList: [String]) {
                 throw PlistError.readError(description: "plist is in wrong format")
             }
         } catch {
-            display.error("Retreived catalog is invalid: \(error.localizedDescription)")
+            display.error("Retrieved catalog is invalid: \(error.localizedDescription)")
         }
     }
 }

--- a/code/cli/munki/shared/updatecheck/compare.swift
+++ b/code/cli/munki/shared/updatecheck/compare.swift
@@ -202,7 +202,7 @@ func compareApplicationVersion(_ appItem: PlistDict) throws -> MunkiComparisonRe
 ///
 /// If item has md5checksum attribute, compares on disk file's checksum.
 ///
-/// Throws a MunkiError if there's a problwm with the input
+/// Throws a MunkiError if there's a problem with the input
 func filesystemItemStatus(_ item: PlistDict) throws -> MunkiComparisonResult {
     guard let filepath = item["path"] as? String else {
         throw MunkiError("No path specified for filesystem item")

--- a/code/cli/munki/shared/updatecheck/download.swift
+++ b/code/cli/munki/shared/updatecheck/download.swift
@@ -197,7 +197,7 @@ func getIconHashes() -> [String: String] {
         )
         return try readPlist(fromFile: iconsHashesPlist) as? [String: String] ?? [:]
     } catch {
-        display.debug1("Error while retreiving icon hashes: \(error.localizedDescription)")
+        display.debug1("Error while retrieving icon hashes: \(error.localizedDescription)")
         return [String: String]()
     }
 }

--- a/code/cli/munki/shared/updatecheck/download.swift
+++ b/code/cli/munki/shared/updatecheck/download.swift
@@ -91,7 +91,7 @@ func enoughDiskSpaceFor(
 
 /// Downloads an (un)installer item.
 /// Returns true if the item was downloaded, false if it was already cached.
-/// Thows an error if there are issues
+/// Throws an error if there are issues
 func downloadInstallerItem(
     _ item: PlistDict,
     installInfo: PlistDict,
@@ -427,7 +427,7 @@ func uncache(_ spaceNeededInKB: Int) {
     var deletedKB = 0
     let filemanager = FileManager.default
     for (path, size) in itemsWithSize {
-        // we delete the smallest item first, proceeeding until
+        // we delete the smallest item first, proceeding until
         // we've freed up enough space or deleted all the items
         if deletedKB >= spaceNeededInKB {
             break

--- a/code/cli/munki/shared/updatecheck/installationstate.swift
+++ b/code/cli/munki/shared/updatecheck/installationstate.swift
@@ -196,8 +196,8 @@ func someVersionInstalled(_ pkginfo: PlistDict) async -> Bool {
     if pkginfo["version_script"] is String {
         // if there's a version_script, let's use that to determine
         // if some version installed
-        let comparsionResult = await compareUsingVersionScript(pkginfo)
-        if comparsionResult == .notPresent {
+        let comparisonResult = await compareUsingVersionScript(pkginfo)
+        if comparisonResult == .notPresent {
             return false
         }
         return true

--- a/code/cli/munki/shared/updatecheck/installationstate.swift
+++ b/code/cli/munki/shared/updatecheck/installationstate.swift
@@ -242,7 +242,7 @@ func someVersionInstalled(_ pkginfo: PlistDict) async -> Bool {
 }
 
 /// Checks to see if there is any evidence that the item described
-/// by pkginfo (any version) is currenly installed.
+/// by pkginfo (any version) is currently installed.
 /// If any tests pass, the item might be installed.
 /// This is used when determining if we can remove the item, thus
 /// the attention given to the uninstall method.

--- a/code/cli/munki/shared/updatecheck/manifests.swift
+++ b/code/cli/munki/shared/updatecheck/manifests.swift
@@ -118,7 +118,7 @@ func getManifest(_ name: String, suppressErrors: Bool = false) throws -> String 
     }
 
     // got a valid plist
-    display.detail("Retreived manifest \(name)")
+    display.detail("Retrieved manifest \(name)")
     Manifests.shared.set(name, path: manifestLocalPath)
     return manifestLocalPath
 }
@@ -169,7 +169,7 @@ func getPrimaryManifest(alternateIdentifier: String? = nil) throws -> String {
                     display.detail("Manifest \(identifier) not found...")
                     continue // try the next identifier
                 } else {
-                    // juse rethrow it
+                    // just rethrow it
                     throw error
                 }
             }

--- a/code/cli/munki/shared/updatecheck/manifests.swift
+++ b/code/cli/munki/shared/updatecheck/manifests.swift
@@ -23,7 +23,7 @@ extension ManifestError: LocalizedError {
         case let .invalid(description):
             return "Manifest is invalid: \(description)"
         case let .notRetrieved(description):
-            return "Manifest was not retreived: \(description)"
+            return "Manifest was not retrieved: \(description)"
         case let .connection(errorCode, description):
             return "There was a connection error: \(errorCode): \(description)"
         case let .http(errorCode, description):

--- a/code/cli/munki/shared/updatecheck/manifests.swift
+++ b/code/cli/munki/shared/updatecheck/manifests.swift
@@ -141,7 +141,7 @@ func getPrimaryManifest(alternateIdentifier: String? = nil) throws -> String {
     if !clientIdentifier.isEmpty {
         manifest = try getManifest(clientIdentifier)
     } else {
-        // no clientIdentifer specified. Try a variety of possible identifiers
+        // no clientIdentifier specified. Try a variety of possible identifiers
         display.detail("No client identifier specified. Trying default manifest resolution...")
         var identifiers = [String]()
 

--- a/code/cli/munki/shared/updatecheck/updatecheck.swift
+++ b/code/cli/munki/shared/updatecheck/updatecheck.swift
@@ -264,13 +264,13 @@ func checkForUpdates(clientID: String? = nil, localManifestPath: String? = nil) 
     }
 
     guard let mainManifest = manifestData(mainManifestPath) else {
-        display.error("Could not get manifest data from main mainfest \(mainManifestPath)")
+        display.error("Could not get manifest data from main manifest \(mainManifestPath)")
         return .finishedWithErrors
     }
     guard let mainManifestCatalogsList = mainManifest["catalogs"] as? [String],
           !mainManifestCatalogsList.isEmpty
     else {
-        display.error("Main mainfest \(mainManifestPath) does not have a list of catalogs")
+        display.error("Main manifest \(mainManifestPath) does not have a list of catalogs")
         return .finishedWithErrors
     }
 
@@ -446,7 +446,7 @@ func checkForUpdates(clientID: String? = nil, localManifestPath: String? = nil) 
         installInfo["managed_installs"] = managedInstalls
 
         if startOSInstallItems.count > 1 {
-            display.warning("There are mulitple startosinstall items in managed_installs. Only the install of the first one will be attempted.")
+            display.warning("There are multiple startosinstall items in managed_installs. Only the install of the first one will be attempted.")
         }
 
         // record detail before we throw it away...

--- a/code/cli/munki/shared/utils/cliutils.swift
+++ b/code/cli/munki/shared/utils/cliutils.swift
@@ -132,7 +132,7 @@ class ProcessRunner {
         // delegate?.processUpdated()
     }
 
-    // making this a seperate method so the non-timeout calls
+    // making this a separate method so the non-timeout calls
     // don't need to worry about catching exceptions
     // NOTE: the timeout here is _not_ an idle timeout;
     // it's the maximum time the process can run
@@ -193,7 +193,7 @@ class ProcessRunner {
 
 /// Runs a command line tool synchronously, returns CLIResults
 /// this implementation attempts to handle scenarios in which a large amount of stdout
-/// or sterr output is generated
+/// or stderr output is generated
 func runCLI(_ tool: String,
             arguments: [String] = [],
             environment: [String: String] = [:],
@@ -408,7 +408,7 @@ class AsyncProcessRunner {
         delegate?.processUpdated()
     }
 
-    // making this a seperate method so the non-timeout calls
+    // making this a separate method so the non-timeout calls
     // don't need to worry about catching exceptions
     // NOTE: the timeout here is _not_ an idle timeout;
     // it's the maximum time the process can run

--- a/code/cli/munki/shared/utils/pkgutils.swift
+++ b/code/cli/munki/shared/utils/pkgutils.swift
@@ -497,7 +497,7 @@ func getFlatPackageInfo(_ pkgpath: String) throws -> PlistDict {
             errors.append("No receipts found in Distribution or PackageInfo files within the package.")
         }
     } else {
-        errors.append("An error occurred while geting table of contents for \(pkgpath): \(tocResults.error)")
+        errors.append("An error occurred while getting table of contents for \(pkgpath): \(tocResults.error)")
     }
     // change back to original working dir
     filemanager.changeCurrentDirectoryPath(cwd)

--- a/code/cli/munki/shared/utils/plistutils.swift
+++ b/code/cli/munki/shared/utils/plistutils.swift
@@ -109,7 +109,7 @@ func plistToString(_ dataObject: Any) throws -> String {
 }
 
 /// Parses a string, looking for the first thing that looks like a plist.
-/// Returns two strings. The first will be a string representaion of a plist (or empty)
+/// Returns two strings. The first will be a string representation of a plist (or empty)
 /// The second is any characters remaining after the found plist
 func parseFirstPlist(fromString str: String) -> (String, String) {
     let header = "<?xml version"

--- a/code/client/installhelper
+++ b/code/client/installhelper
@@ -109,7 +109,7 @@ def create_launch_daemon(launchd_group):
         cmd = ['/bin/launchctl', 'bootout', 'system/' + launch_daemon_name]
         subprocess.call(cmd)
 
-    # Populate launch deamon dict
+    # Populate launch daemon dict
     launch_daemon = {}
     launch_daemon['EnvironmentVariables'] = {'INSTALLHELPER_RUN_TYPE': launchd_group}
     launch_daemon['Label'] = launch_daemon_name

--- a/code/client/managedsoftwareupdate.py
+++ b/code/client/managedsoftwareupdate.py
@@ -377,7 +377,7 @@ def startLogoutHelper():
 
 
 def doRestart(shutdown=False):
-    """Handle the need for a restart or a possbile shutdown."""
+    """Handle the need for a restart or a possible shutdown."""
     restartMessage = 'Software installed or removed requires a restart.'
     if shutdown:
         munkilog.log('Software installed or removed requires a shut down.')
@@ -718,7 +718,7 @@ def main():
         'install without logging out. Not for general use.')
     other_options.add_option(
         '--launchosinstaller', action='store_true',
-        help='Used interally. Not for general use.')
+        help='Used internally. Not for general use.')
     other_options.add_option(
         '--manualcheck', action='store_true',
         help='Used by launchd LaunchAgent when checking manually. Not for '
@@ -1115,7 +1115,7 @@ def main():
         else:
             # staged OS installer is missing
             display.display_error(
-                'Requsted to launch staged OS installer, but no info on a '
+                'Requested to launch staged OS installer, but no info on a '
                 'staged installer was found.')
 
     if updatesavailable or appleupdatesavailable:

--- a/code/client/munkilib/admin/pkginfolib.py
+++ b/code/client/munkilib/admin/pkginfolib.py
@@ -620,7 +620,7 @@ def makepkginfo(installeritem, options):
             # handle case where value may have been set (e.g. flat package)
             item_minosversions.append(pkgutils.MunkiLooseVersion(
                 pkginfo['minimum_os_version']))
-        # get the maximum from the list and covert back to string
+        # get the maximum from the list and convert back to string
         pkginfo['minimum_os_version'] = str(max(item_minosversions))
 
     if not 'minimum_os_version' in pkginfo:

--- a/code/client/munkilib/appleupdates/au.py
+++ b/code/client/munkilib/appleupdates/au.py
@@ -346,7 +346,7 @@ class AppleUpdates(object):
             # record items we aren't planning to attempt to install
             remaining_apple_updates = [item for item in installlist
                                        if item not in filtered_installlist]
-            # set the list of items to install to our newly-filted list
+            # set the list of items to install to our newly-filtered list
             installlist = filtered_installlist
 
         elif os_version_tuple >= (10, 14):

--- a/code/client/munkilib/appleupdates/su_tool.py
+++ b/code/client/munkilib/appleupdates/su_tool.py
@@ -89,19 +89,19 @@ def parse_su_update_line_old_style(line):
     info = {}
     # strip leading and trailing whitespace
     line = line.strip()
-    title, seperator, line = line.partition("(")
-    if not seperator == "(":
+    title, separator, line = line.partition("(")
+    if not separator == "(":
         # no idea of the format, just return an empty dict
         return {}
     info['Title'] = title.rstrip()
-    version, seperator, line = line.partition(")")
-    if not seperator == ")":
+    version, separator, line = line.partition(")")
+    if not separator == ")":
         # no idea of the format, just return an empty dict
         return {}
     info['Version'] = version
     line = line.lstrip(', ')
-    size, seperator, line = line.partition('K')
-    if seperator == 'K':
+    size, separator, line = line.partition('K')
+    if separator == 'K':
         info['Size'] = '%sK' % size
     # now start from the end
     if line.endswith(" [restart]"):

--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -754,7 +754,7 @@ class Gurl(NSObject):
                         break
                 else:
                     continue
-                # this break is only excuted if we found a certificate
+                # this break is only executed if we found a certificate
                 break
             else:
                 self.log('Could not find matching identity')

--- a/code/client/munkilib/gurl.py
+++ b/code/client/munkilib/gurl.py
@@ -19,7 +19,7 @@ gurl.py
 Created by Greg Neagle on 2013-11-21.
 Modified in Feb 2016 to add support for NSURLSession.
 Updated June 2019 for compatibility with Python 3 and PyObjC 5.1.2+
-Updated May 2022 for compatibilty with PyObjC 8.5 on macOS Mojave
+Updated May 2022 for compatibility with PyObjC 8.5 on macOS Mojave
 Updated Feb 2025 to add support for Certificate Chains when using Client Certificates
 
 curl replacement using NSURLConnection and friends

--- a/code/client/munkilib/info.py
+++ b/code/client/munkilib/info.py
@@ -818,7 +818,7 @@ def get_conditions():
     conditionalitemspath = os.path.join(
         prefs.pref('ManagedInstallDir'), 'ConditionalItems.plist')
     try:
-        # delete CondtionalItems.plist so that we're starting fresh
+        # delete ConditionalItems.plist so that we're starting fresh
         os.unlink(conditionalitemspath)
     except (OSError, IOError):
         pass

--- a/code/client/munkilib/keychain.py
+++ b/code/client/munkilib/keychain.py
@@ -21,7 +21,7 @@ Incorporating work and ideas from Michael Lynn here:
     https://gist.github.com/pudquick/7704254
 and here:
     https://gist.github.com/pudquick/836a19b5ff17c5b7640d#file-cert_tricks-py
-Updated October 2022 for compatibilty with macOS Ventura
+Updated October 2022 for compatibility with macOS Ventura
 """
 from __future__ import absolute_import, print_function
 

--- a/code/client/munkilib/updatecheck/download.py
+++ b/code/client/munkilib/updatecheck/download.py
@@ -456,7 +456,7 @@ def uncache(space_needed_in_kb):
         if deleted_kb >= space_needed_in_kb:
             break
         # remove and return last item in precached_items
-        # we delete the smallest item first, proceeeding until we've freed up
+        # we delete the smallest item first, proceeding until we've freed up
         # enough space or deleted all the items
         item = precached_items.pop()
         item_path = os.path.join(cachedir, item[0])

--- a/code/tools/make_munki_mpkg.sh
+++ b/code/tools/make_munki_mpkg.sh
@@ -797,7 +797,7 @@ fi
 #################
 if [ "$CLIENTCERTPKG" == "YES" ] ; then
 
-    echo "Creating client cert package souce..."
+    echo "Creating client cert package source..."
 
     # Create directory structure
     CLIENTCERTROOT="$PKGTMP/munki_clientcert"

--- a/code/tools/make_swift_munki_pkg.sh
+++ b/code/tools/make_swift_munki_pkg.sh
@@ -440,7 +440,7 @@ EOF
 }
 
 
-# Pre-packgage-build cleanup.
+# Pre-package-build cleanup.
 
 if ! rm -rf "$DISTPKG" ; then
     echo "Error removing $DISTPKG before rebuilding it."

--- a/code/tools/make_swift_munki_pkg.sh
+++ b/code/tools/make_swift_munki_pkg.sh
@@ -911,7 +911,7 @@ fi
 #################
 if [ "$CLIENTCERTPKG" == "YES" ] ; then
 
-    echo "Creating client cert package souce..."
+    echo "Creating client cert package source..."
 
     # Create directory structure
     CLIENTCERTROOT="$PKGTMP/munki_clientcert"

--- a/code/tools/pkgresources/Scripts_autorun/postinstall
+++ b/code/tools/pkgresources/Scripts_autorun/postinstall
@@ -2,7 +2,7 @@
 
 # use launchctl to submit a job to run managedsoftwareupdate
 # so that the script returns before the job finishes and ending
-# the installer taks does not end the managedsoftwareupdate run
+# the installer task does not end the managedsoftwareupdate run
 # (It's quite possible that `/usr/local/munki/managedsoftwareupdate --auto &`
 # would work as well!)
 


### PR DESCRIPTION
Includes many spelling fixes for the Munki 7 branch, including one renamed file.

One of these fixes may have actually resolved a bug:

```swift
if let optional_installs = cachedInstallInfo()["optional_instslls"] as? [PlistDict]
```

The resulting codebase builds successfully for me using `./code/tools/build_swift_munki.sh`.