### PR TITLE
Fix environment inheritance in subprocess calls

### DIFF
--- a/code/cli/munki/shared/utils/cliutils.swift
+++ b/code/cli/munki/shared/utils/cliutils.swift
@@ -211,7 +211,7 @@ func runCLI(_ tool: String,
     let task = Process()
     task.executableURL = URL(fileURLWithPath: tool)
     task.arguments = arguments
-    if !environment.isEmpty == false {
+    if !environment.isEmpty {
         task.environment = environment
     }
 


### PR DESCRIPTION
Fixes a logic error introduced in commit 131feb17 where `if !environment.isEmpty == false` should be `if !environment.isEmpty`.

The buggy condition caused subprocesses to run with an empty environment when no custom environment was provided, preventing git from locating `~/.gitconfig` when using the GitFileRepo plugin.

This fix ensures that:
- When no custom environment is provided (default), subprocesses inherit the parent's environment
- When a custom environment is provided, it is used as intended

The correct logic already exists in `ProcessRunner.init()` at line 61, and this changes matches the default behavior in Munki 6.x with Python's `subprocess.Popen`.