### PR TITLE
Reject any embedded scheme in handleMunkiURL(), not just http/https

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -1245,14 +1245,14 @@ class MainWindowController: NSWindowController {
             return
         }
         var filename = unquote(host)
-        // Reject payloads that smuggle a remote URL through the munki:// scheme.
+        // Reject payloads that smuggle a URL through the munki:// scheme.
         // handleMunkiURL is for internal page names only; load_page accepts
         // http/https specifically for admin-configured CustomSidebarItems,
         // which never flow through this function.
         if let components = URLComponents(string: filename),
-           ["https", "http"].contains(components.scheme)
+           let embeddedScheme = components.scheme
         {
-            msc_debug_log("Refusing munki:// URL with embedded http(s) scheme: \(filename)")
+            msc_debug_log("Refusing munki:// URL with embedded \(embeddedScheme) scheme: \(filename)")
             return
         }
         if filename == "appleupdates" {


### PR DESCRIPTION
Follow-up to #1356, implementing the "I wonder if we should just disallow *any* embedded scheme" suggestion.

Log message now names the specific scheme that was rejected, which is more useful than the static `"http(s)"` string when triaging from logs.

## Verified locally

Built the patched MSC and tested additional schemes:

| URL (decoded) | Result |
|---|---|
| `http://127.0.0.1/poc.html` | `Refusing munki:// URL with embedded http scheme: ...` |
| `file:///etc/passwd` | `Refusing munki:// URL with embedded file scheme: ...` |
| `smb://attacker/share` | `Refusing munki:// URL with embedded smb scheme: ...` |
| `javascript:alert(1)` | `Refusing munki:// URL with embedded javascript scheme: ...` |
| `munki://updates` | Loads updates page normally |

`CustomSidebarItems` with `http(s)` page values still reach `load_page` directly via `loadSidebarItemPage` and are unaffected — same as #1356.

## Trade-off considered

`URLComponents` parses anything matching the RFC 3986 scheme grammar (`<alpha>(<alpha>|<digit>|+|-|.)*:`) as a scheme — so a Munki item whose `name` contains a colon (e.g., `MyApp:Pro` → `detail-MyApp:Pro`) would be falsely blocked, with the log line `Refusing munki:// URL with embedded detail-MyApp scheme:`. The narrower http/https check in #1356 doesn't have this issue.

If you'd prefer avoiding the colon edge case at the cost of leaving non-`//` schemes (e.g. `javascript:`, `data:`) unblocked at this entry, an alternative is to match only `<scheme>://`. Happy to switch.
