### PR TITLE
Fix Spanish (es) localization: spelling, accents, grammar, and verb form consistency

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/XIBs/es.lproj/MainMenu.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/XIBs/es.lproj/MainMenu.strings
@@ -128,7 +128,7 @@
 "hz9-B4-Xy5.title" = "Servicios";
 
 /* Class = "NSTextFieldCell"; title = "Password:"; ObjectID = "iem-kB-sic"; */
-"iem-kB-sic.title" = "Password:";
+"iem-kB-sic.title" = "Contraseña:";
 
 /* Class = "NSMenuItem"; title = "Forward"; ObjectID = "nIf-zM-816"; */
 "nIf-zM-816.title" = "Siguiente";

--- a/code/apps/Managed Software Center/Managed Software Center/es.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/es.lproj/Localizable.strings
@@ -5,7 +5,7 @@
 "%@ available Apple updates" = "%@ actualizaciones de Apple disponibles";
 
 /* Multiple Updates message */
-"%@ pending updates" = "%@ actualizaciones pendiente";
+"%@ pending updates" = "%@ actualizaciones pendientes";
 
 /* One managed update message */
 "1 additional pending update" = "1 actualización adicional pendiente";
@@ -26,19 +26,19 @@
 "A logout will be forced in less than %@ minutes." = "Se va a forzar el cierre de sesión en menos de %@ minutos.";
 
 /* Logout warning string when logout is in less than a minute */
-"A logout will be forced in less than a minute.\nAll pending updates will be installed. Unsaved work will be lost." = "Se va a forzar el cierre de sesión en menos de un minuto.\nTodas las actualizaciones pendientes serán instaladas. Se perderá cualquier cambio no guardado.";
+"A logout will be forced in less than a minute.\nAll pending updates will be installed. Unsaved work will be lost." = "Se va a forzar el cierre de sesión en menos de un minuto.\nSe instalarán todas las actualizaciones pendientes. Se perderá cualquier cambio no guardado.";
 
 /* macOS Install Pending detail */
-"A macOS install is pending. This install may take some time. Other pending items will be installed later.\n\nContinue with the install?" = "Una instalación de macOS esta pendiente. Esta instalación podria tomar algo de tiempo. Otras aplicaciones pendientes se instalarán después.\n\n¿Continuar con la instalación?";
+"A macOS install is pending. This install may take some time. Other pending items will be installed later.\n\nContinue with the install?" = "Una instalación de macOS está pendiente. Esta instalación podría tomar algo de tiempo. Otras aplicaciones pendientes se instalarán después.\n\n¿Continuar con la instalación?";
 
 /* Removal Error message */
-"A removal attempt failed. Removal will be attempted again.\nIf this situation continues, contact your systems administrator." = "Una desinstalación ha fallado. Se volverá a intentar.\nSi esta situación continua, contacta con el administrador de sistemas.";
+"A removal attempt failed. Removal will be attempted again.\nIf this situation continues, contact your systems administrator." = "Una desinstalación ha fallado. Se volverá a intentar.\nSi esta situación continúa, contacta con el administrador de sistemas.";
 
 /* Restart Required detail */
 "A restart is required after updating. Log out and update now?" = "Es necesario reiniciar después de instalar las actualizaciones. ¿Cerrar sesión y actualizar ahora?";
 
 /* System configuration problem alert detail */
-"A systems configuration issue is preventing Managed Software Center from operating correctly. The reported issue is: " = "Un fallo en la configuración del sistema ha provocado que Centro de Aplicaciones no funcione de forma correcta. El fallo reportado es: ";
+"A systems configuration issue is preventing Managed Software Center from operating correctly. The reported issue is: " = "Un fallo en la configuración del sistema ha provocado que Centro de aplicaciones no funcione de forma correcta. El fallo reportado es: ";
 
 /* Additional Pending Updates title */
 "Additional Pending Updates" = "Actualizaciones adicionales pendientes";
@@ -50,13 +50,13 @@
 "All items" = "Todos";
 
 /* Forced Logout warning detail */
