### PR TITLE
Change ETag / Last-Modified fetch.swift logic

### DIFF
--- a/code/cli/munki/shared/network/fetch.swift
+++ b/code/cli/munki/shared/network/fetch.swift
@@ -344,13 +344,13 @@ func getHTTPfileIfChangedAtomically(
         do {
             let data = try getXattr(named: GURL_XATTR, atPath: destinationPath)
             if let headers = try readPlist(fromData: data) as? [String: String] {
-                eTag = headers["etag"] ?? ""
+                // We can use onlyIfNewer if we have either etag or last-modified
+                if headers["etag"] != nil || headers["last-modified"] != nil {
+                    getOnlyIfNewer = true
+                }
             }
         } catch {
-            // fall through
-        }
-        if eTag.isEmpty {
-            getOnlyIfNewer = false
+            // fall through - no cached headers
         }
     }
     var headers: [String: String]


### PR DESCRIPTION
Potentially addresses #1279. I applied these changes and recompiled on my machine. in my extremely limited testing it appears to include the `If-Modified-Since` header properly when a file is present/cached on disk.