### PR TITLE
Silence attempted removal of nonexistent items

### DIFF
--- a/code/cli/munki/shared/installer/rmpkgs.swift
+++ b/code/cli/munki/shared/installer/rmpkgs.swift
@@ -532,7 +532,8 @@ func removeFilesystemItems(pathsToRemove: [String], forceDeleteBundles: Bool) {
     for item in pathsToRemove.sorted().reversed() {
         itemIndex += 1
         let pathToRemove = "/" + item
-        if !pathExists(pathToRemove) {
+        // Check existence without following symlinks
+        if fileType(pathToRemove) == nil {
             display.debug("\(pathToRemove) is already removed")
             continue
         }

--- a/code/cli/munki/shared/installer/rmpkgs.swift
+++ b/code/cli/munki/shared/installer/rmpkgs.swift
@@ -532,6 +532,10 @@ func removeFilesystemItems(pathsToRemove: [String], forceDeleteBundles: Bool) {
     for item in pathsToRemove.sorted().reversed() {
         itemIndex += 1
         let pathToRemove = "/" + item
+        if !pathExists(pathToRemove) {
+            display.debug("\(pathToRemove) is already removed")
+            continue
+        }
         if pathIsRegularFile(pathToRemove) || pathIsSymlink(pathToRemove) {
             display.detail("Removing: \(pathToRemove)")
             removeItemOrRecordError(pathToRemove)


### PR DESCRIPTION
Munki 7 logs an error about "unsupported filesystem type" if it tries to remove an item that doesn't exist when performing a removepackages uninstall. This is a regression from Munki 6.x.