### PR TITLE
MSC.app: avoid redundant InstallInfo.plist reads

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/munki.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/munki.swift
@@ -436,7 +436,7 @@ func discardTimeZoneFromDate(_ theDate: Date) -> Date {
 func thereAreUpdatesToBeForcedSoon(hours: Int = 72) -> Bool {
     // Return True if any updates need to be installed within the next
     // X hours, false otherwise
-    var installinfo = getInstallInfo()["managed_installs"] as? [PlistDict] ?? [PlistDict]()
+    var installinfo = cachedInstallInfo()["managed_installs"] as? [PlistDict] ?? [PlistDict]()
     installinfo = installinfo + getAppleUpdates()
     let now_xhours = Date(timeIntervalSinceNow: TimeInterval(hours * 3600))
     for item in installinfo {
@@ -456,7 +456,7 @@ func earliestForceInstallDate(_ installinfo: [PlistDict]? = nil) -> Date? {
     var installinfo = installinfo
     var earliest_date: Date?
     if installinfo == nil {
-        let managed_installs = getInstallInfo()["managed_installs"] as? [PlistDict] ?? [PlistDict]()
+        let managed_installs = cachedInstallInfo()["managed_installs"] as? [PlistDict] ?? [PlistDict]()
         installinfo = managed_installs + getAppleUpdates()
     }
     for install in installinfo! {


### PR DESCRIPTION
`thereAreUpdatesToBeForcedSoon()` and `earliestForceInstallDate()` read InstallInfo.plist from disk on every call instead of using the `cachedInstallInfo()` cache other code paths already rely on.