-"All pending updates will be installed. Unsaved work will be lost.\nYou may avoid the forced logout by logging out now." = "Todas las actualizaciones pendientes serán instaladas. Cualquier cambio no guardado se perderá.\nPuedes evitar el cierre forzado de la sesión cerrándola ahora.";
+"All pending updates will be installed. Unsaved work will be lost.\nYou may avoid the forced logout by logging out now." = "Se instalarán todas las actualizaciones pendientes. Cualquier cambio no guardado se perderá.\nPuedes evitar el cierre forzado de la sesión cerrándola ahora.";
 
 /* Allow button text */
 "Allow" = "Permitir";
 
 /* Install Error message */
-"An installation attempt failed. Installation will be attempted again.\nIf this situation continues, contact your systems administrator." = "Una instalación ha fallado. Se volverá a intentar.\nSi esta situación continua, contacta con el administrador de sistemas.";
+"An installation attempt failed. Installation will be attempted again.\nIf this situation continues, contact your systems administrator." = "Una instalación ha fallado. Se volverá a intentar.\nSi esta situación continúa, contacta con el administrador de sistemas.";
 
 /* Long Not Enough Disk Space For Update display text */
 "An older version is currently installed. There is not enough disk space to download and install this update." = "Una versión anterior está instalada. No hay espacio suficiente en el disco para descargar e instalar esta actualización.";
@@ -68,7 +68,7 @@
 "Apple software is up to date" = "El software de Apple está actualizado";
 
 /* Other Users Blocking Apps Running title */
-"Applications in use by others" = "Applicaciones en uso por otros";
+"Applications in use by others" = "Aplicaciones en uso por otros";
 
 /* Force Quit confirmation message */
 "Are you sure you want to force quit \"%@\"? Any unsaved changes may be lost." = "¿Estás seguro de que quieres forzar el cierre de \"%@\"? Es posible que se pierdan los cambios no guardados.";
@@ -89,7 +89,7 @@
 "Cancel update" = "Cancelar actualización";
 
 /* Item Not Found message */
-"Cannot display the requested item." = "No se puede mostar el ítem solicitado.";
+"Cannot display the requested item." = "No se puede mostrar el ítem solicitado.";
 
 /* Not volume owner title */
 "Cannot upgrade macOS" = "No se ha podido actualizar macOS";
@@ -134,7 +134,7 @@
 "Deny" = "Denegar";
 
 /* managedsoftwareupdate message */
-"Determining which filesystem items to remove" = "Determinando que archivos hay que quitar";
+"Determining which filesystem items to remove" = "Determinando qué archivos hay que quitar";
 
 /* Sidebar Developer label */
 "Developer:" = "Desarrollador:";
@@ -191,7 +191,7 @@
 "Install" = "Instalar";
 
 /* Install now button title */
-"Install now" = "Install ahora";
+"Install now" = "Instalar ahora";
 
 /* Install Requested status text */
 "Install requested" = "Instalación solicitada";
@@ -233,13 +233,13 @@
 "macOS update required" = "Actualización de macOS requerida";
 
 /* Failed Preflight Check detail */
-"Managed Software Center cannot check for updates now.\nTry again later. If this situation continues, contact your systems administrator." = "Centro de aplicaciones no puede comprobar las actualizaciones.\nPrueba más tarde. Si esta situación continua, contacta con el administrador de sistemas.";
+"Managed Software Center cannot check for updates now.\nTry again later. If this situation continues, contact your systems administrator." = "Centro de aplicaciones no puede comprobar las actualizaciones.\nPrueba más tarde. Si esta situación continúa, contacta con el administrador de sistemas.";
 
 /* Cannot Contact Server detail */
-"Managed Software Center cannot contact the update server at this time.\nTry again later. If this situation continues, contact your systems administrator." = "Centro de aplicaciones no puede contactar con el servidor de actualizaciones.\nPrueba más tarde. Si esta situación continua, contacta con el administrador de sistemas.";
+"Managed Software Center cannot contact the update server at this time.\nTry again later. If this situation continues, contact your systems administrator." = "Centro de aplicaciones no puede contactar con el servidor de actualizaciones.\nPrueba más tarde. Si esta situación continúa, contacta con el administrador de sistemas.";
 
 /* Password prompt title */
