### PR TITLE
jordancalhoun/auto close for updates

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center.xcodeproj/project.pbxproj
+++ b/code/apps/Managed Software Center/Managed Software Center.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		C0546BD620FBE61A003FE5A6 /* MSCAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0546BD520FBE61A003FE5A6 /* MSCAlertController.swift */; };
 		C0546BD820FDAD82003FE5A6 /* power.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0546BD720FDAD82003FE5A6 /* power.swift */; };
 		C0546BDC20FE961E003FE5A6 /* MSCPasswordAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0546BDB20FE961E003FE5A6 /* MSCPasswordAlertController.swift */; };
+		AABB00012E2412600012345A /* MSCBlockingAppsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00002E2412600012345A /* MSCBlockingAppsController.swift */; };
 		C05F87932105587A000DB8D8 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = C05F87952105587A000DB8D8 /* Localizable.strings */; };
 		C094C26C28B7E17800CFB0D8 /* osinstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C094C26B28B7E17800CFB0D8 /* osinstaller.swift */; };
 		C0B2E4D921460E7D00FA9806 /* MSCWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B2E4D821460E7D00FA9806 /* MSCWebView.swift */; };
@@ -122,6 +123,7 @@
 		C0546BD520FBE61A003FE5A6 /* MSCAlertController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSCAlertController.swift; sourceTree = "<group>"; };
 		C0546BD720FDAD82003FE5A6 /* power.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = power.swift; sourceTree = "<group>"; };
 		C0546BDB20FE961E003FE5A6 /* MSCPasswordAlertController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSCPasswordAlertController.swift; sourceTree = "<group>"; };
+		AABB00002E2412600012345A /* MSCBlockingAppsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSCBlockingAppsController.swift; sourceTree = "<group>"; };
 		C05F878D210556C9000DB8D8 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		C05F879621055BFE000DB8D8 /* Base */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C05F879721055DAA000DB8D8 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				C0C5DF6B20F5C27700CA0687 /* MSCStatusController.swift */,
 				C0546BD520FBE61A003FE5A6 /* MSCAlertController.swift */,
 				C0546BDB20FE961E003FE5A6 /* MSCPasswordAlertController.swift */,
+				AABB00002E2412600012345A /* MSCBlockingAppsController.swift */,
 				C012D5332C25121F004FDB5A /* BlurredBackgroundController.swift */,
 				8428C7E32E0CB41F00D83D41 /* SidebarViewController.swift */,
 				8428C7E52E0CB44200D83D41 /* MainContentViewController.swift */,
@@ -504,6 +507,7 @@
 				C012D5342C25121F004FDB5A /* BlurredBackgroundController.swift in Sources */,
 				C04F829120BB34D100F9C57D /* Localization.swift in Sources */,
 				C0546BD620FBE61A003FE5A6 /* MSCAlertController.swift in Sources */,
