### PR TITLE
Add new download retry keys to --show-config

### DIFF
--- a/code/cli/munki/shared/prefs.swift
+++ b/code/cli/munki/shared/prefs.swift
@@ -83,6 +83,8 @@ let CONFIG_KEY_NAMES = [
     "ClientResourcesFilename",
     "ClientResourceURL",
     "DaysBetweenNotifications",
+    "DownloadRetries",
+    "DownloadRetrySleepSeconds",
     "EmulateProfileSupport",
     "FollowHTTPRedirects",
     "HelpURL",


### PR DESCRIPTION
Adding new download retry–related keys specified in https://github.com/munki/munki/releases/tag/v7.1.0b1 to the --show-config list of preference keys.