### PR TITLE
Add --rebuild-catalogs flag to munkiimport

### DIFF
--- a/code/cli/munki/munkiimport/munkiimport.swift
+++ b/code/cli/munki/munkiimport/munkiimport.swift
@@ -426,20 +426,28 @@ struct MunkiImport: AsyncParsableCommand {
             print("Saved pkginfo to \(pkginfoPath).")
         }
         // Maybe rebuild the catalogs?
-        if !munkiImportOptions.nointeractive {
+        if munkiImportOptions.rebuildCatalogs {
+            print("Rebuilding catalogs...")
+            try await performCatalogRebuild(repo: repo)
+        } else if !munkiImportOptions.nointeractive {
             print("Rebuild catalogs? [y/N] ", terminator: "")
             if let answer = readLine(),
                answer.lowercased().hasPrefix("y")
             {
-                let makecatalogOptions = MakeCatalogOptions()
-                var catalogsmaker = try await CatalogsMaker(repo: repo, options: makecatalogOptions)
-                await catalogsmaker.makecatalogs()
-                if !catalogsmaker.errors.isEmpty {
-                    for error in catalogsmaker.errors {
-                        printStderr(error)
-                    }
-                }
+                try await performCatalogRebuild(repo: repo)
             }
+        }
+    }
+}
+
+/// Helper function to rebuild catalogs
+private func performCatalogRebuild(repo: Repo) async throws {
+    let makecatalogOptions = MakeCatalogOptions()
+    var catalogsmaker = try await CatalogsMaker(repo: repo, options: makecatalogOptions)
+    await catalogsmaker.makecatalogs()
+    if !catalogsmaker.errors.isEmpty {
+        for error in catalogsmaker.errors {
+            printStderr(error)
         }
     }
 }

--- a/code/cli/munki/munkiimport/munkiimport.swift
+++ b/code/cli/munki/munkiimport/munkiimport.swift
@@ -424,23 +424,25 @@ struct MunkiImport: AsyncParsableCommand {
         do {
             pkginfoPath = try await copyPkgInfoToRepo(repo, pkginfo: pkginfo, subdirectory: subdir)
             print("Saved pkginfo to \(pkginfoPath).")
-        }
-        // Maybe rebuild the catalogs?
-        if munkiImportOptions.rebuildCatalogs {
-            print("Rebuilding catalogs...")
-            try await performCatalogRebuild(repo: repo)
-        } else if !munkiImportOptions.nointeractive {
-            print("Rebuild catalogs? [y/N] ", terminator: "")
-            if let answer = readLine(),
-               answer.lowercased().hasPrefix("y")
-            {
+            
+            // rebuild catalogs if --rebuild-catalogs was specified
+            if munkiImportOptions.rebuildCatalogs {
+                print("Rebuilding catalogs...")
                 try await performCatalogRebuild(repo: repo)
+            } else if !munkiImportOptions.nointeractive {
+                // rebuild catalogs if interative mode and users responds y/yes
+                print("Rebuild catalogs? [y/N] ", terminator: "")
+                if let answer = readLine(),
+                    answer.lowercased().hasPrefix("y")
+                {
+                    try await performCatalogRebuild(repo: repo)
+                }
             }
         }
     }
 }
 
-/// Helper function to rebuild catalogs
+
 private func performCatalogRebuild(repo: Repo) async throws {
     let makecatalogOptions = MakeCatalogOptions()
     var catalogsmaker = try await CatalogsMaker(repo: repo, options: makecatalogOptions)

--- a/code/cli/munki/shared/admin/munkiimportOptions.swift
+++ b/code/cli/munki/shared/admin/munkiimportOptions.swift
@@ -52,6 +52,10 @@ struct MunkiImportOptions: ParsableArguments {
     @Flag(name: .shortAndLong, help: "More detailed output.")
     var verbose = false
 
+    @Flag(name: [.long, .customLong("rebuild-catalogs")],
+          help: "Rebuild the catalogs after importing the item. If interactive and this flag is not specified, you will be prompted.")
+    var rebuildCatalogs = false
+
     mutating func validate() throws {
         // update plugin (not really a validation, but close enough)
         if plugin == nil {


### PR DESCRIPTION
This PR adds a new --rebuild-catalogs flag to munkiimport for automatically rebuilding catalogs after importing items.

## Changes
- Add new --rebuild-catalogs flag to munkiimportOptions
- When flag is passed, automatically rebuild catalogs after import (works in both interactive and non-interactive modes)
- When flag is not passed and running interactive, prompt user as before (current behavior)
- Extract catalog rebuild logic into performCatalogRebuild() helper function to eliminate code duplication

## Usage Examples
```bash
# Force rebuild catalogs automatically
munkiimport --rebuild-catalogs package.pkg

# Interactive mode with flag (no prompt)
munkiimport --rebuild-catalogs -i package.pkg

# Non-interactive mode with flag
munkiimport --rebuild-catalogs --nointeractive package.pkg

# Interactive mode without flag (prompts as before)
munkiimport package.pkg
```