### PR TITLE
Enable client certificate auth against servers that don't advertise acceptable CA names

### DIFF
--- a/code/cli/munki/munki.xcodeproj/project.pbxproj
+++ b/code/cli/munki/munki.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 		C0AD96302F3E58D80029A293 /* appleupdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD96192F3E58D80029A293 /* appleupdatesTests.swift */; };
 		C0AD96312F3E58D80029A293 /* cliutilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD961A2F3E58D80029A293 /* cliutilsTests.swift */; };
 		C0AD96322F3E58D80029A293 /* compareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD961B2F3E58D80029A293 /* compareTests.swift */; };
+		C0AD96FE2F3E58D80029A293 /* clientcertsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD96FD2F3E58D80029A293 /* clientcertsTests.swift */; };
 		C0AD96332F3E58D80029A293 /* downloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD961C2F3E58D80029A293 /* downloadTests.swift */; };
 		C0AD96342F3E58D80029A293 /* factsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD961D2F3E58D80029A293 /* factsTests.swift */; };
 		C0AD96352F3E58D80029A293 /* fetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD961E2F3E58D80029A293 /* fetchTests.swift */; };
@@ -860,6 +861,7 @@
 		C0AD961F2F3E58D80029A293 /* fileUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fileUtilsTests.swift; sourceTree = "<group>"; };
 		C0AD96202F3E58D80029A293 /* installationstateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = installationstateTests.swift; sourceTree = "<group>"; };
 		C0AD96212F3E58D80029A293 /* keychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = keychainTests.swift; sourceTree = "<group>"; };
+		C0AD96FD2F3E58D80029A293 /* clientcertsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = clientcertsTests.swift; sourceTree = "<group>"; };
 		C0AD96222F3E58D80029A293 /* makepkginfolibTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = makepkginfolibTests.swift; sourceTree = "<group>"; };
 		C0AD96232F3E58D80029A293 /* manifestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = manifestsTests.swift; sourceTree = "<group>"; };
 		C0AD96242F3E58D80029A293 /* pkgutilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pkgutilsTests.swift; sourceTree = "<group>"; };
@@ -1404,6 +1406,7 @@
 				C0AD96182F3E58D80029A293 /* analyzeTests.swift */,
 				C0AD96192F3E58D80029A293 /* appleupdatesTests.swift */,
 				C0AD961A2F3E58D80029A293 /* cliutilsTests.swift */,
+				C0AD96FD2F3E58D80029A293 /* clientcertsTests.swift */,
 				C0AD961B2F3E58D80029A293 /* compareTests.swift */,
 				C0AD961C2F3E58D80029A293 /* downloadTests.swift */,
 				C0AD961D2F3E58D80029A293 /* factsTests.swift */,
@@ -2223,6 +2226,7 @@
 				C0AD962F2F3E58D80029A293 /* analyzeTests.swift in Sources */,
 				C0AD96302F3E58D80029A293 /* appleupdatesTests.swift in Sources */,
 				C0AD96312F3E58D80029A293 /* cliutilsTests.swift in Sources */,
+				C0AD96FE2F3E58D80029A293 /* clientcertsTests.swift in Sources */,
 				C0AD96322F3E58D80029A293 /* compareTests.swift in Sources */,
 				C0AD96332F3E58D80029A293 /* downloadTests.swift in Sources */,
 				C0AD96342F3E58D80029A293 /* factsTests.swift in Sources */,

--- a/code/cli/munki/munkiCLItesting/clientcertsTests.swift
+++ b/code/cli/munki/munkiCLItesting/clientcertsTests.swift
@@ -31,7 +31,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [dn],
-            configuredIssuers: []
+            configuredTrustedAnchorDNs: []
         ))
     }
 
@@ -41,7 +41,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredIssuers: ["CN=Munki Client CA,O=SomeOrg"]
+            configuredTrustedAnchorDNs: ["CN=Munki Client CA,O=SomeOrg"]
         ))
     }
 
