### PR TITLE
Split load_page() into internal-page and arbitrary-URL variants

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -251,7 +251,12 @@ class MainWindowController: NSWindowController {
             } else {
                 msc_debug_log("Could not parse sidebar item page URL \(page)")
             }
+        } else if let components = URLComponents(string: page),
+                  ["https", "http"].contains(components.scheme)
+        {
+            load_url(page)
         } else {
+            // Treat as a relative page name in htmlDir.
             load_page(page)
         }
     }
@@ -1159,46 +1164,34 @@ class MainWindowController: NSWindowController {
         setInnerHTML(items_html, elementID: "optional_installs_items")
     }
     
-    func load_page(_ url_fragment: String) {
-        // Tells the WebView to load the appropriate page
-        msc_debug_log("load_page request for \(url_fragment)")
-        var request: URLRequest
-        
-        if let components = URLComponents(string: url_fragment),
-           ["https", "http"].contains(components.scheme)
-        {
-            // url_fragment is http:// or https:// URL
-            request = URLRequest(
-                url: URL(string: url_fragment)!,
-                cachePolicy: .reloadIgnoringLocalCacheData,
-                timeoutInterval: TimeInterval(10.0)
-            )
-        } else {
-            // url_fragment is just a path (or filename)
-            let baseURL = URL(fileURLWithPath: htmlDir).standardizedFileURL
-            let requestURL = baseURL.appendingPathComponent(url_fragment).standardizedFileURL
-            
-            let baseComponents = baseURL.pathComponents
-            let requestComponents = requestURL.pathComponents
-            
-            guard requestComponents.starts(with: baseComponents) else {
-                msc_debug_log("Attempt to access file outside htmlDir: \(url_fragment)")
-                // since error.html doesn't exist, this ends up triggering buildItemNotFoundPage()
-                let errorURL = baseURL.appendingPathComponent("error.html")
-                webView.load(URLRequest(url: errorURL))
-                return
-            }
-            
-            request = URLRequest(
-                url: requestURL,
-                cachePolicy: .reloadIgnoringLocalCacheData,
-                timeoutInterval: 10.0
-            )
+    func load_page(_ name: String) {
+        // Tells the WebView to load a Munki-internal HTML page from htmlDir.
+        // `name` should be a page name (with or without ".html"). Path traversal
+        // outside htmlDir is blocked. Will not navigate to remote URLs — callers
+        // that need to load an admin-configured http(s) URL must use load_url().
+        msc_debug_log("load_page request for \(name)")
+        let baseURL = URL(fileURLWithPath: htmlDir).standardizedFileURL
+        let requestURL = baseURL.appendingPathComponent(name).standardizedFileURL
+
+        let baseComponents = baseURL.pathComponents
+        let requestComponents = requestURL.pathComponents
+
+        guard requestComponents.starts(with: baseComponents) else {
+            msc_debug_log("Attempt to access file outside htmlDir: \(name)")
+            // since error.html doesn't exist, this ends up triggering buildItemNotFoundPage()
+            let errorURL = baseURL.appendingPathComponent("error.html")
+            webView.load(URLRequest(url: errorURL))
+            return
         }
 
+        let request = URLRequest(
+            url: requestURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 10.0
+        )
         webView.load(request)
-        
-        if url_fragment == "updates.html" {
+
+        if name == "updates.html" {
             if !_update_in_progress && NSApp.isActive {
                 // clear all earlier update notifications
                 removeAllDeliveredNotifications()
@@ -1208,6 +1201,26 @@ class MainWindowController: NSWindowController {
                 _alertedUserToOutstandingUpdates = true
             }
         }
+    }
+
+    func load_url(_ url_string: String) {
+        // Loads an arbitrary http(s) URL into the main webview. Used by
+        // loadSidebarItemPage to honor admin-configured CustomSidebarItems
+        // whose `page` value is a remote URL. Refuses any other scheme.
+        msc_debug_log("load_url request for \(url_string)")
+        guard let components = URLComponents(string: url_string),
+              ["https", "http"].contains(components.scheme),
+              let url = URL(string: url_string)
+        else {
+            msc_debug_log("load_url refused: \(url_string) is not an http(s) URL")
+            return
+        }
+        let request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: TimeInterval(10.0)
+        )
+        webView.load(request)
     }
     
     func removeAllDeliveredNotifications() {
@@ -1245,16 +1258,6 @@ class MainWindowController: NSWindowController {
             return
         }
         var filename = unquote(host)
-        // Reject payloads that smuggle a remote URL through the munki:// scheme.
-        // handleMunkiURL is for internal page names only; load_page accepts
-        // http/https specifically for admin-configured CustomSidebarItems,
-        // which never flow through this function.
-        if let components = URLComponents(string: filename),
-           ["https", "http"].contains(components.scheme)
-        {
-            msc_debug_log("Refusing munki:// URL with embedded http(s) scheme: \(filename)")
-            return
-        }
         if filename == "appleupdates" {
             openSoftwareUpdatePrefsPane()
             return


### PR DESCRIPTION
Alternative to #1359, implementing the "split `load_page()` into two different functions" suggestion. Splits `load_page()` into two functions with distinct intents:

- `load_page(name)` — loads a Munki-internal HTML page from htmlDir. Path traversal still blocked. Will not navigate to remote URLs.
- `load_url(url_string)` — loads an arbitrary http(s) URL. Used only by `loadSidebarItemPage` to honor admin-configured `CustomSidebarItems` with remote `page` values.

`loadSidebarItemPage` is the only caller that branches on input scheme — the other 13 call sites pass internal page names and continue calling `load_page` unchanged.

Also removes the input guard added in #1356. The function split makes that guard redundant — `handleMunkiURL` → `load_page(filename)` can no longer reach remote-loading code regardless of what `filename` contains — and keeping it alongside the split would create an asymmetry (explicit refusal log for http/https inputs, silent fall-through for other schemes that hit the same downstream code).

## Verified locally

Built the patched MSC and tested:

| URL | Result |
|---|---|
| `munki://category-all`, `munki://categories`, `munki://myitems`, `munki://updates` | Pages load correctly |
| `munki://detail-Slack` | Detail page loads |
| `munki://` wrapping encoded `http://127.0.0.1/poc.html` | Re-interpreted as nonexistent filename in htmlDir; no remote navigation |
| `munki://` wrapping encoded `file:///etc/passwd` | Same — no remote navigation |
| `munki://` wrapping encoded `smb://attacker/share` | Same — no remote navigation |
| `munki://` wrapping encoded `javascript:alert(1)` | Resolves to nonexistent filename; webView shows standard not-found page (same UX as `munki://detail-fake`) |

Attack URLs that smuggle remote URLs through `munki://` are neutralized by construction — `handleMunkiURL` → `load_page` no longer has the capability to navigate remote.

## Relationship to #1359

This PR is an alternative approach to #1359, not an addition. Both close the same vulnerability:

- **#1359** — input-layer fix: rejects any URL with embedded scheme at the entry of `handleMunkiURL`.
- **This PR** — architecture fix: removes the remote-navigation capability from the `handleMunkiURL` → `load_page` path entirely.

Please let me know which approach you prefer and I'll happily close the other.