-"Managed Software Center wants to unlock the startup disk after restarting to complete all pending updates." = "Centro de Aplicaciones quiere desbloquear el disco de inicio tras el reinicio para completar todas las actualizaciones pendientes.";
+"Managed Software Center wants to unlock the startup disk after restarting to complete all pending updates." = "Centro de aplicaciones quiere desbloquear el disco de inicio tras el reinicio para completar todas las actualizaciones pendientes.";
 
 /* Managed Update type */
 "Managed Update" = "Actualización controlada";
@@ -275,7 +275,7 @@
 "Not currently available" = "Actualmente no disponible";
 
 /* Not Enough Disk Space display text */
-"Not enough disk space" = "No hay suficiente espacion en el disco";
+"Not enough disk space" = "No hay suficiente espacio en el disco";
 
 /* Item Not Found title */
 "Not Found" = "No encontrado";
@@ -290,22 +290,22 @@
 "OK" = "Aceptar";
 
 /* Pending Apple Updates warning */
-"One or more important Apple updates must be installed" = "Una o más actualizaciones importates de Apple deben ser instaladas";
+"One or more important Apple updates must be installed" = "Una o más actualizaciones importantes de Apple deben instalarse";
 
 /* Forced Install Date summary */
-"One or more items must be installed by %@" = "Uno o mas ítems tienen que ser instalados para el %@";
+"One or more items must be installed by %@" = "Uno o más ítems tienen que ser instalados para el %@";
 
 /* Mandatory Updates Imminent detail */
-"One or more mandatory updates are overdue for installation. A logout will be forced soon." = "El periodo de instalación de una o más actualizaciones requeridas ha expirado. En breve se forzará el cierre de sesión";
+"One or more mandatory updates are overdue for installation. A logout will be forced soon." = "El periodo de instalación de una o más actualizaciones requeridas ha expirado. En breve se forzará el cierre de sesión.";
 
 /* Mandatory Updates Pending detail */
-"One or more updates must be installed by %@. A logout may be forced if you wait too long to update." = "Una o más actualizaciones tienen ser instaladas para el %@. Se forzará el cierre de sesión si esperas demasiado en actualizar.";
+"One or more updates must be installed by %@. A logout may be forced if you wait too long to update." = "Una o más actualizaciones tienen que ser instaladas para el %@. Se forzará el cierre de sesión si esperas demasiado en actualizar.";
 
 /* Other Available Updates label */
 "Other available updates" = "Otras actualizaciones disponibles";
 
 /* Other Users Blocking Apps Running detail */
-"Other logged in users are using the following applications. Try updating later when they are no longer in use:\n\n%@" = "Otros usuarios estan utilizando las siguientes aplicaciones. Prueba de actualizar más tarde cuando no esten en uso:\n\n%@";
+"Other logged in users are using the following applications. Try updating later when they are no longer in use:\n\n%@" = "Otros usuarios están utilizando las siguientes aplicaciones. Prueba de actualizar más tarde cuando no estén en uso:\n\n%@";
 
 /* Other Users Logged In title */
 "Other users logged in" = "Hay otros usuarios con sesiones abiertas";
@@ -329,10 +329,10 @@
 "Preparing removal" = "Preparando desinstalación";
 
 /* managedsoftwareupdate message */
-"Preparing to run macOS Installer..." = "Preparando para ejecutar el instalador de macOS";
+"Preparing to run macOS Installer..." = "Preparando la ejecución del instalador de macOS...";
 
 /* Problem Updates label */
-"Problem updates" = "Actualización problematica";
+"Problem updates" = "Actualizaciones problemáticas";
 
 /* Quit button title */
 "Quit" = "Salir";
@@ -380,10 +380,10 @@
 "Running Adobe Uninstall" = "Desinstalación de Adobe en marcha";
 
 /* See All link text */
-"See All" = "Iniciar sesión";
+"See All" = "Ver todo";
 
 /* No Installed Software secondary text */
-"Select software to install." = "Selecciona la aplicaciones a instalar.";
+"Select software to install." = "Selecciona las aplicaciones a instalar.";
 
 /* Show Apple updates button title */
 "Show" = "Mostrar";
