### PR TITLE
Reduce transparency fix

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -448,6 +448,7 @@ class MSCBlockingAppsController: NSObject {
         let blockingScrollView = NSScrollView()
         blockingScrollView.translatesAutoresizingMaskIntoConstraints = false
         blockingScrollView.contentView = FlippedClipView()
+        blockingScrollView.drawsBackground = false
         blockingScrollView.hasVerticalScroller = (apps.count > maxVisibleRows)
         if apps.count > maxVisibleRows {
             blockingScrollView.hasVerticalScroller = true


### PR DESCRIPTION
In Munki 7.1rc3, the "offer to quit" modal displays open apps differently if "reduce transparency" is on in Accessibility > Display and the Mac Appearance is set to Light mode. 

Reduce transparency off:
<img width="335" height="333" alt="Accessibility _ Display _ Reduce Transparency off" src="https://github.com/user-attachments/assets/1cadd397-beea-4cc2-8745-c3e3de981e27" />

Reduce transparency on:
<img width="337" height="336" alt="Accessibility _ Display _ Reduce Transparency on" src="https://github.com/user-attachments/assets/469b24f3-bb3a-409b-9ee3-4d7493ab5342" />

Adding `blockingScrollView.drawsBackground = false` to the definition of blockingScrollView addresses this. Built the apps with Xcode 26.4.1 on macOS 26.4.1 and tested on macOS 15 and 26.