### PR TITLE
Fix bug in installhelper logic

### DIFF
--- a/code/cli/munki/installhelper/main.swift
+++ b/code/cli/munki/installhelper/main.swift
@@ -263,10 +263,7 @@ func reloadUserLaunchAgents(group: String) {
         // first, unload active Munki jobs
         var activeAgentLabels = getMunkiLaunchdLabels(uid: uid)
         if group == "appusage" {
-            if activeAgentLabels.contains(APPUSAGE_AGENT) {
-                // only unload APPUSAGE_AGENT
-                activeAgentLabels = [APPUSAGE_AGENT]
-            }
+            activeAgentLabels = activeAgentLabels.filter { $0 == APPUSAGE_AGENT }
         }
         if group == "launchd" {
             // unload everything but APPUSAGE_AGENT
@@ -341,9 +338,7 @@ func reloadLaunchDaemons(group: String) {
     var activeDaemonLabels = getMunkiLaunchdLabels()
     if group == "appusage" {
         // we should only unload APPUSAGE_DAEMON if if's active
-        if activeDaemonLabels.contains(APPUSAGE_DAEMON) {
-            activeDaemonLabels = [APPUSAGE_DAEMON]
-        }
+        activeDaemonLabels = activeDaemonLabels.filter { $0 == APPUSAGE_DAEMON }
     }
     if group == "launchd" {
         // unload all Munki jobs _except_ APPUSAGE_DAEMON and our installhelper jobs


### PR DESCRIPTION
# Summary
This PR addresses a bug in the `installhelper` logic which unintentionally removes the main Munki LaunchDaemons/Agents whenever the tool is run with the `appusage` argument and the `appusage` LaunchDaemons/Agents are not currently loaded.

## Replicating

This scenario can happen during initial installation of Munki when the postinstall scripts for the `launchd` and `appusage` packages are run in quick succession. If the `installhelper` for `launchd` runs before or at the same time as `appusage`, then when `appusage` runs, the Munki jobs loaded by `launchd` (including the `installhelper` jobs themselves) are unloaded and never re-loaded. This leads to the main Munki daemons/agents not being loaded after first install on a clean system.

This can be replicated outside of the installer package by unloading all agents/daemons and then running the following...

```
sudo /usr/local/munki/libexec/installhelper appusage &; sudo /usr/local/munki/libexec/installhelper launchd &
```

Running both at the same time creates a race condition. It will depend how quickly each executes as to which agents/daemons will get caught by the other and unloaded.

The following logs provide an example of this race condition execution. As you can see, both executions are writing to the logs simultaneously. Once the `appusage` execution unloads the `installhelper-` jobs, both executions are terminated and never finish. The `cleanUp` function is also then never executed and the two `installhelper` LaunchDaemon plists are left on disk.

```
2025-10-27 17:15:07.590Z Starting installhelper 0.2
2025-10-27 17:15:07.593Z Launched manually - arg: appusage
2025-10-27 17:15:07.594Z Creating launch daemon: /Library/LaunchDaemons/com.googlecode.munki.installhelper-appusage.plist
2025-10-27 17:15:07.611Z Starting installhelper 0.2
2025-10-27 17:15:07.611Z Launched manually - arg: launchd
2025-10-27 17:15:07.611Z Creating launch daemon: /Library/LaunchDaemons/com.googlecode.munki.installhelper-launchd.plist
2025-10-27 17:15:07.691Z Starting installhelper 0.2
2025-10-27 17:15:07.692Z Launched via launchd - arg: launchd
2025-10-27 17:15:07.755Z managedsoftwareupdate is not running, proceeding...
2025-10-27 17:15:07.756Z Processing LaunchAgents for alex.jones
2025-10-27 17:15:07.766Z Starting installhelper 0.2
2025-10-27 17:15:07.768Z Launched via launchd - arg: appusage
2025-10-27 17:15:07.780Z Enabling agent com.googlecode.munki.ManagedSoftwareCenter
2025-10-27 17:15:07.802Z Loading agent /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
2025-10-27 17:15:07.815Z Enabling agent com.googlecode.munki.munki-notifier
2025-10-27 17:15:07.825Z managedsoftwareupdate is not running, proceeding...
2025-10-27 17:15:07.826Z Processing LaunchAgents for alex.jones
2025-10-27 17:15:07.830Z Loading agent /Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist
2025-10-27 17:15:07.850Z Skipping loginwindow launchd reload, we're not at the loginwindow
2025-10-27 17:15:07.851Z Processing launch daemons
2025-10-27 17:15:07.859Z Stopping agent com.googlecode.munki.ManagedSoftwareCenter
2025-10-27 17:15:07.873Z Enabling daemon com.googlecode.munki.managedsoftwareupdate-install
2025-10-27 17:15:07.873Z Enabling agent com.googlecode.munki.app_usage_monitor
2025-10-27 17:15:07.886Z Loading agent /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
2025-10-27 17:15:07.887Z Loading daemon /Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-install.plist
2025-10-27 17:15:07.898Z Processing launch daemons
2025-10-27 17:15:07.902Z Enabling daemon com.googlecode.munki.logouthelper
2025-10-27 17:15:07.926Z Loading daemon /Library/LaunchDaemons/com.googlecode.munki.logouthelper.plist
2025-10-27 17:15:07.940Z Enabling daemon com.googlecode.munki.authrestartd
2025-10-27 17:15:07.947Z Stopping launch daemon com.googlecode.munki.installhelper-launchd
2025-10-27 17:15:07.997Z Stopping launch daemon com.googlecode.munki.installhelper-appusage
```

## Code logic breakdown

The previous logic would get a list of all active daemons/agents. When running for `appusage`, it would check to see if the `appusage` daemon/agent is currently loaded, and if it is, set the list to include only the `appusage` daemon/agent, and then unload it. However, if the `appusage` daemon/agent isn't currently loaded, the list would never be altered to remove any items, and so if the main Munki daemons/agents were already loaded, or the `installhelper-launchd` daemon was loaded, they would remain in the list and would be unloaded.

The new logic will _always_ filter the list even if `appusage` isn't currently loaded. If it is loaded, it will be the only item left in the list, and if it is not loaded, the list will be empty, leaving any other daemons/agents as they are.