@@ -52,7 +52,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [serverDN],
-            configuredIssuers: ["CN=Munki Client CA,O=SomeOrg"]
+            configuredTrustedAnchorDNs: ["CN=Munki Client CA,O=SomeOrg"]
         ))
     }
 
@@ -63,7 +63,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(!dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [serverDN],
-            configuredIssuers: ["CN=Some Other CA,O=SomeOrg"]
+            configuredTrustedAnchorDNs: ["CN=Some Other CA,O=SomeOrg"]
         ))
     }
 
@@ -73,7 +73,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(!dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredIssuers: []
+            configuredTrustedAnchorDNs: []
         ))
     }
 
@@ -83,12 +83,12 @@ struct dnMatchesExpectedIssuersTests {
         #expect(!dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredIssuers: ["O=SomeOrg,CN=Munki Client CA"]
+            configuredTrustedAnchorDNs: ["O=SomeOrg,CN=Munki Client CA"]
         ))
         #expect(!dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredIssuers: ["CN=Munki Client CA, O=SomeOrg"]
+            configuredTrustedAnchorDNs: ["CN=Munki Client CA, O=SomeOrg"]
         ))
     }
 
@@ -98,7 +98,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredIssuers: ["CN=Munki Client CA,O=SomeOrg\\, Inc."]
+            configuredTrustedAnchorDNs: ["CN=Munki Client CA,O=SomeOrg\\, Inc."]
         ))
     }
 }

--- a/code/cli/munki/munkiCLItesting/clientcertsTests.swift
+++ b/code/cli/munki/munkiCLItesting/clientcertsTests.swift
@@ -1,0 +1,104 @@
+//
+//  clientcertsTests.swift
+//  munkiCLItesting
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Testing
+import X509
+
+struct dnMatchesExpectedIssuersTests {
+    private func makeDN(commonName: String, organization: String) throws -> DistinguishedName {
+        try DistinguishedName {
+            OrganizationName(organization)
+            CommonName(commonName)
+        }
+    }
+
+    /// A DN advertised by the server should match, with no configured issuers
+    @Test func matchesServerAdvertisedIssuer() throws {
+        let dn = try makeDN(commonName: "Munki Client CA", organization: "SomeOrg")
+        #expect(dnMatchesExpectedIssuers(
+            dn,
+            serverIssuers: [dn],
+            configuredIssuers: []
+        ))
+    }
+
+    /// A configured issuer string should match when the server sends no CA names
+    @Test func matchesConfiguredIssuerWhenServerListEmpty() throws {
+        let dn = try makeDN(commonName: "Munki Client CA", organization: "SomeOrg")
+        #expect(dnMatchesExpectedIssuers(
+            dn,
+            serverIssuers: [],
+            configuredIssuers: ["CN=Munki Client CA,O=SomeOrg"]
+        ))
+    }
+
+    /// A configured issuer string should also match alongside server-advertised names
+    @Test func matchesConfiguredIssuerAlongsideServerList() throws {
+        let serverDN = try makeDN(commonName: "Other CA", organization: "OtherOrg")
+        let dn = try makeDN(commonName: "Munki Client CA", organization: "SomeOrg")
+        #expect(dnMatchesExpectedIssuers(
+            dn,
+            serverIssuers: [serverDN],
+            configuredIssuers: ["CN=Munki Client CA,O=SomeOrg"]
+        ))
+    }
+
+    /// No match when neither server-advertised nor configured issuers match
+    @Test func noMatchWhenNothingMatches() throws {
+        let serverDN = try makeDN(commonName: "Other CA", organization: "OtherOrg")
+        let dn = try makeDN(commonName: "Munki Client CA", organization: "SomeOrg")
+        #expect(!dnMatchesExpectedIssuers(
+            dn,
+            serverIssuers: [serverDN],
+            configuredIssuers: ["CN=Some Other CA,O=SomeOrg"]
+        ))
+    }
+
+    /// No match when both lists are empty
+    @Test func noMatchWhenBothListsEmpty() throws {
+        let dn = try makeDN(commonName: "Munki Client CA", organization: "SomeOrg")
+        #expect(!dnMatchesExpectedIssuers(
+            dn,
+            serverIssuers: [],
+            configuredIssuers: []
+        ))
+    }
+
+    /// Configured issuer matching is exact — order and spacing matter
+    @Test func configuredIssuerMatchIsExact() throws {
+        let dn = try makeDN(commonName: "Munki Client CA", organization: "SomeOrg")
+        #expect(!dnMatchesExpectedIssuers(
+            dn,
+            serverIssuers: [],
+            configuredIssuers: ["O=SomeOrg,CN=Munki Client CA"]
+        ))
+        #expect(!dnMatchesExpectedIssuers(
+            dn,
+            serverIssuers: [],
+            configuredIssuers: ["CN=Munki Client CA, O=SomeOrg"]
+        ))
+    }
+
+    /// DNs with escaped characters render and match in RFC 4514-style form
+    @Test func matchesIssuerWithEscapedCharacters() throws {
+        let dn = try makeDN(commonName: "Munki Client CA", organization: "SomeOrg, Inc.")
+        #expect(dnMatchesExpectedIssuers(
+            dn,
+            serverIssuers: [],
+            configuredIssuers: ["CN=Munki Client CA,O=SomeOrg\\, Inc."]
+        ))
+    }
+}

