### PR TITLE
Use a clock unaffected by system sleep for script timeouts

### DIFF
--- a/code/cli/munki/shared/utils/cliutils.swift
+++ b/code/cli/munki/shared/utils/cliutils.swift
@@ -21,8 +21,6 @@
 import Darwin
 import Foundation
 
-private let display = DisplayAndLog.main
-
 /// Removes a final newline character from a string if present
 func trimTrailingNewline(_ s: String) -> String {
     var trimmedString = s


### PR DESCRIPTION
Munki 7 added 60 second timeouts when running certain scripts, such as preflight/postflight and conditions. The implementation uses [Date](https://developer.apple.com/documentation/foundation/date), [TimeInterval](https://developer.apple.com/documentation/Foundation/TimeInterval) and friends, which don't handle system sleep gracefully causing spurious timeouts e.g. if a user closes the lid in the middle of a munki run.

This PR changes it to use clock_gettime_nsec_np(CLOCK_UPTIME_RAW_APPROX) instead, which uses a monotonic clock that does not increment while the system is asleep.