### PR TITLE
Add retry on interrupted download

### DIFF
--- a/code/cli/munki/shared/network/fetch.swift
+++ b/code/cli/munki/shared/network/fetch.swift
@@ -368,34 +368,69 @@ func getHTTPfileIfChangedAtomically(
             // fall through - no cached headers
         }
     }
-    var headers: [String: String]
-    do {
-        headers = try getURL(
-            url,
-            destinationPath: destinationPath,
-            customHeaders: customHeaders,
-            message: message,
-            onlyIfNewer: getOnlyIfNewer,
-            resume: resume,
-            followRedirects: followRedirects
-        )
-    } catch let err as FetchError {
-        switch err {
-        case .connection:
-            // just rethrow it
-            throw err
-        case let .http(errorCode, description):
-            // rethrow as download error
-            throw FetchError.download(errorCode: errorCode, description: description)
-        case let .fileSystem(description):
-            // rethrow as download error
-            throw FetchError.download(errorCode: -1, description: description)
-        default:
-            // these can't actually happen, but makes compiler happy
-            throw err
+
+    var numTries = 1
+    if let downloadRetriesPref = pref("DownloadRetries") as? Int {
+        if downloadRetriesPref >= 1 && downloadRetriesPref <= 10 {
+            numTries = downloadRetriesPref + 1
+        } else if downloadRetriesPref != 0 {
+            DisplayAndLog.main.warning("Ignoring invalid DownloadRetries pref: \(downloadRetriesPref)")
         }
-    } catch {
-        throw FetchError.download(errorCode: -1, description: error.localizedDescription)
+    }
+    var retrySleepSeconds:UInt32 = 10
+    if let retrySleepSecondsPref = pref("RetrySleepSeconds") as? Int {
+        if retrySleepSecondsPref >= 1 && retrySleepSecondsPref <= 30 {
+            retrySleepSeconds = UInt32(retrySleepSecondsPref)
+        } else {
+            DisplayAndLog.main.warning("Ignoring invalid RetrySleepSeconds pref: \(retrySleepSecondsPref)")
+        }
+    }
+    var triesLeft = numTries
+    // Retry on these HTTP error codes, fail immediately on all other
+    let retryHTTPCodes = [408, 425, 429, 500, 502, 503, 504]
+    var headers: [String: String]
+    while true {
+        if triesLeft != numTries {
+            sleep(retrySleepSeconds)
+        }
+        triesLeft -= 1
+        do {
+            headers = try getURL(
+                url,
+                destinationPath: destinationPath,
+                customHeaders: customHeaders,
+                message: message,
+                onlyIfNewer: getOnlyIfNewer,
+                resume: resume,
+                followRedirects: followRedirects
+            )
+            break
+        } catch let err as FetchError {
+            switch err {
+            case .connection:
+                if triesLeft > 0 {
+                    DisplayAndLog.main.info("Retrying connection error: \(err.localizedDescription)")
+                    continue
+                }
+                // just rethrow it
+                throw err
+            case let .http(errorCode, description):
+                if triesLeft > 0 && retryHTTPCodes.contains(errorCode) {
+                    DisplayAndLog.main.info("Retrying HTTP error \(errorCode): \(description)")
+                    continue
+                }
+                // rethrow as download error
+                throw FetchError.download(errorCode: errorCode, description: description)
+            case let .fileSystem(description):
+                // rethrow as download error
+                throw FetchError.download(errorCode: -1, description: description)
+            default:
+                // these can't actually happen, but makes compiler happy
+                throw err
+            }
+        } catch {
+            throw FetchError.download(errorCode: -1, description: error.localizedDescription)
+        }
     }
 
     if (headers["http_result_code"] ?? "") == "304" {


### PR DESCRIPTION
When munki needs to fetch a resource from the repo any network interruption causes the current run to fail. This is normally not an issue as munki will try again an hour later, or the user can check again in MSC. It is however a missed opportunity and it causes a fair amount of noise in the logs. We're seeing a steady stream of errors in Grafana and MunkiReport — not a huge issue, but it raises the noise floor.

I've experimented a bit with implementing retries in network/middleware/fetch.swift:getHTTPfileIfChangedAtomically(). It adds two new pref keys:

DownloadRetries: int between 0 and 10. Defaults to 0 which is no retries and thus keeps the old behavior.
RetrySleepSeconds: int between 1 and 30. Defaults to 10 seconds.