+				AABB00012E2412600012345A /* MSCBlockingAppsController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/code/apps/Managed Software Center/Managed Software Center/Base.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/Base.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Quit";
 
+/* Quit Apps button title */
+"Quit Apps" = "Quit Apps";
+
+/* Force Quit button title */
+"Force Quit" = "Force Quit";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Force Quit Application?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Closed Applications";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Reopen applications after update";
+
+/* Manual quit required label */
+"Manual quit required" = "Manual quit required";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Please quit the following applications to continue with the update:";
+
 /* Removal Error status text */
 "Removal Error" = "Removal Error";
 

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -517,6 +517,8 @@ class MSCAlertController: NSObject {
 	///
 	/// The sheet is dismissed automatically when all apps are closed or when the user cancels/ignores it.
 	/// This method blocks further progress until the user has handled the apps or dismissed the sheet.
+	/// Note: The `blockingAppsController` is kept alive after this method returns so that
+	/// `reopenAppsAfterUpdate()` can be called later. Call `clearBlockingAppsController()` when done.
 	func autoQuitAlertedToBlockingAppsRunning() -> Bool {
 		guard let mainWindow = window else {
 			msc_debug_log("Could not get main window in autoQuitAlertedToBlockingAppsRunning")
@@ -525,8 +527,22 @@ class MSCAlertController: NSObject {
 
 		blockingAppsController = MSCBlockingAppsController(parentWindow: mainWindow)
 		let result = blockingAppsController?.presentBlockingAppsSheet() ?? false
-		blockingAppsController = nil
+		// Don't nil out blockingAppsController here - we need it for reopenAppsAfterUpdate()
 		return result
+	}
+
+	/// Reopens any applications that were closed during the blocking apps sheet,
+	/// if the user had the "Reopen applications after update" checkbox enabled.
+	func reopenAppsAfterUpdate() {
+		blockingAppsController?.reopenApps()
+		blockingAppsController = nil
+	}
+
+	/// Clears the blocking apps controller without reopening apps.
+	/// Call this if the update was cancelled or failed.
+	func clearBlockingAppsController() {
+		blockingAppsController?.clearAppsToReopen()
+		blockingAppsController = nil
 	}
 
     func getFirmwareAlertInfo() -> [[String: String]] {

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -11,11 +11,12 @@ import Cocoa
 class MSCAlertController: NSObject {
     // An object that handles some of our alerts, if for no other reason
     // than to move a giant bunch of ugly code out of the WindowController
-    
+
     var window: NSWindow? // our parent window
     var timers: [Timer] = []
     var quitButton: NSButton?
     var haveOpenedSysPrefsSUPane = false
+    var blockingAppsController: MSCBlockingAppsController? // controller for blocking apps sheet
     
     func handlePossibleAuthRestart() {
         // Ask for and store a password for auth restart if needed/possible
@@ -509,7 +510,25 @@ class MSCAlertController: NSObject {
         })
         return true
     }
-    
+
+	/// Presents an interactive sheet listing blocking applications so the user can close them.
+	///
+	/// - Returns: `true` if blocking apps are running and user cancelled; `false` if no blocking apps or all were closed.
+	///
+	/// The sheet is dismissed automatically when all apps are closed or when the user cancels/ignores it.
+	/// This method blocks further progress until the user has handled the apps or dismissed the sheet.
+	func autoQuitAlertedToBlockingAppsRunning() -> Bool {
+		guard let mainWindow = window else {
+			msc_debug_log("Could not get main window in autoQuitAlertedToBlockingAppsRunning")
+			return false
+		}
+
+		blockingAppsController = MSCBlockingAppsController(parentWindow: mainWindow)
+		let result = blockingAppsController?.presentBlockingAppsSheet() ?? false
+		blockingAppsController = nil
+		return result
+	}
+
     func getFirmwareAlertInfo() -> [[String: String]] {
         // Get detail about a firmware update
         var info = [[String: String]]()

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -338,15 +338,7 @@ class MSCBlockingAppsController: NSObject {
 
 			if isManualQuit {
 				// Show "Manual quit required" label for apps that can't be auto-quit
-				let manualQuitLabel = NSTextField(labelWithString: NSLocalizedString(
-					"Manual quit required",
-					comment: "Manual quit required label"))
-				manualQuitLabel.translatesAutoresizingMaskIntoConstraints = false
-				manualQuitLabel.font = NSFont.systemFont(ofSize: 10)
-				manualQuitLabel.textColor = .systemOrange
-				manualQuitLabel.alignment = .right
-
-				rowView.addSubview(manualQuitLabel)
+				let manualQuitLabel = showManualQuitLabel(for: app.path, in: rowView)
 
 				NSLayoutConstraint.activate([
 					rowView.heightAnchor.constraint(equalToConstant: rowHeight),
@@ -360,9 +352,6 @@ class MSCBlockingAppsController: NSObject {
 					nameLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
 					nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: manualQuitLabel.leadingAnchor, constant: -8),
 					nameLabel.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
-
-					manualQuitLabel.trailingAnchor.constraint(equalTo: rowView.trailingAnchor, constant: -4),
-					manualQuitLabel.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
 				])
 			} else {
 				// Progress spinner (hidden by default) for apps that can be auto-quit
@@ -669,6 +658,14 @@ class MSCBlockingAppsController: NSObject {
 		spinner.stopAnimation(nil)
 		spinner.isHidden = true
 
+		// Check if AutoForceQuitAppsOnUpdates is disabled
+		let autoForceQuitEnabled = pythonishBool(pref("AutoForceQuitAppsOnUpdate"))
+		if !autoForceQuitEnabled {
+			// Show "Manual quit required" label instead of Force Quit button
+			showManualQuitLabel(for: appPath, in: rowView)
+			return
+		}
+
 		// Create the Force Quit button
 		let forceQuitButton = NSButton(title: NSLocalizedString("Force Quit", comment: "Force Quit button title"), target: self, action: #selector(forceQuitButtonClicked(_:)))
 		forceQuitButton.translatesAutoresizingMaskIntoConstraints = false
@@ -689,6 +686,28 @@ class MSCBlockingAppsController: NSObject {
 		forceQuitButtons[appPath] = forceQuitButton
 
 		msc_debug_log("Showing Force Quit button for: \(appPath)")
+	}
+
+	@discardableResult
+	private func showManualQuitLabel(for appPath: String, in rowView: NSView) -> NSTextField {
+		let manualQuitLabel = NSTextField(labelWithString: NSLocalizedString(
+			"Manual quit required",
+			comment: "Manual quit required label"))
+		manualQuitLabel.translatesAutoresizingMaskIntoConstraints = false
+		manualQuitLabel.font = NSFont.systemFont(ofSize: 10)
+		manualQuitLabel.textColor = .systemOrange
+		manualQuitLabel.alignment = .right
+
+		rowView.addSubview(manualQuitLabel)
+
+		NSLayoutConstraint.activate([
+			manualQuitLabel.trailingAnchor.constraint(equalTo: rowView.trailingAnchor, constant: -4),
+			manualQuitLabel.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+		])
+
+		msc_debug_log("Showing Manual quit required label for: \(appPath)")
+
+		return manualQuitLabel
 	}
 
 	@objc private func forceQuitButtonClicked(_ sender: NSButton) {

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -47,6 +47,9 @@ class MSCBlockingAppsController: NSObject {
 	private var manualQuitAppNames: Set<String> = [] // app names that require manual quit
 	private var manualQuitAppPaths: Set<String> = [] // app paths that require manual quit
 
+	// Custom quit script tracking - maps app names to their quit scripts
+	private var appQuitScripts: [String: String] = [:] // keyed by app name (e.g. "Safari.app")
+
 	// Reopen apps after update
 	private var reopenCheckbox: NSButton?
 	private(set) var appsToReopenAfterUpdate: [String] = []
@@ -81,6 +84,7 @@ class MSCBlockingAppsController: NSObject {
 		// Gather apps to check from update list
 		appsToCheck = []
 		manualQuitAppNames = []
+		appQuitScripts = [:]
 		for update_item in getUpdateList() {
 			let preventAutoQuit = update_item["prevent_auto_quit_on_update"] as? Bool ?? false
 			var itemBlockingApps = [String]()
@@ -100,6 +104,14 @@ class MSCBlockingAppsController: NSObject {
 			if preventAutoQuit {
 				for appName in itemBlockingApps {
 					manualQuitAppNames.insert(appName)
+				}
+			}
+
+			// Track custom quit scripts for blocking apps
+			if let quitScript = update_item["application_quit_script"] as? String {
+				for appName in itemBlockingApps {
+					appQuitScripts[appName] = quitScript
+					msc_debug_log("Found application_quit_script for \(appName)")
 				}
 			}
 		}
@@ -833,6 +845,7 @@ class MSCBlockingAppsController: NSObject {
 		forceQuitButtons = [:]
 		manualQuitAppNames = []
 		manualQuitAppPaths = []
+		appQuitScripts = [:]
 		reopenCheckbox = nil
 		// Note: appsToReopenAfterUpdate is intentionally NOT cleared here
 		// so the caller can access it after the sheet is dismissed
@@ -895,23 +908,41 @@ class MSCBlockingAppsController: NSObject {
 				// Record quit initiation time for force quit tracking
 				quitInitiatedTimes[app.path] = Date()
 
-				// Find the running application by its bundle URL and terminate it
-				let bundleURL = URL(fileURLWithPath: app.path)
-				let bundlePrefix = app.path + "/"
+				// Check for custom quit script
+				let appFileName = (app.path as NSString).lastPathComponent
+				if let quitScript = appQuitScripts[appFileName] {
+					// Run the custom quit script instead of default termination
+					msc_debug_log("Running application_quit_script for \(app.displayName)")
+					DispatchQueue.global(qos: .userInitiated).async {
+						let result = runEmbeddedScript(quitScript, scriptName: "application_quit_script")
+						DispatchQueue.main.async {
+							if result.exitcode != 0 {
+								msc_debug_log("application_quit_script for \(app.displayName) failed with exit code \(result.exitcode)")
+							} else {
+								msc_debug_log("application_quit_script for \(app.displayName) completed successfully")
+							}
+						}
+					}
+				} else {
+					// Use default termination logic
+					// Find the running application by its bundle URL and terminate it
+					let bundleURL = URL(fileURLWithPath: app.path)
+					let bundlePrefix = app.path + "/"
 
-				// Find all running apps that match this bundle or are nested inside it
-				// This handles apps like Docker that contain nested .app bundles
-				let runningApps = NSWorkspace.shared.runningApplications.filter { runningApp in
-					guard let runningBundleURL = runningApp.bundleURL else { return false }
-					let runningPath = runningBundleURL.path
-					return runningBundleURL == bundleURL ||
-						   runningPath.hasPrefix(bundlePrefix)
-				}
+					// Find all running apps that match this bundle or are nested inside it
+					// This handles apps like Docker that contain nested .app bundles
+					let runningApps = NSWorkspace.shared.runningApplications.filter { runningApp in
+						guard let runningBundleURL = runningApp.bundleURL else { return false }
+						let runningPath = runningBundleURL.path
+						return runningBundleURL == bundleURL ||
+							   runningPath.hasPrefix(bundlePrefix)
+					}
 
-				msc_debug_log("Terminating \(runningApps.count) app(s) for bundle: \(app.path)")
-				for runningApp in runningApps {
-					msc_debug_log("  - Terminating: \(runningApp.bundleURL?.path ?? "unknown")")
-					_ = runningApp.terminate()
+					msc_debug_log("Terminating \(runningApps.count) app(s) for bundle: \(app.path)")
+					for runningApp in runningApps {
+						msc_debug_log("  - Terminating: \(runningApp.bundleURL?.path ?? "unknown")")
+						_ = runningApp.terminate()
+					}
 				}
 			}
 		}

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -238,7 +238,12 @@ class MSCBlockingAppsController: NSObject {
 		blockingScrollView.hasVerticalScroller = true
 		blockingScrollView.hasHorizontalScroller = false
 		blockingScrollView.autohidesScrollers = true
-		blockingScrollView.borderType = .bezelBorder
+		blockingScrollView.borderType = .lineBorder
+		blockingScrollView.wantsLayer = true
+		blockingScrollView.layer?.cornerRadius = 6
+		blockingScrollView.layer?.masksToBounds = true
+		blockingScrollView.layer?.borderWidth = 1
+		blockingScrollView.layer?.borderColor = NSColor.separatorColor.cgColor
 		blockingScrollView.documentView = blockingStackView
 		contentView.addSubview(blockingScrollView)
 
@@ -421,7 +426,12 @@ class MSCBlockingAppsController: NSObject {
 		closedScrollView.hasVerticalScroller = true
 		closedScrollView.hasHorizontalScroller = false
 		closedScrollView.autohidesScrollers = true
-		closedScrollView.borderType = .bezelBorder
+		closedScrollView.borderType = .lineBorder
+		closedScrollView.wantsLayer = true
+		closedScrollView.layer?.cornerRadius = 6
+		closedScrollView.layer?.masksToBounds = true
+		closedScrollView.layer?.borderWidth = 1
+		closedScrollView.layer?.borderColor = NSColor.separatorColor.cgColor
 		closedScrollView.documentView = closedStackView
 		containerView.addSubview(closedScrollView)
 

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -50,6 +50,10 @@ class MSCBlockingAppsController: NSObject {
 	// Custom quit script tracking - maps app names to their quit scripts
 	private var appQuitScripts: [String: String] = [:] // keyed by app name (e.g. "Safari.app")
 
+	// Removal tracking - apps being removed shouldn't be reopened
+	private var appsBeingRemovedNames: Set<String> = [] // app names being removed
+	private var appsBeingRemovedPaths: Set<String> = [] // app paths being removed
+
 	// Reopen apps after update
 	private var reopenCheckbox: NSButton?
 	private(set) var appsToReopenAfterUpdate: [String] = []
@@ -85,8 +89,10 @@ class MSCBlockingAppsController: NSObject {
 		appsToCheck = []
 		manualQuitAppNames = []
 		appQuitScripts = [:]
+		appsBeingRemovedNames = []
 		for update_item in getUpdateList() {
 			let preventAutoQuit = update_item["prevent_auto_quit_on_update"] as? Bool ?? false
+			let isBeingRemoved = update_item["status"] as? String == "will-be-removed"
 			var itemBlockingApps = [String]()
 
 			if let blocking_apps = update_item["blocking_applications"] as? [String] {
@@ -104,6 +110,14 @@ class MSCBlockingAppsController: NSObject {
 			if preventAutoQuit {
 				for appName in itemBlockingApps {
 					manualQuitAppNames.insert(appName)
+				}
+			}
+
+			// Track apps that are being removed (shouldn't be reopened)
+			if isBeingRemoved {
+				for appName in itemBlockingApps {
+					appsBeingRemovedNames.insert(appName)
+					msc_debug_log("App is being removed, won't reopen: \(appName)")
 				}
 			}
 
@@ -143,6 +157,7 @@ class MSCBlockingAppsController: NSObject {
 		var uniqueApps = [(displayName: String, path: String)]()
 		var seenNames = Set<String>()
 		manualQuitAppPaths = []
+		appsBeingRemovedPaths = []
 		for app in my_apps {
 			let displayName = app["display_name"] ?? ""
 			if !displayName.isEmpty && !seenNames.contains(displayName) {
@@ -155,12 +170,16 @@ class MSCBlockingAppsController: NSObject {
 				}
 				uniqueApps.append((displayName: displayName, path: appPath))
 
-				// Check if this app requires manual quit
+				// Check if this app requires manual quit or is being removed
 				if !appPath.isEmpty {
 					let appFileName = (appPath as NSString).lastPathComponent
 					if manualQuitAppNames.contains(appFileName) {
 						manualQuitAppPaths.insert(appPath)
 						msc_debug_log("App requires manual quit: \(displayName) at \(appPath)")
+					}
+					if appsBeingRemovedNames.contains(appFileName) {
+						appsBeingRemovedPaths.insert(appPath)
+						msc_debug_log("App is being removed: \(displayName) at \(appPath)")
 					}
 				}
 			}
@@ -197,8 +216,9 @@ class MSCBlockingAppsController: NSObject {
 		monitorTimer?.invalidate()
 
 		// Save apps to reopen if checkbox is checked and user didn't cancel
+		// Exclude apps that are being removed as they won't exist after the update
 		if !userCancelled && reopenCheckbox?.state == .on {
-			appsToReopenAfterUpdate = Array(closedApps)
+			appsToReopenAfterUpdate = closedApps.filter { !appsBeingRemovedPaths.contains($0) }
 		} else {
 			appsToReopenAfterUpdate = []
 		}
@@ -846,6 +866,8 @@ class MSCBlockingAppsController: NSObject {
 		manualQuitAppNames = []
 		manualQuitAppPaths = []
 		appQuitScripts = [:]
+		appsBeingRemovedNames = []
+		appsBeingRemovedPaths = []
 		reopenCheckbox = nil
 		// Note: appsToReopenAfterUpdate is intentionally NOT cleared here
 		// so the caller can access it after the sheet is dismissed

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -857,11 +857,14 @@ class MSCBlockingAppsController: NSObject {
 	/// Call this method after the update has completed.
 	/// Clears the list of apps to reopen after attempting to open them.
 	func reopenApps() {
+		let config = NSWorkspace.OpenConfiguration()
+		config.activates = false  // Open apps in background without bringing to foreground
+
 		for appPath in appsToReopenAfterUpdate {
-			msc_debug_log("Reopening app: \(appPath)")
+			msc_debug_log("Reopening app in background: \(appPath)")
 			NSWorkspace.shared.openApplication(
 				at: URL(fileURLWithPath: appPath),
-				configuration: NSWorkspace.OpenConfiguration()
+				configuration: config
 			) { _, error in
 				if let error = error {
 					msc_debug_log("Failed to reopen app at \(appPath): \(error.localizedDescription)")

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -246,6 +246,8 @@ class MSCBlockingAppsController: NSObject {
 		blockingScrollView.hasHorizontalScroller = false
 		blockingScrollView.autohidesScrollers = true
 		blockingScrollView.borderType = .lineBorder
+		blockingScrollView.automaticallyAdjustsContentInsets = false
+		blockingScrollView.contentInsets = NSEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
 		blockingScrollView.wantsLayer = true
 		blockingScrollView.layer?.cornerRadius = 6
 		blockingScrollView.layer?.masksToBounds = true
@@ -435,6 +437,8 @@ class MSCBlockingAppsController: NSObject {
 		closedScrollView.hasHorizontalScroller = false
 		closedScrollView.autohidesScrollers = true
 		closedScrollView.borderType = .lineBorder
+		closedScrollView.automaticallyAdjustsContentInsets = false
+		closedScrollView.contentInsets = NSEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
 		closedScrollView.wantsLayer = true
 		closedScrollView.layer?.cornerRadius = 6
 		closedScrollView.layer?.masksToBounds = true

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -8,6 +8,12 @@
 
 import Cocoa
 
+/// A flipped NSClipView that positions content from top to bottom.
+/// Used in scroll views to ensure content aligns to the top rather than the bottom.
+private class FlippedClipView: NSClipView {
+	override var isFlipped: Bool { true }
+}
+
 /// Controller that manages the blocking apps sheet UI.
 /// Presents a sheet listing running applications that must be quit before updates can proceed.
 class MSCBlockingAppsController: NSObject {
@@ -235,6 +241,7 @@ class MSCBlockingAppsController: NSObject {
 		// Create scroll view for blocking apps
 		let blockingScrollView = NSScrollView()
 		blockingScrollView.translatesAutoresizingMaskIntoConstraints = false
+		blockingScrollView.contentView = FlippedClipView()
 		blockingScrollView.hasVerticalScroller = true
 		blockingScrollView.hasHorizontalScroller = false
 		blockingScrollView.autohidesScrollers = true
@@ -423,6 +430,7 @@ class MSCBlockingAppsController: NSObject {
 		// Scroll view for closed apps
 		let closedScrollView = NSScrollView()
 		closedScrollView.translatesAutoresizingMaskIntoConstraints = false
+		closedScrollView.contentView = FlippedClipView()
 		closedScrollView.hasVerticalScroller = true
 		closedScrollView.hasHorizontalScroller = false
 		closedScrollView.autohidesScrollers = true

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -47,6 +47,10 @@ class MSCBlockingAppsController: NSObject {
 	private var manualQuitAppNames: Set<String> = [] // app names that require manual quit
 	private var manualQuitAppPaths: Set<String> = [] // app paths that require manual quit
 
+	// Reopen apps after update
+	private var reopenCheckbox: NSButton?
+	private(set) var appsToReopenAfterUpdate: [String] = []
+
 	// Layout constants
 	private let sheetWidth: CGFloat = 400
 	private let rowHeight: CGFloat = 36
@@ -180,6 +184,13 @@ class MSCBlockingAppsController: NSObject {
 		NSApp.runModal(for: sheetWindow)
 		monitorTimer?.invalidate()
 
+		// Save apps to reopen if checkbox is checked and user didn't cancel
+		if !userCancelled && reopenCheckbox?.state == .on {
+			appsToReopenAfterUpdate = Array(closedApps)
+		} else {
+			appsToReopenAfterUpdate = []
+		}
+
 		// Cleanup
 		cleanup()
 
@@ -206,7 +217,7 @@ class MSCBlockingAppsController: NSObject {
 
 	private func createSheet(for apps: [(displayName: String, path: String)]) -> NSWindow {
 		let visibleHeight = min(CGFloat(apps.count), CGFloat(maxVisibleRows)) * rowHeight
-		let sheetHeight: CGFloat = visibleHeight + 140
+		let sheetHeight: CGFloat = visibleHeight + 170  // Extra height for checkbox
 
 		let sheetWindow = NSPanel(
 			contentRect: NSRect(x: 0, y: 0, width: sheetWidth, height: sheetHeight),
@@ -262,6 +273,15 @@ class MSCBlockingAppsController: NSObject {
 		closedSection.isHidden = true
 		contentView.addSubview(closedSection)
 
+		// Reopen apps checkbox
+		let checkbox = NSButton(checkboxWithTitle: NSLocalizedString(
+			"Reopen applications after update",
+			comment: "Reopen apps after update checkbox"), target: nil, action: nil)
+		checkbox.translatesAutoresizingMaskIntoConstraints = false
+		checkbox.state = .on
+		contentView.addSubview(checkbox)
+		reopenCheckbox = checkbox
+
 		// Quit Apps button
 		let quitButton = NSButton(title: NSLocalizedString("Quit Apps", comment: "Quit Apps button title"), target: self, action: #selector(quitApps(_:)))
 		quitButton.translatesAutoresizingMaskIntoConstraints = false
@@ -300,11 +320,14 @@ class MSCBlockingAppsController: NSObject {
 			closedSection.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
 			closedSection.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
 
-			quitButton.topAnchor.constraint(equalTo: closedSection.bottomAnchor, constant: 16),
+			checkbox.topAnchor.constraint(equalTo: closedSection.bottomAnchor, constant: 12),
+			checkbox.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+
+			quitButton.topAnchor.constraint(equalTo: checkbox.bottomAnchor, constant: 16),
 			quitButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
 			quitButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
 
-			cancelButton.topAnchor.constraint(equalTo: closedSection.bottomAnchor, constant: 16),
+			cancelButton.topAnchor.constraint(equalTo: checkbox.bottomAnchor, constant: 16),
 			cancelButton.trailingAnchor.constraint(equalTo: quitButton.leadingAnchor, constant: -12),
 		])
 
@@ -810,6 +833,34 @@ class MSCBlockingAppsController: NSObject {
 		forceQuitButtons = [:]
 		manualQuitAppNames = []
 		manualQuitAppPaths = []
+		reopenCheckbox = nil
+		// Note: appsToReopenAfterUpdate is intentionally NOT cleared here
+		// so the caller can access it after the sheet is dismissed
+	}
+
+	// MARK: - Public Methods for Reopening Apps
+
+	/// Reopens all applications that were closed during the blocking apps sheet.
+	/// Call this method after the update has completed.
+	/// Clears the list of apps to reopen after attempting to open them.
+	func reopenApps() {
+		for appPath in appsToReopenAfterUpdate {
+			msc_debug_log("Reopening app: \(appPath)")
+			NSWorkspace.shared.openApplication(
+				at: URL(fileURLWithPath: appPath),
+				configuration: NSWorkspace.OpenConfiguration()
+			) { _, error in
+				if let error = error {
+					msc_debug_log("Failed to reopen app at \(appPath): \(error.localizedDescription)")
+				}
+			}
+		}
+		appsToReopenAfterUpdate = []
+	}
+
+	/// Clears the list of apps to reopen without reopening them.
+	func clearAppsToReopen() {
+		appsToReopenAfterUpdate = []
 	}
 
 	// MARK: - Actions

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -1,0 +1,832 @@
+//
+//  MSCBlockingAppsController.swift
+//  Managed Software Center
+//
+//  Created by Jordan Calhoun on 1/12/26.
+//  Copyright © 2026 The Munki Project. All rights reserved.
+//
+
+import Cocoa
+
+/// Controller that manages the blocking apps sheet UI.
+/// Presents a sheet listing running applications that must be quit before updates can proceed.
+class MSCBlockingAppsController: NSObject {
+
+	// MARK: - Properties
+
+	private weak var parentWindow: NSWindow?
+	private var sheet: NSWindow?
+	private var spinners: [String: NSProgressIndicator] = [:]
+	private var appsToQuit: [(displayName: String, path: String)] = []
+	private var quitAppsButton: NSButton?
+	private var monitorTimer: Timer?
+	private var appsToCheck: [String] = []
+	private var currentUser: String = ""
+
+	// UI elements for dynamic updates
+	private var blockingAppsStackView: NSStackView?
+	private var closedAppsStackView: NSStackView?
+	private var closedAppsSectionView: NSView?
+	private var appRowViews: [String: NSView] = [:] // keyed by app path
+	private var closedApps: Set<String> = [] // paths of closed apps
+	private var sheetHeightConstraint: NSLayoutConstraint?
+	private var closedScrollHeightConstraint: NSLayoutConstraint?
+
+	// Force quit tracking
+	private var quitInitiatedTimes: [String: Date] = [:] // keyed by app path
+	private var forceQuitButtons: [String: NSButton] = [:] // keyed by app path
+	private let forceQuitDelay: TimeInterval = 5.0
+
+	// Manual quit tracking - apps that cannot be auto-quit
+	private var manualQuitAppNames: Set<String> = [] // app names that require manual quit
+	private var manualQuitAppPaths: Set<String> = [] // app paths that require manual quit
+
+	// Layout constants
+	private let sheetWidth: CGFloat = 400
+	private let rowHeight: CGFloat = 36
+	private let iconSize: CGFloat = 32
+	private let maxVisibleRows = 6
+
+	// MARK: - Initialization
+
+	init(parentWindow: NSWindow) {
+		self.parentWindow = parentWindow
+		super.init()
+	}
+
+	// MARK: - Public Methods
+
+	/// Presents an interactive sheet listing blocking applications so the user can close them.
+	///
+	/// - Returns: `true` if blocking apps are running and user cancelled; `false` if no blocking apps or all were closed.
+	///
+	/// The sheet is dismissed automatically when all apps are closed or when the user cancels/ignores it.
+	/// This method blocks further progress until the user has handled the apps or dismissed the sheet.
+	func presentBlockingAppsSheet() -> Bool {
+		guard let mainWindow = parentWindow else {
+			msc_debug_log("Could not get main window in presentBlockingAppsSheet")
+			return false
+		}
+
+		// Gather apps to check from update list
+		appsToCheck = []
+		manualQuitAppNames = []
+		for update_item in getUpdateList() {
+			let preventAutoQuit = update_item["prevent_auto_quit_on_update"] as? Bool ?? false
+			var itemBlockingApps = [String]()
+
+			if let blocking_apps = update_item["blocking_applications"] as? [String] {
+				itemBlockingApps = blocking_apps
+			} else if let installs_items = update_item["installs"] as? [PlistDict] {
+				itemBlockingApps = installs_items.filter(
+					{ ($0["type"] as? String ?? "" == "application" &&
+					   !($0["path"] as? String ?? "").isEmpty) }).map(
+						{ ($0["path"] as? NSString ?? "").lastPathComponent })
+			}
+
+			appsToCheck += itemBlockingApps
+
+			// Track apps that require manual quit
+			if preventAutoQuit {
+				for appName in itemBlockingApps {
+					manualQuitAppNames.insert(appName)
+				}
+			}
+		}
+
+		let running_apps = getRunningBlockingApps(appsToCheck)
+
+		if running_apps.isEmpty {
+			return false
+		}
+
+		guard let user = getconsoleuser() else {
+			return false
+		}
+		currentUser = user
+
+		let other_users_apps = running_apps
+			.filter({ $0["user"] ?? "" != currentUser })
+			.map({ $0["display_name"] ?? "" })
+
+		if !other_users_apps.isEmpty {
+			showOtherUsersAlert(apps: other_users_apps, in: mainWindow)
+			return true
+		}
+
+		// Get apps for current user only
+		let my_apps = running_apps.filter({ $0["user"] ?? "" == currentUser })
+
+		// Build a set of unique apps with their paths for icon lookup
+		var uniqueApps = [(displayName: String, path: String)]()
+		var seenNames = Set<String>()
+		manualQuitAppPaths = []
+		for app in my_apps {
+			let displayName = app["display_name"] ?? ""
+			if !displayName.isEmpty && !seenNames.contains(displayName) {
+				seenNames.insert(displayName)
+				var appPath = app["pathname"] ?? ""
+				if !appPath.isEmpty {
+					while !appPath.isEmpty && !appPath.hasSuffix(".app") {
+						appPath = (appPath as NSString).deletingLastPathComponent
+					}
+				}
+				uniqueApps.append((displayName: displayName, path: appPath))
+
+				// Check if this app requires manual quit
+				if !appPath.isEmpty {
+					let appFileName = (appPath as NSString).lastPathComponent
+					if manualQuitAppNames.contains(appFileName) {
+						manualQuitAppPaths.insert(appPath)
+						msc_debug_log("App requires manual quit: \(displayName) at \(appPath)")
+					}
+				}
+			}
+		}
+
+		appsToQuit = uniqueApps
+		spinners = [:]
+		appRowViews = [:]
+		closedApps = []
+
+		// Create and configure the sheet
+		let sheetWindow = createSheet(for: uniqueApps)
+		sheet = sheetWindow
+
+		// Track result
+		var userCancelled = true
+
+		// Start monitoring for app closures
+		startMonitoring(mainWindow: mainWindow, userCancelled: &userCancelled)
+
+		// Show the sheet and wait for it to complete
+		mainWindow.beginSheet(sheetWindow) { [weak self] response in
+			self?.monitorTimer?.invalidate()
+			if response == .cancel {
+				userCancelled = true
+			} else if response == .OK {
+				userCancelled = false
+			}
+			NSApp.stopModal()
+		}
+
+		// Run modal to block until sheet is dismissed
+		NSApp.runModal(for: sheetWindow)
+		monitorTimer?.invalidate()
+
+		// Cleanup
+		cleanup()
+
+		return userCancelled
+	}
+
+	// MARK: - Private Methods
+
+	private func showOtherUsersAlert(apps: [String], in window: NSWindow) {
+		let alert = NSAlert()
+		alert.messageText = NSLocalizedString(
+			"Applications in use by others",
+			comment: "Other Users Blocking Apps Running title")
+		let formatString = NSLocalizedString(
+			"Other logged in users are using the following " +
+			"applications. Try updating later when they are no longer " +
+			"in use:\n\n%@",
+			comment: "Other Users Blocking Apps Running detail")
+		alert.informativeText = String(
+			format: formatString, Array(Set(apps)).joined(separator: "\n"))
+		alert.addButton(withTitle: NSLocalizedString("OK", comment: "OK button title"))
+		alert.beginSheetModal(for: window, completionHandler: { _ in })
+	}
+
+	private func createSheet(for apps: [(displayName: String, path: String)]) -> NSWindow {
+		let visibleHeight = min(CGFloat(apps.count), CGFloat(maxVisibleRows)) * rowHeight
+		let sheetHeight: CGFloat = visibleHeight + 140
+
+		let sheetWindow = NSPanel(
+			contentRect: NSRect(x: 0, y: 0, width: sheetWidth, height: sheetHeight),
+			styleMask: [.titled, .docModalWindow],
+			backing: .buffered,
+			defer: true
+		)
+
+		let contentView = NSView(frame: NSRect(x: 0, y: 0, width: sheetWidth, height: sheetHeight))
+
+		// Title label
+		let titleLabel = NSTextField(labelWithString: NSLocalizedString(
+			"Conflicting applications running",
+			comment: "Blocking Apps Running title"))
+		titleLabel.font = NSFont.boldSystemFont(ofSize: 13)
+		titleLabel.translatesAutoresizingMaskIntoConstraints = false
+		contentView.addSubview(titleLabel)
+
+		// Message label
+		let messageLabel = NSTextField(wrappingLabelWithString: NSLocalizedString(
+			"Please quit the following applications to continue with the update:",
+			comment: "Blocking Apps Running detail for auto-quit sheet"))
+		messageLabel.font = NSFont.systemFont(ofSize: 11)
+		messageLabel.textColor = .secondaryLabelColor
+		messageLabel.translatesAutoresizingMaskIntoConstraints = false
+		contentView.addSubview(messageLabel)
+
+		// Create stack view for blocking app rows
+		let blockingStackView = createBlockingAppsStackView(apps: apps)
+		blockingAppsStackView = blockingStackView
+
+		// Create scroll view for blocking apps
+		let blockingScrollView = NSScrollView()
+		blockingScrollView.translatesAutoresizingMaskIntoConstraints = false
+		blockingScrollView.hasVerticalScroller = true
+		blockingScrollView.hasHorizontalScroller = false
+		blockingScrollView.autohidesScrollers = true
+		blockingScrollView.borderType = .bezelBorder
+		blockingScrollView.documentView = blockingStackView
+		contentView.addSubview(blockingScrollView)
+
+		// Create closed apps section (initially hidden)
+		let closedSection = createClosedAppsSection()
+		closedAppsSectionView = closedSection
+		closedSection.isHidden = true
+		contentView.addSubview(closedSection)
+
+		// Quit Apps button
+		let quitButton = NSButton(title: NSLocalizedString("Quit Apps", comment: "Quit Apps button title"), target: self, action: #selector(quitApps(_:)))
+		quitButton.translatesAutoresizingMaskIntoConstraints = false
+		quitButton.bezelStyle = .rounded
+		quitButton.keyEquivalent = "\r"
+		contentView.addSubview(quitButton)
+		quitAppsButton = quitButton
+
+		// Cancel button
+		let cancelButton = NSButton(title: NSLocalizedString("Cancel", comment: "Cancel button title/short action text"), target: self, action: #selector(cancelSheet(_:)))
+		cancelButton.translatesAutoresizingMaskIntoConstraints = false
+		cancelButton.bezelStyle = .rounded
+		cancelButton.keyEquivalent = "\u{1B}"
+		contentView.addSubview(cancelButton)
+
+		// Layout constraints
+		NSLayoutConstraint.activate([
+			titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+			titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+			titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+
+			messageLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+			messageLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+			messageLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+
+			blockingScrollView.topAnchor.constraint(equalTo: messageLabel.bottomAnchor, constant: 12),
+			blockingScrollView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+			blockingScrollView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+			blockingScrollView.heightAnchor.constraint(equalToConstant: visibleHeight + 8),
+
+			blockingStackView.topAnchor.constraint(equalTo: blockingScrollView.contentView.topAnchor),
+			blockingStackView.leadingAnchor.constraint(equalTo: blockingScrollView.contentView.leadingAnchor, constant: 4),
+			blockingStackView.trailingAnchor.constraint(equalTo: blockingScrollView.contentView.trailingAnchor, constant: -4),
+
+			closedSection.topAnchor.constraint(equalTo: blockingScrollView.bottomAnchor, constant: 12),
+			closedSection.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+			closedSection.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+
+			quitButton.topAnchor.constraint(equalTo: closedSection.bottomAnchor, constant: 16),
+			quitButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+			quitButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
+
+			cancelButton.topAnchor.constraint(equalTo: closedSection.bottomAnchor, constant: 16),
+			cancelButton.trailingAnchor.constraint(equalTo: quitButton.leadingAnchor, constant: -12),
+		])
+
+		sheetWindow.contentView = contentView
+		return sheetWindow
+	}
+
+	private func createBlockingAppsStackView(apps: [(displayName: String, path: String)]) -> NSStackView {
+		let stackView = NSStackView()
+		stackView.orientation = .vertical
+		stackView.alignment = .leading
+		stackView.spacing = 4
+		stackView.translatesAutoresizingMaskIntoConstraints = false
+
+		let spinnerSize: CGFloat = 16
+
+		for app in apps {
+			let rowView = NSView()
+			rowView.translatesAutoresizingMaskIntoConstraints = false
+
+			let isManualQuit = manualQuitAppPaths.contains(app.path)
+
+			// App icon
+			let iconView = NSImageView()
+			iconView.translatesAutoresizingMaskIntoConstraints = false
+			iconView.imageScaling = .scaleProportionallyUpOrDown
+			if !app.path.isEmpty {
+				iconView.image = NSWorkspace.shared.icon(forFile: app.path)
+			} else {
+				iconView.image = NSImage(named: NSImage.applicationIconName)
+			}
+
+			// App name label
+			let nameLabel = NSTextField(labelWithString: app.displayName)
+			nameLabel.translatesAutoresizingMaskIntoConstraints = false
+			nameLabel.font = NSFont.systemFont(ofSize: 13)
+			nameLabel.lineBreakMode = .byTruncatingTail
+
+			rowView.addSubview(iconView)
+			rowView.addSubview(nameLabel)
+
+			if !app.path.isEmpty {
+				appRowViews[app.path] = rowView
+			}
+
+			if isManualQuit {
+				// Show "Manual quit required" label for apps that can't be auto-quit
+				let manualQuitLabel = NSTextField(labelWithString: NSLocalizedString(
+					"Manual quit required",
+					comment: "Manual quit required label"))
+				manualQuitLabel.translatesAutoresizingMaskIntoConstraints = false
+				manualQuitLabel.font = NSFont.systemFont(ofSize: 10)
+				manualQuitLabel.textColor = .systemOrange
+				manualQuitLabel.alignment = .right
+
+				rowView.addSubview(manualQuitLabel)
+
+				NSLayoutConstraint.activate([
+					rowView.heightAnchor.constraint(equalToConstant: rowHeight),
+					rowView.widthAnchor.constraint(equalToConstant: sheetWidth - 40),
+
+					iconView.leadingAnchor.constraint(equalTo: rowView.leadingAnchor, constant: 4),
+					iconView.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+					iconView.widthAnchor.constraint(equalToConstant: iconSize),
+					iconView.heightAnchor.constraint(equalToConstant: iconSize),
+
+					nameLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
+					nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: manualQuitLabel.leadingAnchor, constant: -8),
+					nameLabel.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+
+					manualQuitLabel.trailingAnchor.constraint(equalTo: rowView.trailingAnchor, constant: -4),
+					manualQuitLabel.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+				])
+			} else {
+				// Progress spinner (hidden by default) for apps that can be auto-quit
+				let spinner = NSProgressIndicator()
+				spinner.translatesAutoresizingMaskIntoConstraints = false
+				spinner.style = .spinning
+				spinner.controlSize = .small
+				spinner.isHidden = true
+				spinner.isDisplayedWhenStopped = false
+
+				if !app.path.isEmpty {
+					spinners[app.path] = spinner
+				}
+
+				rowView.addSubview(spinner)
+
+				NSLayoutConstraint.activate([
+					rowView.heightAnchor.constraint(equalToConstant: rowHeight),
+					rowView.widthAnchor.constraint(equalToConstant: sheetWidth - 40),
+
+					iconView.leadingAnchor.constraint(equalTo: rowView.leadingAnchor, constant: 4),
+					iconView.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+					iconView.widthAnchor.constraint(equalToConstant: iconSize),
+					iconView.heightAnchor.constraint(equalToConstant: iconSize),
+
+					nameLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
+					nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: spinner.leadingAnchor, constant: -8),
+					nameLabel.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+
+					spinner.trailingAnchor.constraint(equalTo: rowView.trailingAnchor, constant: -4),
+					spinner.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+					spinner.widthAnchor.constraint(equalToConstant: spinnerSize),
+					spinner.heightAnchor.constraint(equalToConstant: spinnerSize),
+				])
+			}
+
+			stackView.addArrangedSubview(rowView)
+		}
+
+		return stackView
+	}
+
+	private func createClosedAppsSection() -> NSView {
+		let containerView = NSView()
+		containerView.translatesAutoresizingMaskIntoConstraints = false
+
+		// "Closed Applications" label
+		let closedLabel = NSTextField(labelWithString: NSLocalizedString(
+			"Closed Applications",
+			comment: "Closed Applications section title"))
+		closedLabel.font = NSFont.boldSystemFont(ofSize: 11)
+		closedLabel.textColor = .secondaryLabelColor
+		closedLabel.translatesAutoresizingMaskIntoConstraints = false
+		containerView.addSubview(closedLabel)
+
+		// Stack view for closed apps
+		let closedStackView = NSStackView()
+		closedStackView.orientation = .vertical
+		closedStackView.alignment = .leading
+		closedStackView.spacing = 4
+		closedStackView.translatesAutoresizingMaskIntoConstraints = false
+		closedAppsStackView = closedStackView
+
+		// Scroll view for closed apps
+		let closedScrollView = NSScrollView()
+		closedScrollView.translatesAutoresizingMaskIntoConstraints = false
+		closedScrollView.hasVerticalScroller = true
+		closedScrollView.hasHorizontalScroller = false
+		closedScrollView.autohidesScrollers = true
+		closedScrollView.borderType = .bezelBorder
+		closedScrollView.documentView = closedStackView
+		containerView.addSubview(closedScrollView)
+
+		// Initial height constraint (will be updated as apps are added)
+		let scrollHeightConstraint = closedScrollView.heightAnchor.constraint(equalToConstant: rowHeight + 8)
+		closedScrollHeightConstraint = scrollHeightConstraint
+
+		NSLayoutConstraint.activate([
+			closedLabel.topAnchor.constraint(equalTo: containerView.topAnchor),
+			closedLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+			closedLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+
+			closedScrollView.topAnchor.constraint(equalTo: closedLabel.bottomAnchor, constant: 6),
+			closedScrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+			closedScrollView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+			closedScrollView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+			scrollHeightConstraint,
+
+			closedStackView.topAnchor.constraint(equalTo: closedScrollView.contentView.topAnchor),
+			closedStackView.leadingAnchor.constraint(equalTo: closedScrollView.contentView.leadingAnchor, constant: 4),
+			closedStackView.trailingAnchor.constraint(equalTo: closedScrollView.contentView.trailingAnchor, constant: -4),
+		])
+
+		return containerView
+	}
+
+	private func createClosedAppRow(displayName: String, path: String) -> NSView {
+		let rowView = NSView()
+		rowView.translatesAutoresizingMaskIntoConstraints = false
+
+		// App icon
+		let iconView = NSImageView()
+		iconView.translatesAutoresizingMaskIntoConstraints = false
+		iconView.imageScaling = .scaleProportionallyUpOrDown
+		if !path.isEmpty {
+			iconView.image = NSWorkspace.shared.icon(forFile: path)
+		} else {
+			iconView.image = NSImage(named: NSImage.applicationIconName)
+		}
+
+		// App name label
+		let nameLabel = NSTextField(labelWithString: displayName)
+		nameLabel.translatesAutoresizingMaskIntoConstraints = false
+		nameLabel.font = NSFont.systemFont(ofSize: 13)
+		nameLabel.textColor = .secondaryLabelColor
+		nameLabel.lineBreakMode = .byTruncatingTail
+
+		// Checkmark image
+		let checkmarkView = NSImageView()
+		checkmarkView.translatesAutoresizingMaskIntoConstraints = false
+		checkmarkView.imageScaling = .scaleProportionallyUpOrDown
+		if #available(macOS 11.0, *) {
+			if let checkmarkImage = NSImage(systemSymbolName: "checkmark.circle.fill", accessibilityDescription: "Closed") {
+				checkmarkView.image = checkmarkImage
+				checkmarkView.contentTintColor = .systemGreen
+			}
+		} else {
+			// Fallback for older macOS versions
+			checkmarkView.image = NSImage(named: NSImage.statusAvailableName)
+		}
+
+		rowView.addSubview(iconView)
+		rowView.addSubview(nameLabel)
+		rowView.addSubview(checkmarkView)
+
+		let checkmarkSize: CGFloat = 16
+
+		NSLayoutConstraint.activate([
+			rowView.heightAnchor.constraint(equalToConstant: rowHeight),
+			rowView.widthAnchor.constraint(equalToConstant: sheetWidth - 40),
+
+			iconView.leadingAnchor.constraint(equalTo: rowView.leadingAnchor, constant: 4),
+			iconView.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+			iconView.widthAnchor.constraint(equalToConstant: iconSize),
+			iconView.heightAnchor.constraint(equalToConstant: iconSize),
+
+			nameLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
+			nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: checkmarkView.leadingAnchor, constant: -8),
+			nameLabel.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+
+			checkmarkView.trailingAnchor.constraint(equalTo: rowView.trailingAnchor, constant: -4),
+			checkmarkView.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+			checkmarkView.widthAnchor.constraint(equalToConstant: checkmarkSize),
+			checkmarkView.heightAnchor.constraint(equalToConstant: checkmarkSize),
+		])
+
+		return rowView
+	}
+
+	private func moveAppToClosedSection(path: String) {
+		guard !closedApps.contains(path),
+			  let rowView = appRowViews[path],
+			  let blockingStack = blockingAppsStackView,
+			  let closedStack = closedAppsStackView else {
+			return
+		}
+
+		// Find the app info
+		guard let appInfo = appsToQuit.first(where: { $0.path == path }) else {
+			return
+		}
+
+		// Mark as closed
+		closedApps.insert(path)
+
+		// Stop and hide the spinner
+		if let spinner = spinners[path] {
+			spinner.stopAnimation(nil)
+			spinner.isHidden = true
+		}
+
+		// Remove from blocking apps stack view
+		blockingStack.removeArrangedSubview(rowView)
+		rowView.removeFromSuperview()
+
+		// Create a new row for the closed apps section with checkmark
+		let closedRow = createClosedAppRow(displayName: appInfo.displayName, path: path)
+		closedStack.addArrangedSubview(closedRow)
+
+		// Show the closed apps section if this is the first closed app
+		if closedAppsSectionView?.isHidden == true {
+			closedAppsSectionView?.isHidden = false
+
+			// Animate the sheet height change
+			if let sheetWindow = sheet {
+				var frame = sheetWindow.frame
+				let additionalHeight: CGFloat = rowHeight + 40 // section title + scroll view + padding
+				frame.size.height += additionalHeight
+				frame.origin.y -= additionalHeight
+				sheetWindow.setFrame(frame, display: true, animate: true)
+			}
+		}
+
+		// Update the closed scroll view height based on number of closed apps
+		let closedCount = closedApps.count
+		let newHeight = min(CGFloat(closedCount), CGFloat(maxVisibleRows)) * rowHeight + 8
+		if let heightConstraint = closedScrollHeightConstraint, heightConstraint.constant != newHeight {
+			let heightDiff = newHeight - heightConstraint.constant
+			heightConstraint.constant = newHeight
+
+			// Adjust sheet height if needed
+			if closedCount > 1, let sheetWindow = sheet {
+				var frame = sheetWindow.frame
+				frame.size.height += heightDiff
+				frame.origin.y -= heightDiff
+				sheetWindow.setFrame(frame, display: true, animate: true)
+			}
+		}
+	}
+
+	private func startMonitoring(mainWindow: NSWindow, userCancelled: inout Bool) {
+		let appsToCheckCopy = appsToCheck
+		let currentUserCopy = currentUser
+
+		let timer = Timer(timeInterval: 1.0, repeats: true) { [weak self, weak mainWindow] timer in
+			guard let self = self, let mainWindow = mainWindow else {
+				timer.invalidate()
+				return
+			}
+
+			let stillRunning = getRunningBlockingApps(appsToCheckCopy)
+			let myStillRunning = stillRunning.filter({ $0["user"] ?? "" == currentUserCopy })
+
+			// Get the paths of still-running apps (extract the executable paths)
+			var stillRunningPaths = Set<String>()
+			for app in myStillRunning {
+				let appPath = app["pathname"] ?? ""
+				if !appPath.isEmpty {
+					stillRunningPaths.insert(appPath)
+				}
+			}
+
+			msc_debug_log("Still running paths: \(stillRunningPaths)")
+			msc_debug_log("Apps to quit paths: \(self.appsToQuit.map { $0.path })")
+			msc_debug_log("Already closed: \(self.closedApps)")
+
+			// Helper function to check if any running process is part of an app bundle
+			func isAppStillRunning(_ appBundlePath: String) -> Bool {
+				// Check if any running process path contains this app bundle path
+				// This handles nested .app bundles (e.g., Docker.app contains Docker Desktop.app)
+				let bundlePrefix = appBundlePath + "/"
+				for runningPath in stillRunningPaths {
+					if runningPath.hasPrefix(bundlePrefix) || runningPath == appBundlePath {
+						return true
+					}
+				}
+				return false
+			}
+
+			// Check for newly closed apps and move them to the closed section
+			// Must be done on main thread for UI updates
+			DispatchQueue.main.async {
+				let now = Date()
+
+				for app in self.appsToQuit {
+					if !app.path.isEmpty && !isAppStillRunning(app.path) && !self.closedApps.contains(app.path) {
+						msc_debug_log("Moving app to closed section: \(app.displayName) at \(app.path)")
+						self.moveAppToClosedSection(path: app.path)
+					}
+
+					// Check if app has exceeded force quit delay and is still running
+					if let quitTime = self.quitInitiatedTimes[app.path],
+					   now.timeIntervalSince(quitTime) >= self.forceQuitDelay,
+					   isAppStillRunning(app.path),
+					   !self.closedApps.contains(app.path),
+					   self.forceQuitButtons[app.path] == nil {
+						// Show force quit button for this app
+						self.showForceQuitButton(for: app.path)
+					}
+				}
+
+				if myStillRunning.isEmpty {
+					// All apps have been closed
+					timer.invalidate()
+					if let sheetWindow = self.sheet {
+						mainWindow.endSheet(sheetWindow, returnCode: .OK)
+					}
+				}
+			}
+		}
+
+		// Add timer to common run loop modes so it fires during modal sessions
+		RunLoop.main.add(timer, forMode: .common)
+		monitorTimer = timer
+	}
+
+	private func showForceQuitButton(for appPath: String) {
+		guard let rowView = appRowViews[appPath],
+			  let spinner = spinners[appPath] else {
+			return
+		}
+
+		// Hide and stop the spinner
+		spinner.stopAnimation(nil)
+		spinner.isHidden = true
+
+		// Create the Force Quit button
+		let forceQuitButton = NSButton(title: NSLocalizedString("Force Quit", comment: "Force Quit button title"), target: self, action: #selector(forceQuitButtonClicked(_:)))
+		forceQuitButton.translatesAutoresizingMaskIntoConstraints = false
+		forceQuitButton.bezelStyle = .rounded
+		forceQuitButton.controlSize = .small
+		forceQuitButton.font = NSFont.systemFont(ofSize: 10)
+
+		// Store the app path in the button's identifier for later retrieval
+		forceQuitButton.identifier = NSUserInterfaceItemIdentifier(appPath)
+
+		rowView.addSubview(forceQuitButton)
+
+		NSLayoutConstraint.activate([
+			forceQuitButton.trailingAnchor.constraint(equalTo: rowView.trailingAnchor, constant: -4),
+			forceQuitButton.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+		])
+
+		forceQuitButtons[appPath] = forceQuitButton
+
+		msc_debug_log("Showing Force Quit button for: \(appPath)")
+	}
+
+	@objc private func forceQuitButtonClicked(_ sender: NSButton) {
+		guard let appPath = sender.identifier?.rawValue,
+			  let appInfo = appsToQuit.first(where: { $0.path == appPath }),
+			  let mainWindow = parentWindow else {
+			return
+		}
+
+		// Show confirmation alert
+		let alert = NSAlert()
+		alert.messageText = NSLocalizedString(
+			"Force Quit Application?",
+			comment: "Force Quit confirmation title")
+		let formatString = NSLocalizedString(
+			"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost.",
+			comment: "Force Quit confirmation message")
+		alert.informativeText = String(format: formatString, appInfo.displayName)
+		alert.alertStyle = .warning
+		alert.addButton(withTitle: NSLocalizedString("Force Quit", comment: "Force Quit button title"))
+		alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Cancel button title/short action text"))
+
+		alert.beginSheetModal(for: sheet ?? mainWindow) { [weak self] response in
+			if response == .alertFirstButtonReturn {
+				self?.performForceQuit(for: appPath)
+			}
+		}
+	}
+
+	private func performForceQuit(for appPath: String) {
+		let bundleURL = URL(fileURLWithPath: appPath)
+		let bundlePrefix = appPath + "/"
+
+		// Find all running apps that match this bundle or are nested inside it
+		let runningApps = NSWorkspace.shared.runningApplications.filter { runningApp in
+			guard let runningBundleURL = runningApp.bundleURL else { return false }
+			let runningPath = runningBundleURL.path
+			return runningBundleURL == bundleURL ||
+				   runningPath.hasPrefix(bundlePrefix)
+		}
+
+		msc_debug_log("Force terminating \(runningApps.count) app(s) for bundle: \(appPath)")
+		for runningApp in runningApps {
+			msc_debug_log("  - Force terminating: \(runningApp.bundleURL?.path ?? "unknown")")
+			_ = runningApp.forceTerminate()
+		}
+
+		// Remove the force quit button and show spinner while we wait for it to close
+		if let button = forceQuitButtons[appPath] {
+			button.removeFromSuperview()
+			forceQuitButtons.removeValue(forKey: appPath)
+		}
+
+		if let spinner = spinners[appPath] {
+			spinner.isHidden = false
+			spinner.startAnimation(nil)
+		}
+
+		// Reset the quit initiation time so we don't immediately show the force quit button again
+		quitInitiatedTimes[appPath] = Date()
+	}
+
+	private func cleanup() {
+		sheet = nil
+		spinners = [:]
+		appsToQuit = []
+		quitAppsButton = nil
+		monitorTimer = nil
+		appsToCheck = []
+		blockingAppsStackView = nil
+		closedAppsStackView = nil
+		closedAppsSectionView = nil
+		appRowViews = [:]
+		closedApps = []
+		sheetHeightConstraint = nil
+		closedScrollHeightConstraint = nil
+		quitInitiatedTimes = [:]
+		forceQuitButtons = [:]
+		manualQuitAppNames = []
+		manualQuitAppPaths = []
+	}
+
+	// MARK: - Actions
+
+	@objc private func cancelSheet(_ sender: Any?) {
+		guard let sheetWindow = sheet,
+			  let mainWindow = parentWindow else {
+			return
+		}
+		mainWindow.endSheet(sheetWindow, returnCode: .cancel)
+	}
+
+	@objc private func quitApps(_ sender: Any?) {
+		quitAppsButton?.isEnabled = false
+
+		for app in appsToQuit {
+			guard !app.path.isEmpty else { continue }
+
+			// Skip apps that require manual quit
+			if manualQuitAppPaths.contains(app.path) {
+				msc_debug_log("Skipping auto-quit for manual quit app: \(app.displayName)")
+				continue
+			}
+
+			// Only show spinner for apps that haven't been closed yet
+			if !closedApps.contains(app.path) {
+				if let spinner = spinners[app.path] {
+					spinner.isHidden = false
+					spinner.startAnimation(nil)
+				}
+
+				// Record quit initiation time for force quit tracking
+				quitInitiatedTimes[app.path] = Date()
+
+				// Find the running application by its bundle URL and terminate it
+				let bundleURL = URL(fileURLWithPath: app.path)
+				let bundlePrefix = app.path + "/"
+
+				// Find all running apps that match this bundle or are nested inside it
+				// This handles apps like Docker that contain nested .app bundles
+				let runningApps = NSWorkspace.shared.runningApplications.filter { runningApp in
+					guard let runningBundleURL = runningApp.bundleURL else { return false }
+					let runningPath = runningBundleURL.path
+					return runningBundleURL == bundleURL ||
+						   runningPath.hasPrefix(bundlePrefix)
+				}
+
+				msc_debug_log("Terminating \(runningApps.count) app(s) for bundle: \(app.path)")
+				for runningApp in runningApps {
+					msc_debug_log("  - Terminating: \(runningApp.bundleURL?.path ?? "unknown")")
+					_ = runningApp.terminate()
+				}
+			}
+		}
+
+		// Re-enable the button after a delay in case some apps don't quit
+		DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+			self?.quitAppsButton?.isEnabled = true
+		}
+	}
+}

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -528,7 +528,7 @@ class MainWindowController: NSWindowController {
         let tasktype = managedsoftwareupdate_task
         managedsoftwareupdate_task = ""
         _update_in_progress = false
-        
+
         // The managedsoftwareupdate run will have changed state preferences
         // in ManagedInstalls.plist. Load the new values.
         reloadPrefs()
@@ -546,6 +546,10 @@ class MainWindowController: NSWindowController {
                 msc_log("MSC", "cant_update", msg: "Install session failed")
                 alertMessageText = NSLocalizedString(
                     "Install session failed", comment: "Install Session Failed title")
+                // Clear the blocking apps controller since install failed
+                if alert_controller.blockingAppsController != nil {
+                    alert_controller.clearBlockingAppsController()
+                }
             }
             if sessionResult == -1 {
                 // connection was dropped unexpectedly
@@ -607,10 +611,16 @@ class MainWindowController: NSWindowController {
             updateNow()
             return
         }
-        
+
+        // Install session completed successfully - reopen any apps that were closed
+        // (only if AutoQuitAppsOnUpdate was enabled and the blocking apps controller was used)
+        if tasktype == "installwithnologout" && alert_controller.blockingAppsController != nil {
+            alert_controller.reopenAppsAfterUpdate()
+        }
+
         // all done checking and/or installing: display results
         resetAndReload()
-        
+
         if updateCheckNeeded() {
             // more stuff pending? Let's do it...
             updateNow()

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -876,11 +876,20 @@ class MainWindowController: NSWindowController {
             }
             // warn about need to logout or restart
             alert_controller.confirmUpdatesAndInstall()
-        } else {
-            if alert_controller.alertedToBlockingAppsRunning() {
-                loadUpdatesPage(self)
-                return
-            }
+		} else {
+			if pythonishBool(pref("AutoQuitForAppUpdates")) {
+				//auto quit enabled, lets do some magic
+				if alert_controller.autoQuitAlertedToBlockingAppsRunning() {
+					loadUpdatesPage(self)
+					return
+				}
+			} else {
+				// Fallback to existing logic if auto qutting isn't enabled
+				if alert_controller.alertedToBlockingAppsRunning() {
+					loadUpdatesPage(self)
+					return
+				}
+			}
             if alert_controller.alertedToRunningOnBatteryAndCancelled() {
                 loadUpdatesPage(self)
                 return

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -877,7 +877,7 @@ class MainWindowController: NSWindowController {
             // warn about need to logout or restart
             alert_controller.confirmUpdatesAndInstall()
 		} else {
-			if pythonishBool(pref("AutoQuitForAppUpdates")) {
+			if pythonishBool(pref("AutoQuitAppsOnUpdate")) {
 				//auto quit enabled, lets do some magic
 				if alert_controller.autoQuitAlertedToBlockingAppsRunning() {
 					loadUpdatesPage(self)

--- a/code/apps/Managed Software Center/Managed Software Center/da.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/da.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Slut";
 
+/* Quit Apps button title */
+"Quit Apps" = "Afslut Apps";
+
+/* Force Quit button title */
+"Force Quit" = "Tvinge op";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Tving afslutning af applikation?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Er du sikker på, at du vil tvinge \"%@\" til at afslutte ? Eventuelle ikke-gemte ændringer kan gå tabt.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Lukkede applikationer";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Genåbn applikationer efter opdatering";
+
+/* Manual quit required label */
+"Manual quit required" = "Manuel afslutning påkrævet";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Luk venligst følgende programmer for at fortsætte med opdateringen:";
+
 /* Removal Error status text */
 "Removal Error" = "Fejl ved fjernelse";
 

--- a/code/apps/Managed Software Center/Managed Software Center/de.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/de.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Beenden";
 
+/* Quit Apps button title */
+"Quit Apps" = "Apps beenden";
+
+/* Force Quit button title */
+"Force Quit" = "Beenden erzwingen";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Anwendung zwangsweise beenden?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Sind Sie sicher, dass Sie \"%@\" zwangsweise beenden möchten? ? Alle nicht gespeicherten Änderungen gehen möglicherweise verloren.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Geschlossene Anwendungen";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Anwendungen nach dem Update erneut öffnen.";
+
+/* Manual quit required label */
+"Manual quit required" = "Manuelles Beenden erforderlich";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Bitte beenden Sie die folgenden Anwendungen, um mit dem Update fortzufahren:";
+
 /* Removal Error status text */
 "Removal Error" = "Fehler beim Entfernen";
 

--- a/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Quit";
 
+/* Quit Apps button title */
+"Quit Apps" = "Quit Apps";
+
+/* Force Quit button title */
+"Force Quit" = "Force Quit";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Force Quit Application?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Closed Applications";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Reopen applications after update";
+
+/* Manual quit required label */
+"Manual quit required" = "Manual quit required";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Please quit the following applications to continue with the update:";
+
 /* Removal Error status text */
 "Removal Error" = "Removal Error";
 

--- a/code/apps/Managed Software Center/Managed Software Center/es.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/es.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Salir";
 
+/* Quit Apps button title */
+"Quit Apps" = "Salir de las aplicaciones";
+
+/* Force Quit button title */
+"Force Quit" = "Forzar salida";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "¿Forzar el cierre de la aplicación?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "¿Estás seguro de que quieres forzar el cierre de \"%@\"? Es posible que se pierdan los cambios no guardados.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Aplicaciones cerradas";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Vuelva a abrir las aplicaciones después de la actualización.";
+
+/* Manual quit required label */
+"Manual quit required" = "Se requiere la salida manual.";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Para continuar con la actualización, cierre las siguientes aplicaciones:";
+
 /* Removal Error status text */
 "Removal Error" = "Error al desinstalar";
 

--- a/code/apps/Managed Software Center/Managed Software Center/fi.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/fi.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Lopeta";
 
+/* Quit Apps button title */
+"Quit Apps" = "Lopeta Apps";
+
+/* Force Quit button title */
+"Force Quit" = "Pakota lopettamaan";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Pakota sovellus lopettamaan?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Oletko varma, että haluat pakottaa \"%@\" lopettamaan? Tallentamattomat muutokset saattavat kadota.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Suljetut sovellukset";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Avaa sovellukset uudelleen päivityksen jälkeen";
+
+/* Manual quit required label */
+"Manual quit required" = "Manuaalinen lopetus vaaditaan";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Sulje seuraavat sovellukset päivityksen jatkamiseksi:";
+
 /* Removal Error status text */
 "Removal Error" = "Virhe poistettaessa";
 

--- a/code/apps/Managed Software Center/Managed Software Center/fr.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/fr.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Quitter";
 
+/* Quit Apps button title */
+"Quit Apps" = "Quitter les applications";
+
+/* Force Quit button title */
+"Force Quit" = "Forcer la fermeture";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Forcer la fermeture de l'application ?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Êtes-vous sûr de vouloir forcer la fermeture \"%@\"? Toutes les modifications non enregistrées risquent d'être perdues.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Applications fermées";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Rouvrir les applications après la mise à jour.";
+
+/* Manual quit required label */
+"Manual quit required" = "Une fermeture manuelle est nécessaire.";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Veuillez fermer les applications suivantes pour poursuivre la mise à jour :";
+
 /* Removal Error status text */
 "Removal Error" = "Erreur de suppression";
 

--- a/code/apps/Managed Software Center/Managed Software Center/it.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/it.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Chiudi";
 
+/* Quit Apps button title */
+"Quit Apps" = "Esci dalle app";
+
+/* Force Quit button title */
+"Force Quit" = "Uscita forzata";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Forzare la chiusura dell'applicazione?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Sei sicuro di voler forzare la chiusura di \"%@\"? Eventuali modifiche non salvate potrebbero andare perse.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Applicazioni chiuse";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Riaprire le applicazioni dopo l'aggiornamento.";
+
+/* Manual quit required label */
+"Manual quit required" = "È necessario uscire manualmente dall'applicazione.";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Per procedere con l'aggiornamento, chiudere le seguenti applicazioni:";
+
 /* Removal Error status text */
 "Removal Error" = "Errore di rimozione";
 

--- a/code/apps/Managed Software Center/Managed Software Center/ja.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/ja.lproj/Localizable.strings
@@ -307,6 +307,30 @@
 /* Quit button title */
 "Quit" = "終了";
 
+/* Quit Apps button title */
+"Quit Apps" = "アプリを終了する";
+
+/* Force Quit button title */
+"Force Quit" = "強制終了";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "アプリケーションを強制終了しますか？";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "強制終了してもよろしいですか \"%@\"? 保存されていない変更内容は失われる可能性があります。";
+
+/* Closed Applications section title */
+"Closed Applications" = "クローズドアプリケーション";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "アップデート後にアプリケーションを再起動してください。";
+
+/* Manual quit required label */
+"Manual quit required" = "手動での終了が必要です";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "アップデートを続行するには、以下のアプリケーションを終了してください。";
+
 /* Removal Error status text */
 "Removal Error" = "削除エラー";
 

--- a/code/apps/Managed Software Center/Managed Software Center/msclib.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/msclib.swift
@@ -40,23 +40,64 @@ func runProcess(_ command: String, args: [String] = []) -> (exitcode: Int, stdou
     let proc = Process()
     let stdout_pipe = Pipe()
     let stderr_pipe = Pipe()
-    
+
     msc_debug_log("Running process \(command) with args \(args)")
     proc.launchPath = command
     proc.arguments = args
     proc.standardOutput = stdout_pipe
     proc.standardError = stderr_pipe
-    
+
     proc.launch()
     proc.waitUntilExit()
-    
+
     let stdout = stdout_pipe.fileHandleForReading.readDataToEndOfFile()
     let stderr = stderr_pipe.fileHandleForReading.readDataToEndOfFile()
     let exitcode = proc.terminationStatus
-    
+
     return (Int(exitcode),
             String(data: stdout, encoding: String.Encoding.utf8)!,
             String(data: stderr, encoding: String.Encoding.utf8)!)
+}
+
+func runEmbeddedScript(_ scriptText: String, scriptName: String = "script") -> (exitcode: Int, stdout: String, stderr: String) {
+    // Run an embedded script by writing it to a temp file and executing it.
+    // Returns a tuple of (exitcode, stdout, stderr)
+    let tempDir = NSTemporaryDirectory()
+    let scriptPath = (tempDir as NSString).appendingPathComponent(
+        "\(scriptName)_\(UUID().uuidString)")
+
+    // Write script to temp file
+    do {
+        try scriptText.write(toFile: scriptPath, atomically: true, encoding: .utf8)
+    } catch {
+        msc_debug_log("Failed to write script to \(scriptPath): \(error)")
+        return (-1, "", "Failed to write script: \(error)")
+    }
+
+    // Make it executable (0o700)
+    do {
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: scriptPath)
+    } catch {
+        msc_debug_log("Failed to set permissions on \(scriptPath): \(error)")
+        try? FileManager.default.removeItem(atPath: scriptPath)
+        return (-1, "", "Failed to set script permissions: \(error)")
+    }
+
+    msc_debug_log("Running embedded script: \(scriptName)")
+    let result = runProcess(scriptPath)
+
+    // Clean up temp file
+    try? FileManager.default.removeItem(atPath: scriptPath)
+
+    if result.exitcode != 0 {
+        msc_debug_log("Script \(scriptName) exited with code \(result.exitcode)")
+        if !result.stderr.isEmpty {
+            msc_debug_log("Script stderr: \(result.stderr)")
+        }
+    }
+
+    return result
 }
 
 enum ZipExtractError: Error {

--- a/code/apps/Managed Software Center/Managed Software Center/munki.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/munki.swift
@@ -114,7 +114,8 @@ func pref(_ prefName: String) -> Any? {
         "ShowRemovalDetail": false,
         "InstallRequiresLogout": false,
         "CheckResultsCacheSeconds": DEFAULT_GUI_CACHE_AGE_SECS,
-        "LogFile": "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log"
+        "LogFile": "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log",
+		"AutoQuitAppsOnUpdates": false
     ]
 
     var value: Any?

--- a/code/apps/Managed Software Center/Managed Software Center/munki.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/munki.swift
@@ -115,7 +115,8 @@ func pref(_ prefName: String) -> Any? {
         "InstallRequiresLogout": false,
         "CheckResultsCacheSeconds": DEFAULT_GUI_CACHE_AGE_SECS,
         "LogFile": "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log",
-		"AutoQuitAppsOnUpdates": false
+		"AutoQuitAppsOnUpdate": false,
+		"AutoForceQuitAppsOnUpdate": false,
     ]
 
     var value: Any?

--- a/code/apps/Managed Software Center/Managed Software Center/nb.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/nb.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Avslutt";
 
+/* Quit Apps button title */
+"Quit Apps" = "Avslutt Apps";
+
+/* Force Quit button title */
+"Force Quit" = "Tving avslutning";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Tving avslutning av applikasjon?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Er du sikker på at du vil tvinge frem avslutning av \"%@\"? Eventuelle ulagrede endringer kan gå tapt.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Lukkede applikasjoner";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Åpne applikasjoner på nytt etter oppdatering";
+
+/* Manual quit required label */
+"Manual quit required" = "Manuell avslutning kreves";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Vennligst lukk følgende applikasjoner for å fortsette med oppdateringen:";
+
 /* Removal Error status text */
 "Removal Error" = "Feil ved avinstallasjon";
 

--- a/code/apps/Managed Software Center/Managed Software Center/nl.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/nl.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Afsluiten";
 
+/* Quit Apps button title */
+"Quit Apps" = "Apps afsluiten";
+
+/* Force Quit button title */
+"Force Quit" = "Geforceerd afsluiten";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Applicatie geforceerd afsluiten?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Weet u zeker dat u \"%@\" geforceerd wilt afsluiten? Niet-opgeslagen wijzigingen kunnen verloren gaan.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Gesloten aanvragen";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Applicaties opnieuw openen na de update.";
+
+/* Manual quit required label */
+"Manual quit required" = "Handmatig afsluiten is vereist.";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Sluit de volgende toepassingen af om door te gaan met de update:";
+
 /* Removal Error status text */
 "Removal Error" = "Verwijderfout";
 

--- a/code/apps/Managed Software Center/Managed Software Center/ru.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/ru.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Завершить";
 
+/* Quit Apps button title */
+"Quit Apps" = "Закрыть приложения";
+
+/* Force Quit button title */
+"Force Quit" = "Принудительное завершение работы";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Принудительно завершить работу приложения?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Вы уверены, что хотите принудительно завершить работу \"%@\"? Все несохраненные изменения могут быть потеряны.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Закрытые приложения";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Перезапустить приложения после обновления.";
+
+/* Manual quit required label */
+"Manual quit required" = "Требуется ручное завершение работы.";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Для продолжения обновления закройте следующие приложения:";
+
 /* Removal Error status text */
 "Removal Error" = "Ошибка Удаления";
 

--- a/code/apps/Managed Software Center/Managed Software Center/sv.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/sv.lproj/Localizable.strings
@@ -310,6 +310,30 @@
 /* Quit button title */
 "Quit" = "Avsluta";
 
+/* Quit Apps button title */
+"Quit Apps" = "Avsluta Apps";
+
+/* Force Quit button title */
+"Force Quit" = "Tvinga avslut";
+
+/* Force Quit confirmation title */
+"Force Quit Application?" = "Tvångsavsluta applikation?";
+
+/* Force Quit confirmation message */
+"Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "Är du säker på att du vill tvångsavsluta \"%@\"? Alla osparade ändringar kan gå förlorade.";
+
+/* Closed Applications section title */
+"Closed Applications" = "Stängda applikationer";
+
+/* Reopen apps after update checkbox */
+"Reopen applications after update" = "Öppna applikationer igen efter uppdatering";
+
+/* Manual quit required label */
+"Manual quit required" = "Manuell avslutning krävs";
+
+/* Blocking Apps Running detail for auto-quit sheet */
+"Please quit the following applications to continue with the update:" = "Avsluta följande program för att fortsätta med uppdateringen:";
+
 /* Removal Error status text */
 "Removal Error" = "Borttagning misslyckades";
 

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -381,6 +381,7 @@ func processInstall(
             "description_staged",
             "installed_size_staged",
 			"prevent_auto_quit_on_update",
+			"application_quit_script",
         ]
 
         if isOptionalInstall {
@@ -760,6 +761,7 @@ func processOptionalInstall(
         "update_available",
         "localized_strings",
 		"prevent_auto_quit_on_update",
+		"application_quit_script",
     ]
     for key in optionalKeys {
         processedItem[key] = pkginfo[key]
@@ -1001,6 +1003,7 @@ func processRemoval(
         "icon_name",
         "PayloadIdentifier",
 		"prevent_auto_quit_on_update",
+		"application_quit_script",
     ]
     for key in optionalKeys {
         processedItem[key] = uninstallItem[key]

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -1000,6 +1000,7 @@ func processRemoval(
         "developer",
         "icon_name",
         "PayloadIdentifier",
+		"prevent_auto_quit_on_update",
     ]
     for key in optionalKeys {
         processedItem[key] = uninstallItem[key]

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -380,6 +380,7 @@ func processInstall(
             "display_name_staged", // used w/ stage_os_installer
             "description_staged",
             "installed_size_staged",
+			"prevent_auto_quit_on_update",
         ]
 
         if isOptionalInstall {
@@ -758,6 +759,7 @@ func processOptionalInstall(
         "minimum_os_version",
         "update_available",
         "localized_strings",
+		"prevent_auto_quit_on_update",
     ]
     for key in optionalKeys {
         processedItem[key] = pkginfo[key]


### PR DESCRIPTION
Implements #1157 
Discussion can be found here: https://groups.google.com/g/munki-dev/c/X1LL3kNIXi8

There are two global settings that allow for users to enable parts of the update & close logic globally.  Once enabled, there are additional keys that can be set in `pkginfo` for defining more granular changes for specific apps.

## Global preferences
Update logic will retain current update logic by default.  (ie: Prompts user to close any blocking application manually before proceeding).


### `AutoQuitAppsOnUpdate `
By setting the ManagedInstalls preference `AutoQuitAppsOnUpdate ` to true, MSC will attempt to gracefully close any blocking applications before running software updates or removals.

### `AutoForceQuitAppsOnUpdate`
By setting the ManagedInstalls preference `AutoForceQuitAppsOnUpdate` to true, MSC will display a force quit button to the user for applications that fail to gracefully close. 

Setting is ignored if `AutoQuitAppsOnUpdate` is set to `false`.

```swift
AutoQuitAppsOnUpdate: Bool = false //default
AutoForceQuitAppsOnUpdate: Bool = false //default
```

## App Specific configurations

### `application_quit_script` configuration
In the pkginfo for a specific item, adding `application_quit_script` with a value of a `script` (string), MSC will execute the script when closing the blocking application instead of using builtin close logic.

### `prevent_auto_quit_on_update` configuration
In the pkginfo for a specific item, adding `prevent_auto_quit_on_update` with a value of a `true`, MSC will **not** close the application during updates.  The user will be prompted to manually close the application instead.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	...
	<!-- Optional script for defining custom closing logic. -->
	<!-- Default's to using Apple's built-in `.termiante()` -->
	<key>application_quit_script</key>
	<string>...</string>
	<!-- Optional key to opt-out of auto close for specific apps -->
	<!-- Default is `false` -->
	<key>prevent_auto_quit_on_update</key>
	<false/> <!-- default -->
	...
</dict>
</plist>

```

## Re-opening apps
If the user selects the option to reopen apps, MSC will open the apps after the update in the background.  Apps that were removed as part of the update will not be re-launched.

## Screenshots:
<img width="1285" height="1034" alt="Screenshot 2026-01-20 at 1 14 35 PM" src="https://github.com/user-attachments/assets/f2866020-def2-46e7-87f7-2d0aec605ce3" />
<img width="1290" height="1028" alt="Screenshot 2026-01-20 at 1 13 51 PM" src="https://github.com/user-attachments/assets/2c7ed9f4-2687-496b-b1b8-9b455e0905bc" />
<img width="1280" height="1022" alt="Screenshot 2026-01-20 at 1 14 20 PM" src="https://github.com/user-attachments/assets/d2eba0c5-357c-4d9c-9128-08d7def62b61" />


