### PR TITLE
Fix missing comma in ASU symlink list

### DIFF
--- a/code/client/munkilib/adobeutils/core.py
+++ b/code/client/munkilib/adobeutils/core.py
@@ -468,7 +468,7 @@ def run_adobe_cpp_pkg_script(dmgpath, payloads=None, operation='install'):
     tmpdir = tempfile.mkdtemp(prefix='munki-', dir='/tmp')
 
     # make our symlinks
-    for dir_name in ['ASU' 'ASU2', 'ProvisioningTool', 'uninstallinfo']:
+    for dir_name in ['ASU', 'ASU2', 'ProvisioningTool', 'uninstallinfo']:
         if os.path.isdir(os.path.join(basepath, dir_name)):
             os.symlink(os.path.join(basepath, dir_name),
                        os.path.join(tmpdir, dir_name))


### PR DESCRIPTION
I realize this is old/unsupported code, but wanted to offer a quick fix regardless.