### PR TITLE
Approve out-of-date translation

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/de.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/de.lproj/Localizable.strings
@@ -580,6 +580,5 @@
 /* Not volume owner detail */
 "Your user account is not an owner of the current startup volume.\nYou cannot upgrade macOS at this time.\n\nContact your systems administrator." = "Ihr Benutzerkonto ist nicht Eigentümer des aktuellen Startvolumes.\nSie können macOS derzeit nicht aktualisieren.\n\nWenden Sie sich an Ihren Systemadministrator.";
 
-/* TODO: verify translation */
 /* macOS out-of-date days message */
 "macOS has been out-of-date for %@ days." = "macOS ist seit %@ Tagen veraltet.";


### PR DESCRIPTION
Translation is correct. I assume we don't distinguish between one day and several days, since this would differ in English as well.