@@ -398,7 +398,7 @@
 "Skip Apple updates" = "Omitir actualizaciones de Apple";
 
 /* Skip updates requiring logout or restart button text */
-"Skip updates requiring logout or restart" = "Omitir actualizaciones que requieren cerrar sesión o reiniciar";
+"Skip updates requiring logout or restart" = "Omitir actualizaciones que requieran cerrar o reiniciar la sesión";
 
 /* Software label */
 "Software" = "Aplicaciones";
@@ -407,16 +407,16 @@
 "Software installed or removed requires a restart." = "El software instalado o desinstalado requiere reiniciar el equipo.";
 
 /* Restart Required alert detail */
-"Software installed or removed requires a restart. You will have a chance to save open documents." = "El software instalado necesita reiniciar el equipo. Tendrás oportunidad de guardar tus documentos";
+"Software installed or removed requires a restart. You will have a chance to save open documents." = "El software instalado o desinstalado requiere reiniciar el equipo. Tendrás oportunidad de guardar tus documentos.";
 
 /* Pre Install Uninstall Upgrade Alert Detail */
-"Some conditions apply to this software. Please contact your administrator for more details" = "Este software esta sujeto a algunas condiciones. Por favor contacta con tu administrador de sistemas para obtener más información";
+"Some conditions apply to this software. Please contact your administrator for more details" = "Este software está sujeto a algunas condiciones. Por favor contacta con tu administrador de sistemas para obtener más información";
 
 /* managedsoftwareupdate message */
 "Starting Adobe installer..." = "Empezando el instalador de Adobe...";
 
 /* managedsoftwareupdate message */
-"Starting macOS upgrade..." = "Empezando actualización completa de macOS";
+"Starting macOS upgrade..." = "Empezando actualización de macOS...";
 
 /* managedsoftwareupdate message */
 "Starting..." = "Empezando...";
@@ -428,7 +428,7 @@
 "System configuration problem" = "Problema en la configuración del sistema";
 
 /* managedsoftwareupdate message */
-"System will restart and begin upgrade of macOS." = "El sistema se reiniciará y comenzará la intalación completa de macOS";
+"System will restart and begin upgrade of macOS." = "El sistema se reiniciará y comenzará la actualización de macOS.";
 
 /* managedsoftwareupdate message */
 "The software was successfully installed." = "El software se instaló correctamente.";
@@ -440,13 +440,13 @@
 "There are no available software items." = "No hay aplicaciones disponibles.";
 
 /* No Developer Results primary text */
-"There are no items from this developer." = "No hay aplicaciones de este desarollador.";
+"There are no items from this developer." = "No hay aplicaciones de este desarrollador.";
 
 /* No Category Results primary text */
-"There are no items in this category." = "No hay ítems en esta categoria.";
+"There are no items in this category." = "No hay ítems en esta categoría.";
 
 /* Other Users Logged In detail */
-"There are other users logged into this computer.\nUpdating now could cause other users to lose their work.\n\nPlease try again later after the other users have logged out." = "Hay otros usuarios con sesiones abiertas en este equipo.\nActualizar ahora puede causar perdidas en su trabajo.\n\nPor favor prueba más tarde cuando los otros usuarios hayan cerrado sus sesiones.";
+"There are other users logged into this computer.\nUpdating now could cause other users to lose their work.\n\nPlease try again later after the other users have logged out." = "Hay otros usuarios con sesiones abiertas en este equipo.\nActualizar ahora puede causar pérdidas en su trabajo.\n\nPor favor prueba más tarde cuando los otros usuarios hayan cerrado sus sesiones.";
 
 /* Pending Updates alert detail text */
 "There are pending updates for this computer." = "Hay actualizaciones pendientes para este equipo.";
@@ -470,22 +470,22 @@
 "This item must be installed by %@" = "Tiene que estar instalado para el %@";
 
 /* Pending days message */
-"This update has been pending for %@ days." = "Esta actualización ha estado pendiente durante %@ days.";
+"This update has been pending for %@ days." = "Esta actualización ha estado pendiente durante %@ días.";
 
 /* Password explanation */