--- a/code/cli/munki/munkiCLItesting/clientcertsTests.swift
+++ b/code/cli/munki/munkiCLItesting/clientcertsTests.swift
@@ -31,7 +31,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [dn],
-            configuredTrustedAnchorDNs: []
+            configuredAcceptableCAs: []
         ))
     }
 
@@ -41,7 +41,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredTrustedAnchorDNs: ["CN=Munki Client CA,O=SomeOrg"]
+            configuredAcceptableCAs: ["CN=Munki Client CA,O=SomeOrg"]
         ))
     }
 
@@ -52,7 +52,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [serverDN],
-            configuredTrustedAnchorDNs: ["CN=Munki Client CA,O=SomeOrg"]
+            configuredAcceptableCAs: ["CN=Munki Client CA,O=SomeOrg"]
         ))
     }
 
@@ -63,7 +63,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(!dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [serverDN],
-            configuredTrustedAnchorDNs: ["CN=Some Other CA,O=SomeOrg"]
+            configuredAcceptableCAs: ["CN=Some Other CA,O=SomeOrg"]
         ))
     }
 
@@ -73,7 +73,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(!dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredTrustedAnchorDNs: []
+            configuredAcceptableCAs: []
         ))
     }
 
@@ -83,12 +83,12 @@ struct dnMatchesExpectedIssuersTests {
         #expect(!dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredTrustedAnchorDNs: ["O=SomeOrg,CN=Munki Client CA"]
+            configuredAcceptableCAs: ["O=SomeOrg,CN=Munki Client CA"]
         ))
         #expect(!dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredTrustedAnchorDNs: ["CN=Munki Client CA, O=SomeOrg"]
+            configuredAcceptableCAs: ["CN=Munki Client CA, O=SomeOrg"]
         ))
     }
 
@@ -98,7 +98,7 @@ struct dnMatchesExpectedIssuersTests {
         #expect(dnMatchesExpectedIssuers(
             dn,
             serverIssuers: [],
-            configuredTrustedAnchorDNs: ["CN=Munki Client CA,O=SomeOrg\\, Inc."]
+            configuredAcceptableCAs: ["CN=Munki Client CA,O=SomeOrg\\, Inc."]
         ))
     }
 }

