### PR TITLE
Defer downloads on low data connections

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -323,27 +323,27 @@ class MSCAlertController: NSObject {
     
     func confirmDownloadAnyway(_ itemName: String) {
         // Confirm the user wants to download a low-data-deferred item over
-        // their low data connection, then record the override so
-        // managedsoftwareupdate downloads it on its next run.
+        // their low data connection, record the override, then kick off a
+        // check so it downloads now rather than silently waiting for the next
+        // scheduled run.
         guard let mainWindow = window else {
             return
         }
         let alert = NSAlert()
         alert.messageText = NSLocalizedString(
-            "Download this item anyway?",
+            "Download anyway?",
             comment: "Download Anyway alert title")
-        alert.informativeText = NSLocalizedString(
-            "This item will be downloaded over a low data connection, which "
-                + "may use cellular data. It will download the next time "
-                + "Managed Software Center checks for updates.",
-            comment: "Download Anyway alert detail")
         alert.addButton(withTitle: NSLocalizedString(
             "Download anyway", comment: "Download anyway button title"))
         alert.addButton(withTitle: NSLocalizedString(
             "Cancel", comment: "Cancel button title/short action text"))
         alert.beginSheetModal(for: mainWindow, completionHandler: { (modalResponse) -> Void in
             if modalResponse == .alertFirstButtonReturn {
-                if !addLowDataOverride(itemName) {
+                if addLowDataOverride(itemName) {
+                    if let mainWindowController = (NSApp.delegate as? AppDelegate)?.mainWindowController {
+                        mainWindowController.checkForUpdates()
+                    }
+                } else {
                     msc_debug_log("Could not write low-data override for \(itemName)")
                 }
             }

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -321,6 +321,35 @@ class MSCAlertController: NSObject {
         })
     }
     
+    func confirmDownloadAnyway(_ itemName: String) {
+        // Confirm the user wants to download a low-data-deferred item over
+        // their low data connection, then record the override so
+        // managedsoftwareupdate downloads it on its next run.
+        guard let mainWindow = window else {
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = NSLocalizedString(
+            "Download this item anyway?",
+            comment: "Download Anyway alert title")
+        alert.informativeText = NSLocalizedString(
+            "This item will be downloaded over a low data connection, which "
+                + "may use cellular data. It will download the next time "
+                + "Managed Software Center checks for updates.",
+            comment: "Download Anyway alert detail")
+        alert.addButton(withTitle: NSLocalizedString(
+            "Download anyway", comment: "Download anyway button title"))
+        alert.addButton(withTitle: NSLocalizedString(
+            "Cancel", comment: "Cancel button title/short action text"))
+        alert.beginSheetModal(for: mainWindow, completionHandler: { (modalResponse) -> Void in
+            if modalResponse == .alertFirstButtonReturn {
+                if !addLowDataOverride(itemName) {
+                    msc_debug_log("Could not write low-data override for \(itemName)")
+                }
+            }
+        })
+    }
+
     func confirmUpdatesAndInstall() {
         // Make sure it's OK to proceed with installing if logout or restart is
         // required

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController+WKScriptMessageHandler.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController+WKScriptMessageHandler.swift
@@ -51,6 +51,11 @@ extension MainWindowController: WKScriptMessageHandler {
                 updateOptionalInstallButtonFinishAction(item_name)
             }
         }
+        if message.name == "downloadAnywayButtonClicked" {
+            if let item_name = message.body as? String {
+                downloadAnywayButtonClicked(item_name)
+            }
+        }
         if message.name == "openExternalLink" {
             if let link = message.body as? String {
                 openExternalLink(link)
@@ -146,6 +151,13 @@ extension MainWindowController: WKScriptMessageHandler {
     
     func updateOptionalInstallButtonBeginAction(_ item_name: String) {
         webView.evaluateJavaScript("fadeOutAndRemove('\(item_name)')")
+    }
+
+    func downloadAnywayButtonClicked(_ item_name: String) {
+        // called from JavaScript when the user clicks "Download anyway" on a
+        // low-data-deferred update; confirm, then record the override
+        msc_debug_log("User clicked Download anyway for \(item_name)")
+        alert_controller.confirmDownloadAnyway(item_name)
     }
     
     func myItemsActionButtonClicked(_ item_name: String) {

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -705,6 +705,7 @@ class MainWindowController: NSWindowController {
         wkContentController.add(self, name: "changeSelectedCategory")
         wkContentController.add(self, name: "updateOptionalInstallButtonClicked")
         wkContentController.add(self, name: "updateOptionalInstallButtonFinishAction")
+        wkContentController.add(self, name: "downloadAnywayButtonClicked")
     }
 
     func insertWebView() {

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -53,6 +53,14 @@ func clearMunkiItemsCache() {
     Cache.shared.clear()
 }
 
+/// Localized text shown for an item whose download is paused on a low-data
+/// connection.
+func lowDataPausedNote() -> String {
+    return NSLocalizedString(
+        "Download paused — low data connection",
+        comment: "Low data connection deferred download note")
+}
+
 class BaseItem {
     // Base class for our types of Munki items
     var my = [String: Any]()
@@ -312,9 +320,7 @@ class GenericItem: BaseItem {
     func status_text() -> String {
         // Return localized status display text
         if my["low_data_deferred"] as? Bool ?? false {
-            return NSLocalizedString(
-                "Download paused — low data connection",
-                comment: "Low data connection deferred download note")
+            return lowDataPausedNote()
         }
         let status = my["status"] as? String ?? ""
         if status == "unavailable" {
@@ -1000,9 +1006,7 @@ class UpdateItem: GenericItem {
         if my["low_data_deferred"] as? Bool ?? false {
             // Show a localized "paused" message instead of the plain-English
             // note recorded by managedsoftwareupdate on the CLI side.
-            my["note"] = NSLocalizedString(
-                "Download paused — low data connection",
-                comment: "Low data connection deferred download note")
+            my["note"] = lowDataPausedNote()
             // Offer a "Download anyway" button unless the admin disabled
             // user overrides via AllowLowDataOverride.
             if munkiPref("AllowLowDataOverride") as? Bool ?? true {

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -311,6 +311,11 @@ class GenericItem: BaseItem {
     
     func status_text() -> String {
         // Return localized status display text
+        if my["low_data_deferred"] as? Bool ?? false {
+            return NSLocalizedString(
+                "Download paused — low data connection",
+                comment: "Low data connection deferred download note")
+        }
         let status = my["status"] as? String ?? ""
         if status == "unavailable" {
             return unavailable_reason_text()

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -988,6 +988,13 @@ class UpdateItem: GenericItem {
         my["hide_cancel_button"]  = "hidden"
         my["dependent_items"] = dependentItems(name)
         my["days_available"] = getDaysPending(name)
+        if my["low_data_deferred"] as? Bool ?? false {
+            // Show a localized "paused" message instead of the plain-English
+            // note recorded by managedsoftwareupdate on the CLI side.
+            my["note"] = NSLocalizedString(
+                "Download paused — low data connection",
+                comment: "Low data connection deferred download note")
+        }
     }
     
     override func description() -> String {

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -169,6 +169,10 @@ class GenericItem: BaseItem {
             my["size_sort"] = 0
             my["size"] = "-"
         }
+        // Low-data "Download anyway" button defaults; populated for
+        // low_data_deferred UpdateItems (see UpdateItem.init).
+        my["hide_low_data_button"] = "hidden"
+        my["low_data_action_text"] = ""
     }
 
     func description() -> String {
@@ -994,6 +998,14 @@ class UpdateItem: GenericItem {
             my["note"] = NSLocalizedString(
                 "Download paused — low data connection",
                 comment: "Low data connection deferred download note")
+            // Offer a "Download anyway" button unless the admin disabled
+            // user overrides via AllowLowDataOverride.
+            if munkiPref("AllowLowDataOverride") as? Bool ?? true {
+                my["hide_low_data_button"] = ""
+                my["low_data_action_text"] = NSLocalizedString(
+                    "Download anyway",
+                    comment: "Download anyway button title")
+            }
         }
     }
     

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -1007,9 +1007,10 @@ class UpdateItem: GenericItem {
             // Show a localized "paused" message instead of the plain-English
             // note recorded by managedsoftwareupdate on the CLI side.
             my["note"] = lowDataPausedNote()
-            // Offer a "Download anyway" button unless the admin disabled
-            // user overrides via AllowLowDataOverride.
-            if munkiPref("AllowLowDataOverride") as? Bool ?? true {
+            // Offer a "Download anyway" button only when user overrides are
+            // enabled and the low-data threshold permits per-item exceptions.
+            if munkiPref("AllowLowDataOverride") as? Bool ?? true,
+               (munkiPref("MaxSizeOverLowDataConnection") as? Int ?? -1) > 0 {
                 my["hide_low_data_button"] = ""
                 my["low_data_action_text"] = NSLocalizedString(
                     "Download anyway",

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -1007,10 +1007,9 @@ class UpdateItem: GenericItem {
             // Show a localized "paused" message instead of the plain-English
             // note recorded by managedsoftwareupdate on the CLI side.
             my["note"] = lowDataPausedNote()
-            // Offer a "Download anyway" button only when user overrides are
-            // enabled and the low-data threshold permits per-item exceptions.
-            if munkiPref("AllowLowDataOverride") as? Bool ?? true,
-               (munkiPref("MaxSizeOverLowDataConnection") as? Int ?? -1) > 0 {
+            // Offer a "Download anyway" button unless the admin disabled
+            // user overrides via AllowLowDataOverride.
+            if munkiPref("AllowLowDataOverride") as? Bool ?? true {
                 my["hide_low_data_button"] = ""
                 my["low_data_action_text"] = NSLocalizedString(
                     "Download anyway",

--- a/code/apps/Managed Software Center/Managed Software Center/Resources/templates/detail_template.html
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/templates/detail_template.html
@@ -45,6 +45,14 @@
                                         </div>
                                     </button>
                                 </div>
+                                <div class="msc-button large ${hide_low_data_button}">
+                                    <button class="button-area uppercase"
+                                     onClick="window.webkit.messageHandlers.downloadAnywayButtonClicked.postMessage('${name_quoted}');">
+                                        <div class="msc-button-inner large install">
+                                            ${low_data_action_text}
+                                        </div>
+                                    </button>
+                                </div>
                                 <div class="warning">
                                     <br/>&nbsp;
                                     ${restart_action_text}

--- a/code/apps/Managed Software Center/Managed Software Center/Resources/templates/update_item_template.html
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/templates/update_item_template.html
@@ -20,6 +20,14 @@
                 </div>
             </button>
         </div>
+        <div class="msc-button small ${hide_low_data_button}">
+            <button class="button-area uppercase"
+                    onClick="window.webkit.messageHandlers.downloadAnywayButtonClicked.postMessage('${name_quoted}');">
+                <div class="msc-button-inner install">
+                    ${low_data_action_text}
+                </div>
+            </button>
+        </div>
     </div>
     <div class="row2">
         <p class="description" data-text-truncate-lines="2">

--- a/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
@@ -142,6 +142,15 @@
 /* managedsoftwareupdate message */
 "Done." = "Done.";
 
+/* Download anyway button title */
+"Download anyway" = "Download anyway";
+
+/* Low data connection deferred download note */
+"Download paused — low data connection" = "Download paused — low data connection";
+
+/* Download Anyway alert title */
+"Download this item anyway?" = "Download this item anyway?";
+
 /* Downloading status text */
 "Downloading" = "Downloading";
 
@@ -471,6 +480,9 @@
 
 /* Forced Date warning */
 "This item must be installed by %@" = "This item must be installed by %@";
+
+/* Download Anyway alert detail */
+"This item will be downloaded over a low data connection, which may use cellular data. It will download the next time Managed Software Center checks for updates." = "This item will be downloaded over a low data connection, which may use cellular data. It will download the next time Managed Software Center checks for updates.";
 
 /* Pending days message */
 "This update has been pending for %@ days." = "This update has been pending for %@ days.";

--- a/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
@@ -149,7 +149,7 @@
 "Download paused — low data connection" = "Download paused — low data connection";
 
 /* Download Anyway alert title */
-"Download this item anyway?" = "Download this item anyway?";
+"Download anyway?" = "Download anyway?";
 
 /* Downloading status text */
 "Downloading" = "Downloading";
@@ -480,9 +480,6 @@
 
 /* Forced Date warning */
 "This item must be installed by %@" = "This item must be installed by %@";
-
-/* Download Anyway alert detail */
-"This item will be downloaded over a low data connection, which may use cellular data. It will download the next time Managed Software Center checks for updates." = "This item will be downloaded over a low data connection, which may use cellular data. It will download the next time Managed Software Center checks for updates.";
 
 /* Pending days message */
 "This update has been pending for %@ days." = "This update has been pending for %@ days.";

--- a/code/apps/Managed Software Center/Managed Software Center/munki.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/munki.swift
@@ -20,6 +20,7 @@ let INSTALLWITHOUTLOGOUTFILE = "/private/tmp/.com.googlecode.munki.managedinstal
 let BUNDLE_ID = "ManagedInstalls" as CFString
 let DEFAULT_GUI_CACHE_AGE_SECS = 3600
 let WRITEABLE_SELF_SERVICE_MANIFEST_PATH = "/Users/Shared/.SelfServeManifest"
+let WRITEABLE_LOW_DATA_OVERRIDES_PATH = "/Users/Shared/.low_data_overrides.plist"
 
 func exec(_ command: String, args: [String] = []) -> String {
     // runs a UNIX command and returns stdout as a string
@@ -191,6 +192,27 @@ func writeSelfServiceManifest(_ optional_install_choices: PlistDict) -> Bool {
             manifest_contents,
             toFile: WRITEABLE_SELF_SERVICE_MANIFEST_PATH
         )
+        return true
+    } catch {
+        return false
+    }
+}
+
+func addLowDataOverride(_ item_name: String) -> Bool {
+    /* Record that the user wants to download a low-data-deferred item anyway.
+     Appends the item name to a user-writable plist that managedsoftwareupdate
+     copies into place on its next run. Returns true on success. */
+    var overrides = PlistDict()
+    if FileManager.default.isReadableFile(atPath: WRITEABLE_LOW_DATA_OVERRIDES_PATH) {
+        overrides = ((try? readPlist(WRITEABLE_LOW_DATA_OVERRIDES_PATH)) as? PlistDict) ?? PlistDict()
+    }
+    var items = overrides["items"] as? [String] ?? [String]()
+    if !items.contains(item_name) {
+        items.append(item_name)
+    }
+    overrides["items"] = items
+    do {
+        try writePlist(overrides, toFile: WRITEABLE_LOW_DATA_OVERRIDES_PATH)
         return true
     } catch {
         return false

--- a/code/cli/munki/munki.xcodeproj/project.pbxproj
+++ b/code/cli/munki/munki.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09F71AB7CE8B63172BD55302 /* networkconditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033045629272F3646E39608C /* networkconditions.swift */; };
 		8972AAAED592738E565ED67B /* networkconditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033045629272F3646E39608C /* networkconditions.swift */; };
 		C0011CAC2C7A64F30004ED70 /* Predicates.m in Sources */ = {isa = PBXBuildFile; fileRef = C0011CAB2C7A64F30004ED70 /* Predicates.m */; };
 		C0011CAD2C7A64F30004ED70 /* Predicates.m in Sources */ = {isa = PBXBuildFile; fileRef = C0011CAB2C7A64F30004ED70 /* Predicates.m */; };
@@ -2170,6 +2171,7 @@
 				C0684DDE2DBFDD190091E774 /* constants.swift in Sources */,
 				C058EF302DCD18D3002775E0 /* tempfileutils.swift in Sources */,
 				C058EF7E2DCF9FB0002775E0 /* MiddlewareProtocol.swift in Sources */,
+				09F71AB7CE8B63172BD55302 /* networkconditions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/code/cli/munki/munki.xcodeproj/project.pbxproj
+++ b/code/cli/munki/munki.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8972AAAED592738E565ED67B /* networkconditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033045629272F3646E39608C /* networkconditions.swift */; };
 		C0011CAC2C7A64F30004ED70 /* Predicates.m in Sources */ = {isa = PBXBuildFile; fileRef = C0011CAB2C7A64F30004ED70 /* Predicates.m */; };
 		C0011CAD2C7A64F30004ED70 /* Predicates.m in Sources */ = {isa = PBXBuildFile; fileRef = C0011CAB2C7A64F30004ED70 /* Predicates.m */; };
 		C0011CB22C7CDEC40004ED70 /* updatecheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0011CB12C7CDEC40004ED70 /* updatecheck.swift */; };
@@ -574,6 +575,8 @@
 		C0EEC9A72DA7335900F92942 /* clientcerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EEC9A62DA7335900F92942 /* clientcerts.swift */; };
 		C0EEC9A82DA7335900F92942 /* clientcerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EEC9A62DA7335900F92942 /* clientcerts.swift */; };
 		C0FB3AC92DF490CF00BEA7F9 /* libedit.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C030A9F32C4350FE007F0B34 /* libedit.tbd */; };
+		D4375BC0418DD3184FA1567D /* networkconditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033045629272F3646E39608C /* networkconditions.swift */; };
+		EE4741BEC8774B923C0025CC /* networkconditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033045629272F3646E39608C /* networkconditions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -733,6 +736,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		033045629272F3646E39608C /* networkconditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = networkconditions.swift; sourceTree = "<group>"; };
 		C0011CAB2C7A64F30004ED70 /* Predicates.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Predicates.m; sourceTree = "<group>"; };
 		C0011CAE2C7A98280004ED70 /* Predicates.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Predicates.h; sourceTree = "<group>"; };
 		C0011CAF2C7A990B0004ED70 /* managedsoftwareupdate-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "managedsoftwareupdate-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1334,6 +1338,7 @@
 				C058EF7A2DCF9F6E002775E0 /* middleware */,
 				C07AED712C67F77000DE6119 /* sslerrors.swift */,
 				C01792D82C6EC09C008CBC22 /* urls.swift */,
+				033045629272F3646E39608C /* networkconditions.swift */,
 			);
 			path = network;
 			sourceTree = "<group>";
@@ -1502,8 +1507,6 @@
 			dependencies = (
 			);
 			name = authrestartd;
-			packageProductDependencies = (
-			);
 			productName = authrestartd;
 			productReference = C00519A12D2A5B850060DDB6 /* authrestartd */;
 			productType = "com.apple.product-type.tool";
@@ -1538,8 +1541,6 @@
 			dependencies = (
 			);
 			name = repocheck;
-			packageProductDependencies = (
-			);
 			productName = repocheck;
 			productReference = C0276DB12E8C070500D443C3 /* repocheck */;
 			productType = "com.apple.product-type.tool";
@@ -1637,8 +1638,6 @@
 			dependencies = (
 			);
 			name = installhelper;
-			packageProductDependencies = (
-			);
 			productName = installhelper;
 			productReference = C0684E2D2DC040450091E774 /* installhelper */;
 			productType = "com.apple.product-type.tool";
@@ -1779,8 +1778,6 @@
 			dependencies = (
 			);
 			name = logouthelper;
-			packageProductDependencies = (
-			);
 			productName = logouthelper;
 			productReference = C0D66ABF2D2CA1DE009EF807 /* logouthelper */;
 			productType = "com.apple.product-type.tool";
@@ -2279,6 +2276,7 @@
 				C0684E752DC7BE9F0091E774 /* munkistatus.swift in Sources */,
 				C058EF722DCE9C3E002775E0 /* admincommon.swift in Sources */,
 				C0684E7F2DC7C3AE0091E774 /* info.swift in Sources */,
+				D4375BC0418DD3184FA1567D /* networkconditions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2360,6 +2358,7 @@
 				C0209B862C63C9FD007664A0 /* stoprequested.swift in Sources */,
 				C07074DF2C33B9A000B86310 /* reports.swift in Sources */,
 				C058EF2D2DCD11F2002775E0 /* tempfileutils.swift in Sources */,
+				EE4741BEC8774B923C0025CC /* networkconditions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2457,6 +2456,7 @@
 				C01364592C3265D6008DB215 /* display.swift in Sources */,
 				C0D9C2A72C62C12E0019A067 /* munkistatus.swift in Sources */,
 				C0209B8A2C63DDF1007664A0 /* info.swift in Sources */,
+				8972AAAED592738E565ED67B /* networkconditions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/code/cli/munki/munkiCLItesting/analyzeTests.swift
+++ b/code/cli/munki/munkiCLItesting/analyzeTests.swift
@@ -16,7 +16,85 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+import Foundation
 import Testing
+
+struct shouldDeferDownloadForLowDataTests {
+    /// Not on a low data connection: never defer, even a large "never" item
+    @Test func notOnLowDataNeverDefers() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "never"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 999_999,
+            onLowDataConnection: false, maxSizeOverLowDataConnection: 1) == false)
+    }
+
+    /// download_on_low_data "always" never defers on a low data connection
+    @Test func alwaysDoesNotDefer() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "always"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 999_999,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 1) == false)
+    }
+
+    /// download_on_low_data "never" always defers on a low data connection
+    @Test func neverDefers() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "never"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 1,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 0) == true)
+    }
+
+    /// auto with the size threshold disabled (0) downloads
+    @Test func autoThresholdDisabledDownloads() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "auto"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 999_999,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 0) == false)
+    }
+
+    /// auto, item larger than the threshold, defers
+    @Test func autoOverThresholdDefers() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "auto"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 250_001,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 250_000) == true)
+    }
+
+    /// auto, item at or under the threshold, downloads
+    @Test func autoUnderThresholdDownloads() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "auto"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 250_000,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 250_000) == false)
+    }
+
+    /// An absent key is treated as auto (follows the threshold)
+    @Test func absentKeyFollowsThreshold() async throws {
+        let pkginfo = PlistDict()
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 300_000,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 250_000) == true)
+    }
+
+    /// An unrecognized value is treated as auto (follows the threshold)
+    @Test func unknownValueFollowsThreshold() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "bogus"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 100,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 250_000) == false)
+    }
+
+    /// A reached force_install_after_date wins over "never"
+    @Test func passedDeadlineDownloads() async throws {
+        let pkginfo: PlistDict = [
+            "download_on_low_data": "never",
+            "force_install_after_date": Date(timeIntervalSinceNow: -86400),
+        ]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 999_999,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 0) == false)
+    }
+}
 
 struct itemInInstallInfoTests {
     let installInfo: [PlistDict] = [

--- a/code/cli/munki/munkiCLItesting/analyzeTests.swift
+++ b/code/cli/munki/munkiCLItesting/analyzeTests.swift
@@ -60,12 +60,20 @@ struct shouldDeferDownloadForLowDataTests {
             onLowDataConnection: true, maxSizeOverLowDataConnection: -1) == false)
     }
 
-    /// a zero threshold defers every uncached download
-    @Test func zeroThresholdDefersAllDownloads() async throws {
-        let pkginfo: PlistDict = ["download_on_low_data": "always"]
+    /// a zero threshold defers auto/default downloads
+    @Test func zeroThresholdDefersAutoDownloads() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "auto"]
         #expect(shouldDeferDownloadForLowData(
             pkginfo, installerItemSize: 1,
             onLowDataConnection: true, maxSizeOverLowDataConnection: 0) == true)
+    }
+
+    /// download_on_low_data "always" can override a zero threshold
+    @Test func alwaysOverridesZeroThreshold() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "always"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 1,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 0) == false)
     }
 
     /// auto, item larger than the threshold, defers

--- a/code/cli/munki/munkiCLItesting/analyzeTests.swift
+++ b/code/cli/munki/munkiCLItesting/analyzeTests.swift
@@ -28,7 +28,7 @@ struct shouldDeferDownloadForLowDataTests {
             onLowDataConnection: false, maxSizeOverLowDataConnection: 1) == false)
     }
 
-    /// download_on_low_data "always" never defers on a low data connection
+    /// download_on_low_data "always" does not defer when the threshold is positive
     @Test func alwaysDoesNotDefer() async throws {
         let pkginfo: PlistDict = ["download_on_low_data": "always"]
         #expect(shouldDeferDownloadForLowData(
@@ -41,15 +41,31 @@ struct shouldDeferDownloadForLowDataTests {
         let pkginfo: PlistDict = ["download_on_low_data": "never"]
         #expect(shouldDeferDownloadForLowData(
             pkginfo, installerItemSize: 1,
-            onLowDataConnection: true, maxSizeOverLowDataConnection: 0) == true)
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 1) == true)
     }
 
-    /// auto with the size threshold disabled (0) downloads
+    /// a negative threshold disables low-data deferrals
     @Test func autoThresholdDisabledDownloads() async throws {
         let pkginfo: PlistDict = ["download_on_low_data": "auto"]
         #expect(shouldDeferDownloadForLowData(
             pkginfo, installerItemSize: 999_999,
-            onLowDataConnection: true, maxSizeOverLowDataConnection: 0) == false)
+            onLowDataConnection: true, maxSizeOverLowDataConnection: -1) == false)
+    }
+
+    /// a negative threshold disables even explicit low-data pkginfo rules
+    @Test func disabledThresholdIgnoresNever() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "never"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 999_999,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: -1) == false)
+    }
+
+    /// a zero threshold defers every uncached download
+    @Test func zeroThresholdDefersAllDownloads() async throws {
+        let pkginfo: PlistDict = ["download_on_low_data": "always"]
+        #expect(shouldDeferDownloadForLowData(
+            pkginfo, installerItemSize: 1,
+            onLowDataConnection: true, maxSizeOverLowDataConnection: 0) == true)
     }
 
     /// auto, item larger than the threshold, defers

--- a/code/cli/munki/shared/admin/makecatalogslib.swift
+++ b/code/cli/munki/shared/admin/makecatalogslib.swift
@@ -114,6 +114,12 @@ struct CatalogsMaker {
 
     /// Returns true if referenced installer items are present, false otherwise. Updates list of errors.
     mutating func verify(_ identifier: String, _ pkginfo: PlistDict) -> Bool {
+        if let downloadOnLowData = pkginfo["download_on_low_data"] as? String,
+           !["auto", "always", "never"].contains(downloadOnLowData)
+        {
+            warnings.append(
+                "WARNING: \(identifier) has an invalid download_on_low_data value: \(downloadOnLowData). Valid values are auto, always, never.")
+        }
         if let installer_type = pkginfo["installer_type"] as? String {
             if ["nopkg", "apple_update_metadata"].contains(installer_type) {
                 // no associated installer item (pkg) for these types

--- a/code/cli/munki/shared/admin/pkginfoOptions.swift
+++ b/code/cli/munki/shared/admin/pkginfoOptions.swift
@@ -56,6 +56,13 @@ enum SupportedArchitecture: String, CaseIterable, ExpressibleByArgument {
     case arm64
 }
 
+/// Supported values for the download_on_low_data pkginfo key
+enum DownloadOnLowData: String, CaseIterable, ExpressibleByArgument {
+    case auto
+    case always
+    case never
+}
+
 /// Pkginfo Override Options
 struct OverrideOptions: ParsableArguments {
     @Option(help: "Name to be used to refer to the installer item.")
@@ -308,6 +315,10 @@ struct AdditionalPkginfoOptions: ParsableArguments {
 
     @Option(help: ArgumentHelp("Specifies administrator provided notes to be embedded into the pkginfo. Can be a path to a file.", valueName: "text|path"))
     var notes: String? = nil
+
+    @Option(name: [.long, .customLong("download_on_low_data")],
+            help: "Specify whether this item should be downloaded on a low-data connection (cellular, personal hotspot, or an interface in Low Data Mode): 'always' (regardless of size), 'never', or 'auto' (follow the MaxSizeOverLowDataConnection size threshold). Defaults to 'auto' when omitted.")
+    var downloadOnLowData: DownloadOnLowData? = nil
 
     mutating func validate() throws {
         // validate options with version strings actually start with a digit

--- a/code/cli/munki/shared/admin/pkginfoOptions.swift
+++ b/code/cli/munki/shared/admin/pkginfoOptions.swift
@@ -317,7 +317,7 @@ struct AdditionalPkginfoOptions: ParsableArguments {
     var notes: String? = nil
 
     @Option(name: [.long, .customLong("download_on_low_data")],
-            help: "Specify whether this item should be downloaded on a low-data connection (cellular, personal hotspot, or an interface in Low Data Mode): 'always' (regardless of size), 'never', or 'auto' (follow the MaxSizeOverLowDataConnection size threshold). Defaults to 'auto' when omitted.")
+            help: "Specify whether this item should be downloaded on a low-data connection (cellular, personal hotspot, or an interface in Low Data Mode): 'always' (when MaxSizeOverLowDataConnection is positive), 'never', or 'auto' (follow the MaxSizeOverLowDataConnection size threshold). Defaults to 'auto' when omitted.")
     var downloadOnLowData: DownloadOnLowData? = nil
 
     mutating func validate() throws {

--- a/code/cli/munki/shared/admin/pkginfoOptions.swift
+++ b/code/cli/munki/shared/admin/pkginfoOptions.swift
@@ -317,7 +317,7 @@ struct AdditionalPkginfoOptions: ParsableArguments {
     var notes: String? = nil
 
     @Option(name: [.long, .customLong("download_on_low_data")],
-            help: "Specify whether this item should be downloaded on a low-data connection (cellular, personal hotspot, or an interface in Low Data Mode): 'always' (when MaxSizeOverLowDataConnection is positive), 'never', or 'auto' (follow the MaxSizeOverLowDataConnection size threshold). Defaults to 'auto' when omitted.")
+            help: "Specify whether this item should be downloaded on a low-data connection (cellular, personal hotspot, or an interface in Low Data Mode): 'always' (regardless of size), 'never', or 'auto' (follow the MaxSizeOverLowDataConnection size threshold). Defaults to 'auto' when omitted.")
     var downloadOnLowData: DownloadOnLowData? = nil
 
     mutating func validate() throws {

--- a/code/cli/munki/shared/admin/pkginfolib.swift
+++ b/code/cli/munki/shared/admin/pkginfolib.swift
@@ -549,6 +549,9 @@ func makepkginfo(_ filepath: String?,
     if let restartAction = options.override.restartAction {
         pkginfo["RestartAction"] = restartAction.rawValue
     }
+    if let downloadOnLowData = options.other.downloadOnLowData {
+        pkginfo["download_on_low_data"] = downloadOnLowData.rawValue
+    }
     if !options.other.updateFor.isEmpty {
         pkginfo["update_for"] = options.other.updateFor
     }

--- a/code/cli/munki/shared/network/networkconditions.swift
+++ b/code/cli/munki/shared/network/networkconditions.swift
@@ -1,0 +1,55 @@
+//
+//  networkconditions.swift
+//  munki
+//
+//  Created by Graham Gilbert on 7/20/26.
+//  Copyright 2024-2026 The Munki Project. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+import Network
+
+/// Returns true if the current default network path is a "low data" connection:
+/// either cellular/personal hotspot (`path.isExpensive`) or an interface the
+/// user has placed into Low Data Mode (`path.isConstrained`). Either signal is
+/// enough; these are the same signals the OS uses for its own Low Data Mode
+/// restrictions and require no admin configuration of SSIDs or interfaces.
+///
+/// NWPathMonitor is an asynchronous API, but managedsoftwareupdate samples the
+/// network state at a defined point in a run, so we bridge to a synchronous
+/// answer with a one-shot monitor and a semaphore. (Note this is *not* the same
+/// as the natively-synchronous IOKit power-source APIs in powermanager.swift --
+/// NWPathMonitor genuinely requires the async-to-sync bridge.) We bound the
+/// wait and fail *open* -- reporting "not a low data connection" -- if the path
+/// handler does not fire in time, so a stalled monitor can never hang a run or
+/// silently block downloads that would otherwise proceed.
+func isOnLowDataConnection() -> Bool {
+    let monitor = NWPathMonitor()
+    let queue = DispatchQueue(label: "com.googlecode.munki.networkconditions")
+    let semaphore = DispatchSemaphore(value: 0)
+    var isLowData = false
+    monitor.pathUpdateHandler = { path in
+        isLowData = path.isExpensive || path.isConstrained
+        semaphore.signal()
+    }
+    monitor.start(queue: queue)
+    // The handler normally fires almost immediately with the current path;
+    // the timeout only guards against a monitor that never reports.
+    let waitResult = semaphore.wait(timeout: .now() + 5.0)
+    monitor.cancel()
+    if waitResult == .timedOut {
+        return false
+    }
+    return isLowData
+}

--- a/code/cli/munki/shared/network/networkconditions.swift
+++ b/code/cli/munki/shared/network/networkconditions.swift
@@ -53,3 +53,18 @@ func isOnLowDataConnection() -> Bool {
     }
     return isLowData
 }
+
+private var cachedLowDataConnection: Bool? = nil
+
+/// Cached, once-per-run answer to isOnLowDataConnection(). managedsoftwareupdate
+/// runs as a one-shot process, so sampling a single time keeps every per-item
+/// download decision in a run consistent and avoids starting an NWPathMonitor
+/// for every item we evaluate.
+func onLowDataConnection() -> Bool {
+    if let cached = cachedLowDataConnection {
+        return cached
+    }
+    let sampled = isOnLowDataConnection()
+    cachedLowDataConnection = sampled
+    return sampled
+}

--- a/code/cli/munki/shared/prefs.swift
+++ b/code/cli/munki/shared/prefs.swift
@@ -26,6 +26,7 @@ let DEFAULT_INSECURE_REPO_URL = "http://munki/repo"
 let DEFAULT_PREFS: [String: Any] = [
     // "AdditionalHttpHeaders": None,
     "AggressiveUpdateNotificationDays": 14,
+    "AllowLowDataOverride": true,
     "AppleSoftwareUpdatesIncludeMajorOSUpdates": false,
     "AppleSoftwareUpdatesOnly": false,
     // "CatalogURL": None,
@@ -49,6 +50,7 @@ let DEFAULT_PREFS: [String: Any] = [
     "LoggingLevel": 1,
     "LogToSyslog": false,
     "ManagedInstallDir": DEFAULT_MANAGED_INSTALLS_DIR,
+    "MaxSizeOverLowDataConnection": 0,
     "MSCAllowNotificationWindow": false,
     "MSCAllowedNotificationWindowStart": 0,
     "MSCAllowedNotificationWindowEnd": 24,
@@ -80,6 +82,7 @@ let DEFAULT_PREFS: [String: Any] = [
 let CONFIG_KEY_NAMES = [
     "AdditionalHttpHeaders",
     "AggressiveUpdateNotificationDays",
+    "AllowLowDataOverride",
     "AppleSoftwareUpdatesIncludeMajorOSUpdates",
     "AppleSoftwareUpdatesOnly",
     "CatalogURL",
@@ -105,6 +108,7 @@ let CONFIG_KEY_NAMES = [
     "LogToSyslog",
     "ManagedInstallDir",
     "ManifestURL",
+    "MaxSizeOverLowDataConnection",
     "MSCAllowNotificationWindow",
     "MSCAllowedNotificationWindowStart",
     "MSCAllowedNotificationWindowEnd",

--- a/code/cli/munki/shared/prefs.swift
+++ b/code/cli/munki/shared/prefs.swift
@@ -50,7 +50,7 @@ let DEFAULT_PREFS: [String: Any] = [
     "LoggingLevel": 1,
     "LogToSyslog": false,
     "ManagedInstallDir": DEFAULT_MANAGED_INSTALLS_DIR,
-    "MaxSizeOverLowDataConnection": 0,
+    "MaxSizeOverLowDataConnection": -1,
     "MSCAllowNotificationWindow": false,
     "MSCAllowedNotificationWindowStart": 0,
     "MSCAllowedNotificationWindowEnd": 24,

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -325,12 +325,17 @@ func processInstall(
                 onLowDataConnection: onLowDataConnection(),
                 maxSizeOverLowDataConnection: pref("MaxSizeOverLowDataConnection") as? Int ?? 0
             ) {
-                display.detail("Deferring download of \(manifestItemName) because this Mac is on a low data connection.")
-                processedItem["installed"] = false
-                processedItem["low_data_deferred"] = true
-                processedItem["note"] = "Download of \(displayName) was paused because this Mac is on a low data connection."
-                appendToProcessedManagedInstalls(processedItem)
-                return false
+                let allowOverride = pref("AllowLowDataOverride") as? Bool ?? true
+                if allowOverride, lowDataOverrideItems().contains(name) {
+                    display.detail("Downloading \(manifestItemName) anyway on a low data connection due to a user override.")
+                } else {
+                    display.detail("Deferring download of \(manifestItemName) because this Mac is on a low data connection.")
+                    processedItem["installed"] = false
+                    processedItem["low_data_deferred"] = true
+                    processedItem["note"] = "Download of \(displayName) was paused because this Mac is on a low data connection."
+                    appendToProcessedManagedInstalls(processedItem)
+                    return false
+                }
             }
             do {
                 // record starttime

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -124,6 +124,16 @@ func alreadyProcessed(_ itemName: String, installInfo: PlistDict, sections: [Str
     return false
 }
 
+/// True if the item's force_install_after_date has been reached (in local time,
+/// matching the forced-install logic in installinfo.swift). Such an item is due
+/// to be force-installed, so it must download regardless of connection.
+func forceInstallDeadlinePassed(_ pkginfo: PlistDict) -> Bool {
+    guard let forceDate = pkginfo["force_install_after_date"] as? Date else {
+        return false
+    }
+    return Date() >= subtractTZOffsetFromDate(forceDate)
+}
+
 /// Returns true if downloading this item should be deferred because we are on
 /// a low data connection (see isOnLowDataConnection()). The connection state
 /// and the MaxSizeOverLowDataConnection threshold are passed in so this stays a
@@ -143,9 +153,7 @@ func shouldDeferDownloadForLowData(
     if !onLowDataConnection {
         return false
     }
-    if let forceDate = pkginfo["force_install_after_date"] as? Date,
-       Date() >= subtractTZOffsetFromDate(forceDate)
-    {
+    if forceInstallDeadlinePassed(pkginfo) {
         // deadline reached; item will be force-installed, so it must download
         return false
     }
@@ -175,7 +183,8 @@ func processInstall(
     catalogList: [String],
     installInfo: inout PlistDict,
     isManagedUpdate: Bool = false,
-    isOptionalInstall: Bool = false
+    isOptionalInstall: Bool = false,
+    lowDataExempt: Bool = false
 ) async -> Bool {
     /// helper function
     func appendToProcessedManagedInstalls(_ item: PlistDict) {
@@ -269,6 +278,9 @@ func processInstall(
     } else if let requires = pkginfo["requires"] as? String {
         dependencies = [requires]
     }
+    // A forced item past its deadline (or a dependency of one) must download
+    // even on low data, so propagate that exemption to its required items.
+    let lowDataExemptForDependencies = lowDataExempt || forceInstallDeadlinePassed(pkginfo)
     for item in dependencies {
         display.detail("\(name)-\(version) requires \(item). Getting info on \(item)...")
         let success = await processInstall(
@@ -276,7 +288,8 @@ func processInstall(
             catalogList: catalogList,
             installInfo: &installInfo,
             isManagedUpdate: isManagedUpdate,
-            isOptionalInstall: isOptionalInstall
+            isOptionalInstall: isOptionalInstall,
+            lowDataExempt: lowDataExemptForDependencies
         )
         if !success {
             dependenciesMet = false
@@ -319,12 +332,20 @@ func processInstall(
             // "install" that has no actual download
             filename = "packageless_install"
         } else {
-            if shouldDeferDownloadForLowData(
-                pkginfo,
-                installerItemSize: installerItemSize,
-                onLowDataConnection: onLowDataConnection(),
-                maxSizeOverLowDataConnection: pref("MaxSizeOverLowDataConnection") as? Int ?? 0
-            ) {
+            // Skip deferral if the item is exempt (forced/dependency of forced)
+            // or already fully cached (installing it transfers no data).
+            let installerLocation = pkginfo["installer_item_location"] as? String ?? ""
+            // ponytail: presence check, not a hash check; a partial cache would
+            // still resume on low data. Full-cache is the case that matters here.
+            let alreadyCached = !installerLocation.isEmpty && pathExists(getDownloadCachePath(installerLocation))
+            if !lowDataExempt, !alreadyCached,
+               shouldDeferDownloadForLowData(
+                   pkginfo,
+                   installerItemSize: installerItemSize,
+                   onLowDataConnection: onLowDataConnection(),
+                   maxSizeOverLowDataConnection: pref("MaxSizeOverLowDataConnection") as? Int ?? 0
+               )
+            {
                 let allowOverride = pref("AllowLowDataOverride") as? Bool ?? true
                 if allowOverride, lowDataOverrideItems().contains(name) {
                     display.detail("Downloading \(manifestItemName) anyway on a low data connection due to a user override.")
@@ -336,6 +357,12 @@ func processInstall(
                     appendToProcessedManagedInstalls(processedItem)
                     return false
                 }
+            }
+            // We're downloading this item, so a one-time low-data override (if
+            // any) has served its purpose; consume it now so it can't later
+            // authorize a newer version over low data.
+            if lowDataOverrideItems().contains(name) {
+                removeLowDataOverrides(names: [name])
             }
             do {
                 // record starttime

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -124,6 +124,45 @@ func alreadyProcessed(_ itemName: String, installInfo: PlistDict, sections: [Str
     return false
 }
 
+/// Returns true if downloading this item should be deferred because we are on
+/// a low data connection (see isOnLowDataConnection()). The connection state
+/// and the MaxSizeOverLowDataConnection threshold are passed in so this stays a
+/// pure function that is easy to test.
+///
+/// A reached force_install_after_date always wins: an item that is due to be
+/// force-installed must download regardless of connection. The per-item
+/// download_on_low_data key ("always"/"never") overrides the size threshold;
+/// "auto" (or an absent/unrecognized value) follows the threshold, which is
+/// itself disabled when MaxSizeOverLowDataConnection is 0.
+func shouldDeferDownloadForLowData(
+    _ pkginfo: PlistDict,
+    installerItemSize: Int,
+    onLowDataConnection: Bool,
+    maxSizeOverLowDataConnection: Int
+) -> Bool {
+    if !onLowDataConnection {
+        return false
+    }
+    if let forceDate = pkginfo["force_install_after_date"] as? Date,
+       Date() >= subtractTZOffsetFromDate(forceDate)
+    {
+        // deadline reached; item will be force-installed, so it must download
+        return false
+    }
+    switch pkginfo["download_on_low_data"] as? String {
+    case "always":
+        return false
+    case "never":
+        return true
+    default:
+        // "auto", absent, or an unrecognized value: follow the size threshold
+        if maxSizeOverLowDataConnection <= 0 {
+            return false
+        }
+        return installerItemSize > maxSizeOverLowDataConnection
+    }
+}
+
 /// Processes a manifest item for install. Determines if it needs to be
 /// installed, and if so, if any items it is dependent on need to
 /// be installed first.  Installation detail is added to
@@ -280,6 +319,19 @@ func processInstall(
             // "install" that has no actual download
             filename = "packageless_install"
         } else {
+            if shouldDeferDownloadForLowData(
+                pkginfo,
+                installerItemSize: installerItemSize,
+                onLowDataConnection: onLowDataConnection(),
+                maxSizeOverLowDataConnection: pref("MaxSizeOverLowDataConnection") as? Int ?? 0
+            ) {
+                display.detail("Deferring download of \(manifestItemName) because this Mac is on a low data connection.")
+                processedItem["installed"] = false
+                processedItem["low_data_deferred"] = true
+                processedItem["note"] = "Download of \(displayName) was paused because this Mac is on a low data connection."
+                appendToProcessedManagedInstalls(processedItem)
+                return false
+            }
             do {
                 // record starttime
                 let startTime = Date()

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -140,10 +140,11 @@ func forceInstallDeadlinePassed(_ pkginfo: PlistDict) -> Bool {
 /// pure function that is easy to test.
 ///
 /// A reached force_install_after_date always wins: an item that is due to be
-/// force-installed must download regardless of connection. The per-item
-/// download_on_low_data key ("always"/"never") overrides the size threshold;
-/// "auto" (or an absent/unrecognized value) follows the threshold, which is
-/// itself disabled when MaxSizeOverLowDataConnection is 0.
+/// force-installed must download regardless of connection. A negative
+/// MaxSizeOverLowDataConnection disables low-data deferrals. 0 defers every
+/// uncached download. For positive thresholds, the per-item download_on_low_data
+/// key ("always"/"never") overrides the size threshold; "auto" (or an
+/// absent/unrecognized value) follows the threshold.
 func shouldDeferDownloadForLowData(
     _ pkginfo: PlistDict,
     installerItemSize: Int,
@@ -157,6 +158,12 @@ func shouldDeferDownloadForLowData(
         // deadline reached; item will be force-installed, so it must download
         return false
     }
+    if maxSizeOverLowDataConnection < 0 {
+        return false
+    }
+    if maxSizeOverLowDataConnection == 0 {
+        return true
+    }
     switch pkginfo["download_on_low_data"] as? String {
     case "always":
         return false
@@ -164,9 +171,6 @@ func shouldDeferDownloadForLowData(
         return true
     default:
         // "auto", absent, or an unrecognized value: follow the size threshold
-        if maxSizeOverLowDataConnection <= 0 {
-            return false
-        }
         return installerItemSize > maxSizeOverLowDataConnection
     }
 }
@@ -338,16 +342,17 @@ func processInstall(
             // ponytail: presence check, not a hash check; a partial cache would
             // still resume on low data. Full-cache is the case that matters here.
             let alreadyCached = !installerLocation.isEmpty && pathExists(getDownloadCachePath(installerLocation))
+            let maxSizeOverLowDataConnection = pref("MaxSizeOverLowDataConnection") as? Int ?? -1
             if !lowDataExempt, !alreadyCached,
                shouldDeferDownloadForLowData(
                    pkginfo,
                    installerItemSize: installerItemSize,
                    onLowDataConnection: onLowDataConnection(),
-                   maxSizeOverLowDataConnection: pref("MaxSizeOverLowDataConnection") as? Int ?? 0
+                   maxSizeOverLowDataConnection: maxSizeOverLowDataConnection
                )
             {
                 let allowOverride = pref("AllowLowDataOverride") as? Bool ?? true
-                if allowOverride, lowDataOverrideItems().contains(name) {
+                if maxSizeOverLowDataConnection > 0, allowOverride, lowDataOverrideItems().contains(name) {
                     display.detail("Downloading \(manifestItemName) anyway on a low data connection due to a user override.")
                 } else {
                     display.detail("Deferring download of \(manifestItemName) because this Mac is on a low data connection.")

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -141,10 +141,11 @@ func forceInstallDeadlinePassed(_ pkginfo: PlistDict) -> Bool {
 ///
 /// A reached force_install_after_date always wins: an item that is due to be
 /// force-installed must download regardless of connection. A negative
-/// MaxSizeOverLowDataConnection disables low-data deferrals. 0 defers every
-/// uncached download. For positive thresholds, the per-item download_on_low_data
-/// key ("always"/"never") overrides the size threshold; "auto" (or an
-/// absent/unrecognized value) follows the threshold.
+/// MaxSizeOverLowDataConnection disables low-data deferrals. Otherwise, the
+/// per-item download_on_low_data key ("always"/"never") overrides the size
+/// threshold; "auto" (or an absent/unrecognized value) follows the threshold.
+/// With a threshold of 0, auto/default items defer while explicit "always"
+/// items still download.
 func shouldDeferDownloadForLowData(
     _ pkginfo: PlistDict,
     installerItemSize: Int,
@@ -160,9 +161,6 @@ func shouldDeferDownloadForLowData(
     }
     if maxSizeOverLowDataConnection < 0 {
         return false
-    }
-    if maxSizeOverLowDataConnection == 0 {
-        return true
     }
     switch pkginfo["download_on_low_data"] as? String {
     case "always":
@@ -352,7 +350,7 @@ func processInstall(
                )
             {
                 let allowOverride = pref("AllowLowDataOverride") as? Bool ?? true
-                if maxSizeOverLowDataConnection > 0, allowOverride, lowDataOverrideItems().contains(name) {
+                if allowOverride, lowDataOverrideItems().contains(name) {
                     display.detail("Downloading \(manifestItemName) anyway on a low data connection due to a user override.")
                 } else {
                     display.detail("Deferring download of \(manifestItemName) because this Mac is on a low data connection.")

--- a/code/cli/munki/shared/updatecheck/download.swift
+++ b/code/cli/munki/shared/updatecheck/download.swift
@@ -380,6 +380,12 @@ func precache() {
         // nothing to do
         return
     }
+    if onLowDataConnection() {
+        // don't pull speculative background downloads over a metered/low-data
+        // connection
+        display.info("Skipping precaching: on a low data connection.")
+        return
+    }
     display.info("###   Beginning precaching session   ###")
     for item in itemsToPrecache(installInfo) {
         do {

--- a/code/cli/munki/shared/updatecheck/selfservice.swift
+++ b/code/cli/munki/shared/updatecheck/selfservice.swift
@@ -60,6 +60,66 @@ func updateSelfServeManifest() {
     }
 }
 
+/// Returns the path to the root-owned low-data overrides plist. This records the
+/// items the user has chosen to "Download anyway" while on a low-data
+/// connection. Format: a dict with an "items" key holding an array of item
+/// names, e.g. { "items": ["GoogleChrome"] }.
+func lowDataOverridesPath() -> String {
+    return managedInstallsDir(subpath: "LowDataOverrides.plist")
+}
+
+/// Updates the low-data overrides from a user-writable copy if it exists.
+/// Managed Software Center (running as the user) writes the user's "Download
+/// anyway" choices to /Users/Shared/.low_data_overrides.plist; this copies that
+/// staging file into the root-owned location and removes it. Modelled on
+/// updateSelfServeManifest(), including the symlink guard.
+func updateLowDataOverrides() {
+    let userOverrides = "/Users/Shared/.low_data_overrides.plist"
+    let systemOverrides = lowDataOverridesPath()
+    if pathIsSymlink(userOverrides) {
+        // not allowed as it could link to things not normally
+        // readable by unprivileged users
+        try? FileManager.default.removeItem(atPath: userOverrides)
+        display.warning("Found symlink at \(userOverrides). Ignoring and removing.")
+    }
+    if !pathExists(userOverrides) {
+        // nothing to do!
+        return
+    }
+    // read the user-generated file to ensure it's valid, then write it
+    // to the system location
+    do {
+        if let plist = try readPlist(fromFile: userOverrides) {
+            try writePlist(plist, toFile: systemOverrides)
+            try? FileManager.default.removeItem(atPath: userOverrides)
+        } else {
+            display.error("Could not read \(userOverrides): data was nil")
+            try? FileManager.default.removeItem(atPath: userOverrides)
+        }
+    } catch let PlistError.readError(description) {
+        display.error("Could not read \(userOverrides): \(description)")
+        try? FileManager.default.removeItem(atPath: userOverrides)
+    } catch let PlistError.writeError(description) {
+        display.error("Could not write \(systemOverrides): \(description)")
+    } catch {
+        display.error("Unexpected error reading or writing low-data overrides: \(error.localizedDescription)")
+    }
+}
+
+/// Returns the list of item names the user has chosen to download anyway on a
+/// low-data connection.
+func lowDataOverrideItems() -> [String] {
+    let systemOverrides = lowDataOverridesPath()
+    guard pathExists(systemOverrides),
+          let raw = try? readPlist(fromFile: systemOverrides),
+          let plist = raw as? PlistDict,
+          let items = plist["items"] as? [String]
+    else {
+        return []
+    }
+    return items
+}
+
 /// Process a default installs item. Potentially add it to managed_installs
 /// in the SelfServeManifest
 func processDefaultInstalls(_ defaultItems: [String]) {

--- a/code/cli/munki/shared/updatecheck/selfservice.swift
+++ b/code/cli/munki/shared/updatecheck/selfservice.swift
@@ -110,11 +110,10 @@ func lowDataOverrideItems() -> [String] {
     return items
 }
 
-/// Removes now-installed items from the low-data overrides so a stale override
-/// can't suppress deferral of a future update to the same item. The override is
-/// meant to be a one-time "download this anyway"; once the item is installed
-/// it has served its purpose.
-func pruneLowDataOverrides(installedItemNames: [String]) {
+/// Removes the given item names from the low-data overrides. Used to consume a
+/// one-time "download anyway" override when the item is being downloaded, so a
+/// stale override can't later authorize a newer version over low data.
+func removeLowDataOverrides(names: [String]) {
     let systemOverrides = lowDataOverridesPath()
     guard pathExists(systemOverrides),
           let raw = try? readPlist(fromFile: systemOverrides),
@@ -123,7 +122,7 @@ func pruneLowDataOverrides(installedItemNames: [String]) {
     else {
         return
     }
-    let remaining = items.filter { !installedItemNames.contains($0) }
+    let remaining = items.filter { !names.contains($0) }
     if remaining.count == items.count {
         // nothing to prune
         return

--- a/code/cli/munki/shared/updatecheck/selfservice.swift
+++ b/code/cli/munki/shared/updatecheck/selfservice.swift
@@ -26,38 +26,48 @@ func selfServiceManifestPath() -> String {
     return managedInstallsDir(subpath: "manifests/SelfServeManifest")
 }
 
-/// Updates the SelfServeManifest from a user-writable copy if it exists.
-func updateSelfServeManifest() {
-    let userManifest = "/Users/Shared/.SelfServeManifest"
-    let systemManifest = selfServiceManifestPath()
-    if pathIsSymlink(userManifest) {
+/// Promotes a user-writable plist from /Users/Shared into a root-owned location:
+/// validates it by reading, writes it to the system path, then removes the
+/// staging file. Includes a symlink guard, since the staging file is
+/// user-writable and a symlink there could point at things unprivileged users
+/// should not be able to read.
+func promoteUserWritablePlist(from userPath: String, to systemPath: String, label: String) {
+    if pathIsSymlink(userPath) {
         // not allowed as it could link to things not normally
         // readable by unprivileged users
-        try? FileManager.default.removeItem(atPath: userManifest)
-        display.warning("Found symlink at \(userManifest). Ignoring and removing.")
+        try? FileManager.default.removeItem(atPath: userPath)
+        display.warning("Found symlink at \(userPath). Ignoring and removing.")
     }
-    if !pathExists(userManifest) {
+    if !pathExists(userPath) {
         // nothing to do!
         return
     }
-    // read the user-generated manifest to ensure it's valid, then write it
-    // to the system manifest location
+    // read the user-generated file to ensure it's valid, then write it
+    // to the system location
     do {
-        if let plist = try readPlist(fromFile: userManifest) {
-            try writePlist(plist, toFile: systemManifest)
-            try? FileManager.default.removeItem(atPath: userManifest)
+        if let plist = try readPlist(fromFile: userPath) {
+            try writePlist(plist, toFile: systemPath)
+            try? FileManager.default.removeItem(atPath: userPath)
         } else {
-            display.error("Could not read \(userManifest): data was nil")
-            try? FileManager.default.removeItem(atPath: userManifest)
+            display.error("Could not read \(userPath): data was nil")
+            try? FileManager.default.removeItem(atPath: userPath)
         }
     } catch let PlistError.readError(description) {
-        display.error("Could not read \(userManifest): \(description)")
-        try? FileManager.default.removeItem(atPath: userManifest)
+        display.error("Could not read \(userPath): \(description)")
+        try? FileManager.default.removeItem(atPath: userPath)
     } catch let PlistError.writeError(description) {
-        display.error("Could not write \(systemManifest): \(description)")
+        display.error("Could not write \(systemPath): \(description)")
     } catch {
-        display.error("Unexpected error reading or writing SelfServeManifest: \(error.localizedDescription)")
+        display.error("Unexpected error reading or writing \(label): \(error.localizedDescription)")
     }
+}
+
+/// Updates the SelfServeManifest from a user-writable copy if it exists.
+func updateSelfServeManifest() {
+    promoteUserWritablePlist(
+        from: "/Users/Shared/.SelfServeManifest",
+        to: selfServiceManifestPath(),
+        label: "SelfServeManifest")
 }
 
 /// Returns the path to the root-owned low-data overrides plist. This records the
@@ -70,53 +80,33 @@ func lowDataOverridesPath() -> String {
 
 /// Updates the low-data overrides from a user-writable copy if it exists.
 /// Managed Software Center (running as the user) writes the user's "Download
-/// anyway" choices to /Users/Shared/.low_data_overrides.plist; this copies that
-/// staging file into the root-owned location and removes it. Modelled on
-/// updateSelfServeManifest(), including the symlink guard.
+/// anyway" choices to /Users/Shared/.low_data_overrides.plist; this promotes
+/// that staging file into the root-owned location and removes it.
 func updateLowDataOverrides() {
-    let userOverrides = "/Users/Shared/.low_data_overrides.plist"
-    let systemOverrides = lowDataOverridesPath()
-    if pathIsSymlink(userOverrides) {
-        // not allowed as it could link to things not normally
-        // readable by unprivileged users
-        try? FileManager.default.removeItem(atPath: userOverrides)
-        display.warning("Found symlink at \(userOverrides). Ignoring and removing.")
-    }
-    if !pathExists(userOverrides) {
-        // nothing to do!
-        return
-    }
-    // read the user-generated file to ensure it's valid, then write it
-    // to the system location
-    do {
-        if let plist = try readPlist(fromFile: userOverrides) {
-            try writePlist(plist, toFile: systemOverrides)
-            try? FileManager.default.removeItem(atPath: userOverrides)
-        } else {
-            display.error("Could not read \(userOverrides): data was nil")
-            try? FileManager.default.removeItem(atPath: userOverrides)
-        }
-    } catch let PlistError.readError(description) {
-        display.error("Could not read \(userOverrides): \(description)")
-        try? FileManager.default.removeItem(atPath: userOverrides)
-    } catch let PlistError.writeError(description) {
-        display.error("Could not write \(systemOverrides): \(description)")
-    } catch {
-        display.error("Unexpected error reading or writing low-data overrides: \(error.localizedDescription)")
-    }
+    promoteUserWritablePlist(
+        from: "/Users/Shared/.low_data_overrides.plist",
+        to: lowDataOverridesPath(),
+        label: "low-data overrides")
 }
 
+private var cachedLowDataOverrideItems: [String]?
+
 /// Returns the list of item names the user has chosen to download anyway on a
-/// low-data connection.
+/// low-data connection. Cached once per run: the overrides file is staged at the
+/// start of the check and does not change while items are processed, so we don't
+/// re-read it for every deferred item.
 func lowDataOverrideItems() -> [String] {
-    let systemOverrides = lowDataOverridesPath()
-    guard pathExists(systemOverrides),
-          let raw = try? readPlist(fromFile: systemOverrides),
-          let plist = raw as? PlistDict,
-          let items = plist["items"] as? [String]
-    else {
-        return []
+    if let cached = cachedLowDataOverrideItems {
+        return cached
     }
+    var items = [String]()
+    if let raw = try? readPlist(fromFile: lowDataOverridesPath()),
+       let plist = raw as? PlistDict,
+       let list = plist["items"] as? [String]
+    {
+        items = list
+    }
+    cachedLowDataOverrideItems = items
     return items
 }
 

--- a/code/cli/munki/shared/updatecheck/selfservice.swift
+++ b/code/cli/munki/shared/updatecheck/selfservice.swift
@@ -120,6 +120,36 @@ func lowDataOverrideItems() -> [String] {
     return items
 }
 
+/// Removes now-installed items from the low-data overrides so a stale override
+/// can't suppress deferral of a future update to the same item. The override is
+/// meant to be a one-time "download this anyway"; once the item is installed
+/// it has served its purpose.
+func pruneLowDataOverrides(installedItemNames: [String]) {
+    let systemOverrides = lowDataOverridesPath()
+    guard pathExists(systemOverrides),
+          let raw = try? readPlist(fromFile: systemOverrides),
+          var plist = raw as? PlistDict,
+          let items = plist["items"] as? [String]
+    else {
+        return
+    }
+    let remaining = items.filter { !installedItemNames.contains($0) }
+    if remaining.count == items.count {
+        // nothing to prune
+        return
+    }
+    if remaining.isEmpty {
+        try? FileManager.default.removeItem(atPath: systemOverrides)
+        return
+    }
+    plist["items"] = remaining
+    do {
+        try writePlist(plist, toFile: systemOverrides)
+    } catch {
+        display.error("Could not write \(systemOverrides): \(error.localizedDescription)")
+    }
+}
+
 /// Process a default installs item. Potentially add it to managed_installs
 /// in the SelfServeManifest
 func processDefaultInstalls(_ defaultItems: [String]) {

--- a/code/cli/munki/shared/updatecheck/updatecheck.swift
+++ b/code/cli/munki/shared/updatecheck/updatecheck.swift
@@ -309,6 +309,10 @@ func checkForUpdates(clientID: String? = nil, localManifestPath: String? = nil) 
     // recreate if still valid
     removeStagedOSInstallerInfo()
 
+    // copy any user-approved low-data download overrides into place before we
+    // process installs, so deferral decisions honour them for every item
+    updateLowDataOverrides()
+
     do {
         // check managed_installs
         display.detail("**Checking for installs**")

--- a/code/cli/munki/shared/updatecheck/updatecheck.swift
+++ b/code/cli/munki/shared/updatecheck/updatecheck.swift
@@ -447,6 +447,9 @@ func checkForUpdates(clientID: String? = nil, localManifestPath: String? = nil) 
         // clean up any old managed_uninstalls in the SelfServeManifest
         cleanUpSelfServeManagedUninstalls(removals)
 
+        // remove low-data download overrides for items that are now installed
+        pruneLowDataOverrides(installedItemNames: installedItems)
+
         // sort startosinstall items to the end of managed_installs
         let nonStartOSInstallItems = managedInstalls.filter {
             ($0["install_type"] as? String ?? "") != "startosinstall"

--- a/code/cli/munki/shared/updatecheck/updatecheck.swift
+++ b/code/cli/munki/shared/updatecheck/updatecheck.swift
@@ -447,9 +447,6 @@ func checkForUpdates(clientID: String? = nil, localManifestPath: String? = nil) 
         // clean up any old managed_uninstalls in the SelfServeManifest
         cleanUpSelfServeManagedUninstalls(removals)
 
-        // remove low-data download overrides for items that are now installed
-        pruneLowDataOverrides(installedItemNames: installedItems)
-
         // sort startosinstall items to the end of managed_installs
         let nonStartOSInstallItems = managedInstalls.filter {
             ($0["install_type"] as? String ?? "") != "startosinstall"


### PR DESCRIPTION
## Overview

Munki currently downloads all managed items regardless of the network connection. This adds an opt-in ability to **defer downloads on low-data connections** — cellular, personal hotspot, or a Wi-Fi network in Low Data Mode — with an optional user override in Managed Software Center and per-item control in pkginfo.

Detection uses Apple's Network framework (`NWPathMonitor`): a connection is "low data" when `path.isExpensive` (cellular/hotspot) or `path.isConstrained` (Low Data Mode) is true — the same signals macOS uses for its own Low Data Mode restrictions, so no SSID/interface configuration is required.

## Admin preferences

Set in `/Library/Preferences/ManagedInstalls.plist` or via a configuration profile.

| Key | Type | Default | Description |
| :- | :- | :- | :- |
| `MaxSizeOverLowDataConnection` | Integer (KB) | `-1` | Size threshold for low-data deferral. `-1` disables this feature. `0` defers auto/default downloads on low-data connections. Positive values defer items whose `installer_item_size` exceeds the threshold. Same KB unit as `installer_item_size`. |
| `AllowLowDataOverride` | Boolean | `true` | Whether users may override a deferral in Managed Software Center. `false` makes it a hard block (no "Download anyway" button). |

## pkginfo key

`download_on_low_data` (string): `auto` (default when absent — follow the size threshold), `always` (download regardless), `never` (never on low data). Written by `makepkginfo --download_on_low_data <value>`; `makecatalogs` warns on invalid values.

## Decision logic (per item, before download)

```
On a low data connection?
  NO  -> download normally (no change)
  YES ->
    forced item past its force_install_after_date (or a required dependency of one)? -> download
    installer already fully cached (no data needed)? -> download
    user "Download anyway" override (and AllowLowDataOverride)? -> download (override consumed)
    MaxSizeOverLowDataConnection < 0? -> download (feature disabled)
    download_on_low_data == always? -> download
    download_on_low_data == never?  -> defer
    otherwise (auto): installer_item_size > MaxSizeOverLowDataConnection? -> defer, else download
```

With `MaxSizeOverLowDataConnection` set to `0`, auto/default items with a real download are deferred on low-data connections, but explicit exceptions still work: `download_on_low_data: always`, user overrides when allowed, fully cached installers, and items past `force_install_after_date` still download.

A deferred item is recorded with `low_data_deferred = true` and is surfaced like any other item that can't be downloaded right now (e.g. insufficient disk space): it shows in Managed Software Center but is not counted as a pending update. Precaching is skipped entirely on a low-data connection.

## Managed Software Center

Deferred items appear under "Problem updates" as **Download paused — low data connection**. When overrides are allowed, a **Download anyway** button (list + detail page) records the choice and triggers a check so the item downloads on that run; the override is consumed once the item downloads.

## Testing

Validated end-to-end against a staging repo on a Munki 7 client with Wi-Fi Low Data Mode enabled:
- `download_on_low_data: never` → item deferred; not downloaded; not counted as an update.
- MSC shows the paused row + **Download anyway**; confirming writes the override and the item downloads on the next check.
- `MaxSizeOverLowDataConnection`: `-1` disables deferral; `0` defers auto/default downloads; positive thresholds defer items over the threshold and allow under-threshold items to download.
- `download_on_low_data: always`, user overrides, already-cached installers, and a reached `force_install_after_date` still download.

Unit tests cover the `shouldDeferDownloadForLowData` decision matrix (`munkiCLItesting`). The branch also went through a `/simplify` code-quality pass and a `codex` functional review, whose findings are fixed here.

## Notes / limitations

- The size threshold is **per item**, not cumulative — it prevents any single large download but doesn't cap total data over a period. Set it to `0` to defer auto/default downloads on low-data connections, or use `download_on_low_data: never` on specific items that should never download on low data.
- Detection relies entirely on what macOS reports; Munki does not try to detect "slow" links or signal strength.


## Documentation (wiki edits, post-merge)

Munki's wiki isn't part of this repo, so no wiki changes are committed here. Below is the exact content to add to each wiki page once this merges.

### Add to [Supported Pkginfo Keys](https://github.com/munki/munki/wiki/Supported-Pkginfo-Keys)

**`download_on_low_data`** *(string)* — Controls whether this item is downloaded when the Mac is on a low-data connection (cellular, personal hotspot, or a Wi-Fi network in Low Data Mode). One of:
- `auto` — default when the key is absent; follow the `MaxSizeOverLowDataConnection` size threshold.
- `always` — always download, regardless of the connection or size threshold.
- `never` — never download on a low-data connection.

Set with `makepkginfo --download_on_low_data <value>`. `makecatalogs` warns on unrecognized values.

### Add to [Preferences](https://github.com/munki/munki/wiki/Preferences)

**`MaxSizeOverLowDataConnection`** *(integer, KB, default `-1`)* — Size threshold for the `auto` low-data behavior. `-1` disables low-data deferral. `0` defers auto/default downloads on low-data connections. Positive values defer items whose `installer_item_size` exceeds the threshold. Same KB unit as `installer_item_size`.

**`AllowLowDataOverride`** *(boolean, default `true`)* — Whether users may override a low-data deferral in Managed Software Center via the "Download anyway" button. `false` makes the deferral a hard block (no button shown).
