### PR TITLE
Adjust width for pending updates to display horizontally

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/XIBs/Base.lproj/MainMenu.xib
+++ b/code/apps/Managed Software Center/Managed Software Center/XIBs/Base.lproj/MainMenu.xib
@@ -91,13 +91,13 @@
                                                         <rect key="frame" x="178" y="8" width="15" height="16"/>
                                                     </progressIndicator>
                                                     <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LLF-TK-FyK">
-                                                        <rect key="frame" x="178" y="7" width="15" height="18"/>
+                                                        <rect key="frame" x="178" y="7" width="28" height="18"/>
                                                         <buttonCell key="cell" type="inline" title="0" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="q81-SY-K1x">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="systemBold" size="12"/>
                                                         </buttonCell>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="15" id="zcS-4Z-QV7"/>
+                                                            <constraint firstAttribute="width" constant="28" id="zcS-4Z-QV7"/>
                                                         </constraints>
                                                     </button>
                                                     <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="545-FJ-GjT">


### PR DESCRIPTION
Fix for issue #1295 

Testing with this PR, the MSC sidebar now displays pending updates correctly: 

<img width="582" height="296" alt="Pending Update Test Fix" src="https://github.com/user-attachments/assets/acdf8fb2-8e0b-4501-9e51-ec3f845e8a36" />
