### PR TITLE
Fix reference to non-existent verb in manifestutil error

### DIFF
--- a/code/cli/munki/manifestutil/manifestutil.swift
+++ b/code/cli/munki/manifestutil/manifestutil.swift
@@ -22,7 +22,7 @@ import Foundation
 
 func connectToRepo() throws -> Repo {
     guard let repoURL = adminPref("repo_url") as? String else {
-        printStderr("No repo URL defined. Run manifestutil config to define one.")
+        printStderr("No repo URL defined. Run manifestutil configure to define one.")
         throw ExitCode(-1)
     }
     var plugin = adminPref("plugin") as? String ?? "FileRepo"


### PR DESCRIPTION
Fixes a small typo in an error message that occurs when running `manifestutil` without a `repo_url` configured.

This was a fun one to find - even more fun was that running `manifestutil config` to configure the `repo_url`, told me to use `manifestutil config` to fix my issue :) 