--- a/code/cli/munki/shared/network/clientcerts.swift
+++ b/code/cli/munki/shared/network/clientcerts.swift
@@ -52,24 +52,24 @@ func getCertChainRefs(_ certRef: SecCertificate) -> [SecCertificate]? {
 
 /// Returns true if the given distinguished name matches either one of the
 /// server-advertised acceptable issuers, or one of the admin-configured
-/// trusted anchor DN strings (RFC 4514-style, as produced by
+/// acceptable CA strings (RFC 4514-style distinguished names, as produced by
 /// DistinguishedName.description, e.g. "CN=Munki Client CA,O=SomeOrg")
 func dnMatchesExpectedIssuers(
     _ dn: DistinguishedName,
     serverIssuers: [DistinguishedName],
-    configuredTrustedAnchorDNs: [String]
+    configuredAcceptableCAs: [String]
 ) -> Bool {
     if serverIssuers.contains(dn) {
         return true
     }
-    return configuredTrustedAnchorDNs.contains(dn.description)
+    return configuredAcceptableCAs.contains(dn.description)
 }
 
 /// Attempts to find an appropriate identity for the protectionSpace and return a credential
 /// for client certificate authentication
 func getClientCertCredential(
     protectionSpace: URLProtectionSpace,
-    configuredTrustedAnchorDNs: [String] = [],
+    configuredAcceptableCAs: [String] = [],
     log: (String) -> Void
 ) -> URLCredential? {
     var expectedIssuers = [DistinguishedName]()
@@ -88,11 +88,11 @@ func getClientCertCredential(
     if expectedIssuers.isEmpty {
         log("The server didn't send the list of acceptable certificate-issuing authorities")
     }
-    for anchorDN in configuredTrustedAnchorDNs {
-        log("Configured trusted anchor DN: \(anchorDN)")
+    for acceptableCA in configuredAcceptableCAs {
+        log("Configured acceptable certificate-issuing authority: \(acceptableCA)")
     }
-    if expectedIssuers.isEmpty, configuredTrustedAnchorDNs.isEmpty {
-        log("No acceptable certificate-issuing authorities are available, either sent by the server or configured via the ClientCertificateTrustedAnchorDNs preference")
+    if expectedIssuers.isEmpty, configuredAcceptableCAs.isEmpty {
+        log("No acceptable certificate-issuing authorities are available, either sent by the server or configured via the ClientCertificateAcceptableCAs preference")
         return nil
     }
     // search for a matching identity (cert paired with private key)
@@ -130,7 +130,7 @@ func getClientCertCredential(
             if dnMatchesExpectedIssuers(
                 certSubject,
                 serverIssuers: expectedIssuers,
-                configuredTrustedAnchorDNs: configuredTrustedAnchorDNs
+                configuredAcceptableCAs: configuredAcceptableCAs
             ) {
                 log("Found matching identity")
                 return URLCredential(

--- a/code/cli/munki/shared/network/clientcerts.swift
+++ b/code/cli/munki/shared/network/clientcerts.swift
@@ -50,10 +50,26 @@ func getCertChainRefs(_ certRef: SecCertificate) -> [SecCertificate]? {
     return certRefs
 }
 
+/// Returns true if the given distinguished name matches either one of the
+/// server-advertised acceptable issuers, or one of the admin-configured issuer
+/// strings (RFC 4514-style, as produced by DistinguishedName.description,
+/// e.g. "CN=Munki Client CA,O=SomeOrg")
+func dnMatchesExpectedIssuers(
+    _ dn: DistinguishedName,
+    serverIssuers: [DistinguishedName],
+    configuredIssuers: [String]
+) -> Bool {
+    if serverIssuers.contains(dn) {
+        return true
+    }
+    return configuredIssuers.contains(dn.description)
+}
+
 /// Attempts to find an appropriate identity for the protectionSpace and return a credential
 /// for client certificate authentication
 func getClientCertCredential(
     protectionSpace: URLProtectionSpace,
+    configuredIssuers: [String] = [],
     log: (String) -> Void
 ) -> URLCredential? {
     var expectedIssuers = [DistinguishedName]()
@@ -71,6 +87,12 @@ func getClientCertCredential(
     }
     if expectedIssuers.isEmpty {
         log("The server didn't send the list of acceptable certificate-issuing authorities")
+    }
+    for issuer in configuredIssuers {
+        log("Configured acceptable certificate-issuing authority: \(issuer)")
+    }
+    if expectedIssuers.isEmpty, configuredIssuers.isEmpty {
+        log("No acceptable certificate-issuing authorities are available, either sent by the server or configured via the ClientCertificateIssuers preference")
         return nil
     }
     // search for a matching identity (cert paired with private key)
@@ -105,7 +127,11 @@ func getClientCertCredential(
             }
         }
         for certSubject in certSubjects {
-            if expectedIssuers.contains(certSubject) {
+            if dnMatchesExpectedIssuers(
+                certSubject,
+                serverIssuers: expectedIssuers,
+                configuredIssuers: configuredIssuers
+            ) {
                 log("Found matching identity")
                 return URLCredential(
                     identity: identityRef,
@@ -114,7 +140,9 @@ func getClientCertCredential(
                 )
             }
         }
+        log("Identity with subject \(certificate.subject.description) does not match any acceptable certificate-issuing authority; candidate issuers: \(certSubjects.map(\.description).joined(separator: " | "))")
     }
     // no matching identity found
+    log("No keychain identity matches any acceptable certificate-issuing authority")
     return nil
 }

--- a/code/cli/munki/shared/network/clientcerts.swift
+++ b/code/cli/munki/shared/network/clientcerts.swift
@@ -51,25 +51,25 @@ func getCertChainRefs(_ certRef: SecCertificate) -> [SecCertificate]? {
 }
 
 /// Returns true if the given distinguished name matches either one of the
-/// server-advertised acceptable issuers, or one of the admin-configured issuer
-/// strings (RFC 4514-style, as produced by DistinguishedName.description,
-/// e.g. "CN=Munki Client CA,O=SomeOrg")
+/// server-advertised acceptable issuers, or one of the admin-configured
+/// trusted anchor DN strings (RFC 4514-style, as produced by
+/// DistinguishedName.description, e.g. "CN=Munki Client CA,O=SomeOrg")
 func dnMatchesExpectedIssuers(
     _ dn: DistinguishedName,
     serverIssuers: [DistinguishedName],
-    configuredIssuers: [String]
+    configuredTrustedAnchorDNs: [String]
 ) -> Bool {
     if serverIssuers.contains(dn) {
         return true
     }
-    return configuredIssuers.contains(dn.description)
+    return configuredTrustedAnchorDNs.contains(dn.description)
 }
 
 /// Attempts to find an appropriate identity for the protectionSpace and return a credential
 /// for client certificate authentication
 func getClientCertCredential(
     protectionSpace: URLProtectionSpace,
-    configuredIssuers: [String] = [],
+    configuredTrustedAnchorDNs: [String] = [],
     log: (String) -> Void
 ) -> URLCredential? {
     var expectedIssuers = [DistinguishedName]()
@@ -88,11 +88,11 @@ func getClientCertCredential(
     if expectedIssuers.isEmpty {
         log("The server didn't send the list of acceptable certificate-issuing authorities")
     }
-    for issuer in configuredIssuers {
-        log("Configured acceptable certificate-issuing authority: \(issuer)")
+    for anchorDN in configuredTrustedAnchorDNs {
+        log("Configured trusted anchor DN: \(anchorDN)")
     }
-    if expectedIssuers.isEmpty, configuredIssuers.isEmpty {
-        log("No acceptable certificate-issuing authorities are available, either sent by the server or configured via the ClientCertificateIssuers preference")
+    if expectedIssuers.isEmpty, configuredTrustedAnchorDNs.isEmpty {
+        log("No acceptable certificate-issuing authorities are available, either sent by the server or configured via the ClientCertificateTrustedAnchorDNs preference")
         return nil
     }
     // search for a matching identity (cert paired with private key)
@@ -130,7 +130,7 @@ func getClientCertCredential(
             if dnMatchesExpectedIssuers(
                 certSubject,
                 serverIssuers: expectedIssuers,
-                configuredIssuers: configuredIssuers
+                configuredTrustedAnchorDNs: configuredTrustedAnchorDNs
             ) {
                 log("Found matching identity")
                 return URLCredential(

--- a/code/cli/munki/shared/network/fetch.swift
+++ b/code/cli/munki/shared/network/fetch.swift
@@ -230,6 +230,7 @@ func getURL(
     }
 
     let ignoreSystemProxy = pref("IgnoreSystemProxies") as? Bool ?? false
+    let clientCertificateIssuers = pref("ClientCertificateIssuers") as? [String] ?? []
 
     let options = GurlOptions(
         url: request.url,
@@ -240,6 +241,7 @@ func getURL(
         canResume: resume,
         downloadOnlyIfChanged: onlyIfNewer,
         cacheData: cacheData,
+        clientCertificateIssuers: clientCertificateIssuers,
         log: DisplayAndLog.main.debug2
     )
 

--- a/code/cli/munki/shared/network/fetch.swift
+++ b/code/cli/munki/shared/network/fetch.swift
@@ -230,7 +230,7 @@ func getURL(
     }
 
     let ignoreSystemProxy = pref("IgnoreSystemProxies") as? Bool ?? false
-    let clientCertificateIssuers = pref("ClientCertificateIssuers") as? [String] ?? []
+    let clientCertificateTrustedAnchorDNs = pref("ClientCertificateTrustedAnchorDNs") as? [String] ?? []
 
     let options = GurlOptions(
         url: request.url,
@@ -241,7 +241,7 @@ func getURL(
         canResume: resume,
         downloadOnlyIfChanged: onlyIfNewer,
         cacheData: cacheData,
-        clientCertificateIssuers: clientCertificateIssuers,
+        clientCertificateTrustedAnchorDNs: clientCertificateTrustedAnchorDNs,
         log: DisplayAndLog.main.debug2
     )
 

--- a/code/cli/munki/shared/network/fetch.swift
+++ b/code/cli/munki/shared/network/fetch.swift
@@ -230,7 +230,7 @@ func getURL(
     }
 
     let ignoreSystemProxy = pref("IgnoreSystemProxies") as? Bool ?? false
-    let clientCertificateTrustedAnchorDNs = pref("ClientCertificateTrustedAnchorDNs") as? [String] ?? []
+    let clientCertificateAcceptableCAs = pref("ClientCertificateAcceptableCAs") as? [String] ?? []
 
     let options = GurlOptions(
         url: request.url,
@@ -241,7 +241,7 @@ func getURL(
         canResume: resume,
         downloadOnlyIfChanged: onlyIfNewer,
         cacheData: cacheData,
-        clientCertificateTrustedAnchorDNs: clientCertificateTrustedAnchorDNs,
+        clientCertificateAcceptableCAs: clientCertificateAcceptableCAs,
         log: DisplayAndLog.main.debug2
     )
 

--- a/code/cli/munki/shared/network/gurl.swift
+++ b/code/cli/munki/shared/network/gurl.swift
@@ -40,7 +40,7 @@ struct GurlOptions {
     var cacheData: [String: String]?
     var connectionTimeout: Double = 60.0
     var minimumTLSprotocol = tls_protocol_version_t.TLSv10
-    var clientCertificateTrustedAnchorDNs: [String] = []
+    var clientCertificateAcceptableCAs: [String] = []
     var log: (String) -> Void = defaultLogger // logging function
 }
 
@@ -438,7 +438,7 @@ class Gurl: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionData
             options.log("Client certificate required")
             if let credential = getClientCertCredential(
                 protectionSpace: protectionSpace,
-                configuredTrustedAnchorDNs: options.clientCertificateTrustedAnchorDNs,
+                configuredAcceptableCAs: options.clientCertificateAcceptableCAs,
                 log: options.log
             ) {
                 options.log("Will attempt to authenticate")

--- a/code/cli/munki/shared/network/gurl.swift
+++ b/code/cli/munki/shared/network/gurl.swift
@@ -40,7 +40,7 @@ struct GurlOptions {
     var cacheData: [String: String]?
     var connectionTimeout: Double = 60.0
     var minimumTLSprotocol = tls_protocol_version_t.TLSv10
-    var clientCertificateIssuers: [String] = []
+    var clientCertificateTrustedAnchorDNs: [String] = []
     var log: (String) -> Void = defaultLogger // logging function
 }
 
@@ -438,7 +438,7 @@ class Gurl: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionData
             options.log("Client certificate required")
             if let credential = getClientCertCredential(
                 protectionSpace: protectionSpace,
-                configuredIssuers: options.clientCertificateIssuers,
+                configuredTrustedAnchorDNs: options.clientCertificateTrustedAnchorDNs,
                 log: options.log
             ) {
                 options.log("Will attempt to authenticate")

--- a/code/cli/munki/shared/network/gurl.swift
+++ b/code/cli/munki/shared/network/gurl.swift
@@ -40,6 +40,7 @@ struct GurlOptions {
     var cacheData: [String: String]?
     var connectionTimeout: Double = 60.0
     var minimumTLSprotocol = tls_protocol_version_t.TLSv10
+    var clientCertificateIssuers: [String] = []
     var log: (String) -> Void = defaultLogger // logging function
 }
 
@@ -435,7 +436,11 @@ class Gurl: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionData
             completionHandler(.useCredential, credential)
         } else if authenticationMethod == NSURLAuthenticationMethodClientCertificate {
             options.log("Client certificate required")
-            if let credential = getClientCertCredential(protectionSpace: protectionSpace, log: options.log) {
+            if let credential = getClientCertCredential(
+                protectionSpace: protectionSpace,
+                configuredIssuers: options.clientCertificateIssuers,
+                log: options.log
+            ) {
                 options.log("Will attempt to authenticate")
                 completionHandler(.useCredential, credential)
             } else {

--- a/code/cli/munki/shared/prefs.swift
+++ b/code/cli/munki/shared/prefs.swift
@@ -83,7 +83,7 @@ let CONFIG_KEY_NAMES = [
     "AppleSoftwareUpdatesIncludeMajorOSUpdates",
     "AppleSoftwareUpdatesOnly",
     "CatalogURL",
-    "ClientCertificateIssuers",
+    "ClientCertificateTrustedAnchorDNs",
     "ClientCertificatePath",
     "ClientIdentifier",
     "ClientKeyPath",

--- a/code/cli/munki/shared/prefs.swift
+++ b/code/cli/munki/shared/prefs.swift
@@ -83,6 +83,7 @@ let CONFIG_KEY_NAMES = [
     "AppleSoftwareUpdatesIncludeMajorOSUpdates",
     "AppleSoftwareUpdatesOnly",
     "CatalogURL",
+    "ClientCertificateIssuers",
     "ClientCertificatePath",
     "ClientIdentifier",
     "ClientKeyPath",

--- a/code/cli/munki/shared/prefs.swift
+++ b/code/cli/munki/shared/prefs.swift
@@ -83,7 +83,7 @@ let CONFIG_KEY_NAMES = [
     "AppleSoftwareUpdatesIncludeMajorOSUpdates",
     "AppleSoftwareUpdatesOnly",
     "CatalogURL",
-    "ClientCertificateTrustedAnchorDNs",
+    "ClientCertificateAcceptableCAs",
     "ClientCertificatePath",
     "ClientIdentifier",
     "ClientKeyPath",


### PR DESCRIPTION
## Problem

Munki's client certificate support currently depends on the server advertising a list of acceptable client-certificate CAs in its TLS CertificateRequest. When a client certificate is requested, `getClientCertCredential()` in `clientcerts.swift` parses `protectionSpace.distinguishedNames` and matches keychain identities against the advertised issuer DNs. If the server sends an empty CA list, the function returns `nil` before examining any keychain identity, and the connection is cancelled:

```
Authentication challenge for Host: example-repo.example.net Realm:  AuthMethod: NSURLAuthenticationMethodClientCertificate
Client certificate required
The server didn't send the list of acceptable certificate-issuing authorities
Can't authenticate
Download error -999: cancelled
ERROR: Could not retrieve managed install primary manifest: There was a connection error: -999: cancelled
```

Per RFC 8446 (TLS 1.3), this `certificate_authorities` advertisement is optional. Some widely used servers never send it, notably Google Cloud external HTTPS load balancers (GFE), which omit the CA name list on both TLS 1.2 and TLS 1.3 with no server-side configuration option to change this. Other cloud load balancers behave similarly.

The result is that Munki cannot perform mutual TLS against a Munki repo fronted by a Google Cloud load balancer (or any server that omits CA names), even when a perfectly valid client identity is present in the keychain. There is currently no workaround short of modifying the server (impossible for GFE) or patching Munki. I believe I have a much better chance of fixing this via Munki than convincing Google to listen.

## Solution

Add a new preference, `ClientCertificateAcceptableCAs`, an array of strings. Each string is a distinguished name in the same format Munki already logs for server-advertised issuers (RFC 4514-style, as rendered by swift-certificates' `DistinguishedName.description`):

```xml
<key>ClientCertificateAcceptableCAs</key>
<array>
    <string>CN=Munki Client CA,O=SomeOrg</string>
</array>
```

During the client certificate authentication challenge, configured DNs are treated as a union with any server-advertised CA names when matching keychain identities. This lets an admin declare which issuing CA(s) to expect when the server doesn't say, the same information the server would have provided in its CertificateRequest.

Because the configured strings and the candidate identities' issuer DNs are both rendered by the same library (`DistinguishedName.description`), matching is exact and deterministic, with no custom DN string parsing. The correct value for the preference can be copied directly from Munki's own debug log output (`Accepted certificate-issuing authority: ...`) or derived from `openssl x509 -noout -subject` on the issuing CA certificate.

## No impact to existing deployments

This is a safe, purely opt-in change:

- Preference unset (the default): behavior is unchanged. If the server advertises CA names, identity matching proceeds exactly as before. If the server advertises none, Munki declines to authenticate exactly as before (`-999: cancelled`). Only the log message differs, now mentioning the new preference to aid discovery.
- Preference set: configured DNs are only *added* to the acceptable-issuer set. Matching against server-advertised names is unchanged. An identity is never presented unless its issuer chain matches an acceptable DN, so no identity that wouldn't have matched before can be silently offered.
- No changes to keychain handling, server trust evaluation, or any other network behavior.
- The preference is added to `CONFIG_KEY_NAMES` so it appears in `managedsoftwareupdate --show-config`, following the same display behavior as the existing array-valued preference `AdditionalHttpHeaders`.

### Live test against a Google Cloud external HTTPS load balancer

Tested against a private Munki repo served through a Google Cloud external Application Load Balancer configured for mTLS, with a client identity in the System keychain.

Before (stock behavior / preference unset): connection cancelled before any keychain identity is considered:

```
Client certificate required
The server didn't send the list of acceptable certificate-issuing authorities
No acceptable certificate-issuing authorities are available, either sent by the server or configured via the ClientCertificateAcceptableCAs preference
Can't authenticate
Download error -999: cancelled
ERROR: Could not retrieve managed install primary manifest: There was a connection error: -999: cancelled
```

After (preference set): the matching identity is found and presented, and the TLS handshake proceeds with the client certificate:

```
Client certificate required
The server didn't send the list of acceptable certificate-issuing authorities
Configured acceptable certificate-issuing authority: CN=Example Client CA,O=ExampleOrg
Found matching identity
Will attempt to authenticate
```

Backward-compatibility check: after deleting the preference, behavior returns to the exact stock outcome (`-999: cancelled` before any keychain access), confirming existing deployments are unaffected by upgrading.

## Documentation

If this is accepted, I'm happy to add `ClientCertificateAcceptableCAs` to the [Preferences wiki page](https://github.com/munki/munki/wiki/Preferences) alongside the other client certificate preferences, and an explanation of the proper DN format.