-"To allow this, enter your login password." = "Para permitir esto, introduzca su contraseña de usuario.";
+"To allow this, enter your login password." = "Para permitir esto, introduce tu contraseña de usuario.";
 
 /* No Items secondary text */
-"Try again later." = "Probar de nuevo más tarde.";
+"Try again later." = "Prueba de nuevo más tarde.";
 
 /* No Search Results secondary text */
-"Try searching again." = "Intentar buscar otra vez.";
+"Try searching again." = "Intenta buscar otra vez.";
 
 /* No Category Results secondary text */
-"Try selecting another category." = "Intentar seleccionar otra categoría.";
+"Try selecting another category." = "Intenta seleccionar otra categoría.";
 
 /* No Developer Results secondary text */
-"Try selecting another developer." = "Intentar seleccionar otro desarollador.";
+"Try selecting another developer." = "Intenta seleccionar otro desarrollador.";
 
 /* Sidebar Type label */
 "Type" = "Tipo";
@@ -542,10 +542,10 @@
 "Waiting for network..." = "Esperando red...";
 
 /* Will Be Installed status text */
-"Will be installed" = "Será instalado";
+"Will be installed" = "Se instalará";
 
 /* Will Be Removed status text */
-"Will be removed" = "Será desinstalado";
+"Will be removed" = "Se desinstalará";
 
 /* No Installed Software primary text */
 "You have no selected software." = "No has seleccionado ninguna aplicación.";
@@ -569,7 +569,7 @@
 "Your computer is not connected to a power source." = "El equipo no está conectado a una fuente de alimentación.";
 
 /* No Search Results primary text */
-"Your search had no results." = "Tu busqueda no ha obtenido ningún resultado.";
+"Your search had no results." = "Tu búsqueda no ha obtenido ningún resultado.";
 
 /* No Pending Updates primary text */
 "Your software is up to date." = "Tus aplicaciones están actualizadas.";

--- a/code/apps/MunkiStatus/MunkiStatus/es.lproj/Localizable.strings
+++ b/code/apps/MunkiStatus/MunkiStatus/es.lproj/Localizable.strings
@@ -11,7 +11,7 @@
 "Checking for available updates..." = "Comprobando actualizaciones disponibles...";
 
 /* managedsoftwareupdate message */
-"Determining which filesystem items to remove" = "Determinando que archivos hay que quitar";
+"Determining which filesystem items to remove" = "Determinando qué archivos hay que quitar";
 
 /* managedsoftwareupdate message */
 "Done." = "Hecho.";
@@ -68,13 +68,13 @@
 "Software installed or removed requires a restart." = "El software instalado o desinstalado requiere reiniciar el equipo.";
 
 /* No comment provided by engineer. */
-"Software installed or removed requires a restart. You will have a chance to save open documents." = "El software instalado necesita reiniciar el ordenador. Podrás guardar tus documentos";
+"Software installed or removed requires a restart. You will have a chance to save open documents." = "El software instalado o desinstalado requiere reiniciar el equipo. Tendrás oportunidad de guardar tus documentos.";
 
 /* managedsoftwareupdate message */
 "Starting Adobe installer..." = "Empezando el instalador de Adobe...";
 
 /* managedsoftwareupdate message */
-"Starting macOS upgrade..." = "Comenzando actualización de macOS...";
+"Starting macOS upgrade..." = "Empezando actualización de macOS...";
 
 /* managedsoftwareupdate message */
 "Starting..." = "Empezando...";

--- a/code/apps/MunkiStatus/MunkiStatus/es.lproj/MainMenu.strings
+++ b/code/apps/MunkiStatus/MunkiStatus/es.lproj/MainMenu.strings
@@ -23,7 +23,7 @@
 "AYu-sK-qS6.title" = "Main Menu";
 
 /* Class = "NSTextFieldCell"; title = "Starting..."; ObjectID = "D4j-2T-GWB"; */
-"D4j-2T-GWB.title" = "Starting...";
+"D4j-2T-GWB.title" = "Empezando...";
 
 /* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
 "F2S-fz-NVQ.title" = "Ayuda";

--- a/code/apps/munki-notifier/munki-notifier/es.lproj/Localizable.strings
+++ b/code/apps/munki-notifier/munki-notifier/es.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 /* Multiple Update message */
-"%@ pending updates" = "%@ actualizaciones pendiente";
+"%@ pending updates" = "%@ actualizaciones pendientes";
 
 /* One Update message */
 "1 pending update" = "1 actualización pendiente";
