### PR TITLE
Handle newlines in script output better

### DIFF
--- a/code/cli/munki/managedsoftwareupdate/msuutils.swift
+++ b/code/cli/munki/managedsoftwareupdate/msuutils.swift
@@ -54,6 +54,21 @@ func initMunkiDirs() -> Bool {
     return success
 }
 
+
+extension StringProtocol {
+    @inline(__always)
+    var trailingNewlineTrimmed: Self.SubSequence {
+        let view = self[...]
+
+        if view.last?.isNewline == true {
+            return view.dropLast()
+        } else {
+            return view
+        }
+    }
+}
+
+
 /// Run an external script. Do not run if the permissions on the external
 /// script file are weaker than the current executable.
 func runMunkiDirScript(_ scriptPath: String, taskName: String, runType: String) async -> Int {
@@ -69,10 +84,10 @@ func runMunkiDirScript(_ scriptPath: String, taskName: String, runType: String) 
             display.info("\(scriptPath) return code: \(result.exitcode)")
         }
         if !result.output.isEmpty {
-            display.info("\(scriptPath) stdout: \(result.output)")
+            display.info("\(scriptPath) stdout:\n\(result.output.trailingNewlineTrimmed)")
         }
         if !result.error.isEmpty {
-            display.info("\(scriptPath) stderr: \(result.error)")
+            display.info("\(scriptPath) stderr:\n\(result.error.trailingNewlineTrimmed)")
         }
         return result.exitcode
     } catch ExternalScriptError.notFound {

--- a/code/cli/munki/shared/utils/scriptutils.swift
+++ b/code/cli/munki/shared/utils/scriptutils.swift
@@ -31,7 +31,7 @@ class ScriptRunner: AsyncProcessRunner {
     var combinedOutput = ""
 
     func linesAndRemainderOf(_ str: String) -> ([String], String) {
-        var lines = str.components(separatedBy: "\n")
+        var lines = str.split(whereSeparator: \.isNewline).map(String.init)
         var remainder = ""
         if lines.count > 0, !str.hasSuffix("\n") {
             // last line of string did not end with a newline; might be a partial

--- a/code/cli/munki/shared/utils/scriptutils.swift
+++ b/code/cli/munki/shared/utils/scriptutils.swift
@@ -31,7 +31,7 @@ class ScriptRunner: AsyncProcessRunner {
     var combinedOutput = ""
 
     func linesAndRemainderOf(_ str: String) -> ([String], String) {
-        var lines = str.split(whereSeparator: \.isNewline).map(String.init)
+        var lines = str.trailingNewlineTrimmed.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map(String.init)
         var remainder = ""
         if lines.count > 0, !str.hasSuffix("\n") {
             // last line of string did not end with a newline; might be a partial


### PR DESCRIPTION
This patch changes how newlines are parsed and printed when executing preflight/postflight and embedded scripts.

Before:

```
2025-11-30 12:13:56.105+01:00 ### Starting managedsoftwareupdate run: auto ###
2025-11-30 12:13:56.114+01:00 Starting...
2025-11-30 12:13:56.130+01:00     Performing preflight tasks...
2025-11-30 12:13:57.036+01:00 /usr/local/munki/preflight stdout: preflight INFO: Executing /usr/local/munki/preflight.d/ensure_mdm
ensure_mdm INFO: 🏢 Checking MDM enrollment
ensure_mdm INFO: ✅ Already enrolled
preflight INFO: Executing /usr/local/munki/preflight.d/glad_preflight
GLAD Preflight INFO: Fetching licenses for xolope
GLAD Preflight INFO: Checking current licenses
GLAD Preflight INFO: Checking removed licenses
GLAD Preflight INFO: Updating license cache

2025-11-30 12:13:57.710+01:00 ### Beginning managed software check ###
[...]
2025-11-30 12:14:03.306+01:00 Running installcheck_script for GU_FileVaultFix
2025-11-30 12:14:03.451+01:00 🔒 Checking FileVault status
2025-11-30 12:14:03.452+01:00
2025-11-30 12:14:03.513+01:00 ✅ Already enabled, exiting
2025-11-30 12:14:03.522+01:00
2025-11-30 12:14:03.533+01:00 GU_FileVaultFix version 1.0 (or newer) is already installed.
```

After:
```
2025-12-02 18:33:40.320+01:00 ### Starting managedsoftwareupdate run: custom ###
2025-12-02 18:33:40.321+01:00 Starting...
2025-12-02 18:33:40.325+01:00     Performing preflight tasks...
2025-12-02 18:33:41.121+01:00 /usr/local/munki/preflight stdout:
preflight INFO: Executing /usr/local/munki/preflight.d/ensure_mdm
ensure_mdm INFO: 🔁 Checking MDM enrollment
ensure_mdm INFO: ✅ Enrollment is healthy
preflight INFO: Executing /usr/local/munki/preflight.d/glad_preflight
GLAD Preflight INFO: Fetching licenses for xolope
GLAD Preflight INFO: Checking current licenses
GLAD Preflight INFO: Adding GU_KeePassXC to current licenses
GLAD Preflight INFO: Checking removed licenses
GLAD Preflight INFO: Updating license cache
GLAD Preflight INFO: Adding GU_KeePassXC to optional installs
2025-12-02 18:33:41.434+01:00 ### Beginning managed software check ###
[...]
2025-12-02 18:33:44.379+01:00 Running installcheck_script for GU_FileVaultFix
2025-12-02 18:33:44.507+01:00 🔒 Checking FileVault status
2025-12-02 18:33:44.568+01:00 ✅ Already enabled, exiting
2025-12-02 18:33:44.569+01:00 GU_FileVaultFix version 1.0 (or newer) is already installed.
```