@@ -8,7 +8,7 @@
 "Details" = "Detalles";
 
 /* Forced Install Date summary */
-"One or more items must be installed by %@" = "Una o mas aplicaciones tienen que ser instaladas para el %@";
+"One or more items must be installed by %@" = "Una o más aplicaciones tienen que ser instaladas para el %@";
 
 /* Software updates available message */
 "Software updates available" = "Actualizaciones de software disponibles";


### PR DESCRIPTION
## Summary

Systematic review and fix of the Castilian Spanish (`es`) localization across all three apps (Managed Software Center, MunkiStatus, munki-notifier). These are pre-existing issues not introduced by #1346 — that PR correctly translated the new 7.1 strings, but the underlying file had accumulated inconsistencies over time.

All changes align with **Apple's macOS Spanish localization conventions** (tú form, reflexive passive, tú-imperative for instructions).

## Changes by category

### 1. Formal register fix (usted → tú)

The entire project uses informal **tú** to address the user, consistent with Apple's macOS convention. One string used the formal **usted** form:

| String | Before | After | Justification |
|--------|--------|-------|---------------|
| `"To allow this, enter your login password."` | "introduzca su contraseña" | "introduce tu contraseña" | Apple uses tú throughout macOS; the rest of the file already does too |

### 2. Verb form: infinitive → tú imperative for user instructions

Apple's macOS uses **tú imperative** when addressing the user with suggestions. Four secondary-text strings used bare infinitive while all other similar strings in the file correctly use imperative (`"Prueba más tarde"`, `"Contacta con..."`, `"Selecciona..."`):

| String | Before | After |
|--------|--------|-------|
| `"Try again later."` | "Probar de nuevo más tarde." | "Prueba de nuevo más tarde." |
| `"Try searching again."` | "Intentar buscar otra vez." | "Intenta buscar otra vez." |
| `"Try selecting another category."` | "Intentar seleccionar otra categoría." | "Intenta seleccionar otra categoría." |
| `"Try selecting another developer."` | "Intentar seleccionar otro desarrollador." | "Intenta seleccionar otro desarrollador." |

### 3. Passive voice: ser-passive → reflexive passive

Apple prefers reflexive passive (`"se instalará"`) over ser-passive (`"será instalado"`). The file already uses reflexive passive in `"Se instalará la actualización"` (line 521) but was inconsistent elsewhere:

| String | Before | After |
|--------|--------|-------|
| `"Will be installed"` | "Será instalado" | "Se instalará" |
| `"Will be removed"` | "Será desinstalado" | "Se desinstalará" |
| `"...All pending updates will be installed..."` (×2) | "...serán instaladas" | "Se instalarán todas las actualizaciones pendientes" |
| `"...Apple updates must be installed"` | "deben ser instaladas" | "deben instalarse" |

### 4. Subjunctive mood fix

| String | Before | After | Justification |
|--------|--------|-------|---------------|
| `"Skip updates requiring logout or restart"` | "que requieren cerrar sesión o reiniciar" | "que requieran cerrar o reiniciar la sesión" | Subjunctive required for relative clauses with non-specific antecedent |

### 5. Cross-file verb consistency

| File | String | Before | After | Justification |
|------|--------|--------|-------|---------------|
| MunkiStatus/Localizable.strings | `"Starting macOS upgrade..."` | "Comenzando actualización de macOS..." | "Empezando actualización de macOS..." | All other "Starting..." strings use "Empezando" |
| MunkiStatus/Localizable.strings | `"Software installed or removed..."` | "reiniciar el ordenador" | "reiniciar el equipo" | Every other string in the project uses "equipo" |
| MSC/Localizable.strings | `"Starting macOS upgrade..."` | "Empezando actualización completa de macOS" | "Empezando actualización de macOS..." | Align with MunkiStatus; add missing trailing "..." |
| MSC/Localizable.strings | `"System will restart..."` | "la intalación completa de macOS" | "la actualización de macOS." | Fix typo "intalación"; align with MunkiStatus; add missing "." |
| MSC/Localizable.strings | `"Preparing to run macOS Installer..."` | "Preparando para ejecutar el instalador de macOS" | "Preparando la ejecución del instalador de macOS..." | Align with MunkiStatus; add missing trailing "..." |

### 6. Incomplete translation fix

| File | String | Before | After |
|------|--------|--------|-------|
| MunkiStatus + MSC | `"Software installed or removed requires a restart..."` | "El software instalado necesita reiniciar" | "El software instalado o desinstalado requiere reiniciar" (added missing "or removed") |

### 7. Spelling errors (7 fixes)

| Before | After | Files |
|--------|-------|-------|
| Applicaciones | Aplicaciones | MSC |
| mostar | mostrar | MSC |
| espacion | espacio | MSC |
| importates | importantes | MSC |
| intalación | instalación | MSC |
| desarollador (×2) | desarrollador | MSC |

### 8. Missing accents/tildes (16 fixes)

| Before | After | Occurrences |
|--------|-------|-------------|
| continua | continúa | ×4 (MSC) |
| esta pendiente | está pendiente | ×1 (MSC) |
| podria | podría | ×1 (MSC) |
| que archivos | qué archivos | ×1 (MSC) + ×1 (MunkiStatus) |
| mas | más | ×1 (MSC) + ×1 (munki-notifier) |
| estan | están | ×1 (MSC) |
| esten | estén | ×1 (MSC) |
| problematica | problemática | ×1 (MSC) |
| esta sujeto | está sujeto | ×1 (MSC) |
| categoria | categoría | ×1 (MSC) |
| perdidas | pérdidas | ×1 (MSC) |
| busqueda | búsqueda | ×1 (MSC) |

### 9. Grammar fixes

| Before | After | Justification |
|--------|-------|---------------|
| "actualizaciones pendiente" (×2) | "actualizaciones pendientes" | Plural agreement (MSC + munki-notifier) |
| "tienen ser instaladas" | "tienen que ser instaladas" | Missing "que" |
| "Actualización problematica" | "Actualizaciones problemáticas" | Plural agreement + accent |
| "la aplicaciones" | "las aplicaciones" | Article agreement |

### 10. Wrong translation

| String | Before | After | Justification |
|--------|--------|-------|---------------|
| `"See All"` | "Iniciar sesión" (= "Log in") | "Ver todo" | Completely wrong — "Iniciar sesión" means "Log in" |

### 11. Untranslated strings

| File | String | Before | After |
|------|--------|--------|-------|
| MSC/Localizable.strings | `"Install now"` | "Install ahora" | "Instalar ahora" |
| MSC/Localizable.strings | `"...pending for %@ days."` | "durante %@ days." | "durante %@ días." |
| MunkiStatus/MainMenu.strings | `"Starting..."` (XIB) | "Starting..." | "Empezando..." |
| MSC/XIBs/MainMenu.strings | `"Password:"` (XIB) | "Password:" | "Contraseña:" |

### 12. App name capitalization (consistency)

Standardized "Centro de **A**plicaciones" → "Centro de **a**plicaciones" in 2 outlier strings to match the other 12+ occurrences across all files.

### 13. Missing punctuation (4 fixes)

Added missing trailing periods or ellipses to match English source strings and the rest of the file.

## Files changed

- `Managed Software Center/es.lproj/Localizable.strings` — 41 line changes
- `MunkiStatus/es.lproj/Localizable.strings` — 3 line changes
- `munki-notifier/es.lproj/Localizable.strings` — 2 line changes
- `MunkiStatus/es.lproj/MainMenu.strings` — 1 line change
- `Managed Software Center/XIBs/es.lproj/MainMenu.strings` — 1 line change

## Test plan

- [ ] Verify Managed Software Center UI strings display correctly in Spanish locale
- [ ] Verify MunkiStatus progress messages display correctly
- [ ] Verify munki-notifier notification strings display correctly
- [ ] Confirm no untranslated or broken format strings (`%@`) remain

Made with [Cursor](https://cursor.com)