### PR TITLE
Add timeout to version_script

### DIFF
--- a/code/cli/munki/munkiCLItesting/scriptutilsTests.swift
+++ b/code/cli/munki/munkiCLItesting/scriptutilsTests.swift
@@ -28,6 +28,11 @@ private let ERROR_SCRIPT_TEXT = """
 exit 1
 """
 
+private let SLEEP_SCRIPT_TEXT = """
+#!/bin/sh
+sleep 5
+"""
+
 private let PKGINFO: PlistDict = [
     "postinstall_script": """
     #!/bin/sh
@@ -81,6 +86,19 @@ struct runScriptAndReturnResultsTests {
         )
         #expect(results.exitcode == 0)
         #expect(results.output == "Hello, world!")
+    }
+
+    @Test func timesOut() async throws {
+        let filePath = try #require(tempFile(), "Can't get a temp file path")
+        let success = createExecutableFile(
+            atPath: filePath, withStringContents: SLEEP_SCRIPT_TEXT
+        )
+        try #require(success, "Expected to create a file at \(filePath)")
+        let results = await runScriptAndReturnResults(
+            filePath, itemName: "Foo", scriptName: "Bar", timeout: 2
+        )
+        #expect(results.timedOut == true)
+        #expect(results.exitcode != 0)
     }
 }
 

--- a/code/cli/munki/shared/updatecheck/compare.swift
+++ b/code/cli/munki/shared/updatecheck/compare.swift
@@ -50,11 +50,19 @@ func compareVersions(_ thisVersion: String, _ thatVersion: String) -> MunkiCompa
 }
 
 func compareUsingVersionScript(_ item: PlistDict) async -> MunkiComparisonResult {
+    let itemName = item["name"] as? String ?? "<unknown>"
     let itemVersion = item["version"] as? String ?? "0"
     let results = await runEmbeddedScriptAndReturnResults(name: "version_script", pkginfo: item, suppressError: true)
     if results.exitcode != 0 {
-        // treat an error as .notPresent
-        display.debug1("\tVersion script error \(results.exitcode): \(results.error)")
+        if results.timedOut {
+            // a hung version_script used to wedge managedsoftwareupdate
+            // indefinitely; make sure admins can see it happened without
+            // needing -vv
+            display.warning("\(itemName): \(results.error)")
+        } else {
+            // treat an error as .notPresent
+            display.debug1("\tVersion script error \(results.exitcode): \(results.error)")
+        }
         return .notPresent
     }
     let installedVersion = results.output.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/code/cli/munki/shared/utils/scriptutils.swift
+++ b/code/cli/munki/shared/utils/scriptutils.swift
@@ -125,7 +125,7 @@ func runScript(_ path: String, itemName: String, scriptName: String, suppressErr
 }
 
 /// Runs a script, Returns CLIResults.
-func runScriptAndReturnResults(_ path: String, itemName: String, scriptName: String, suppressError: Bool = false) async -> CLIResults {
+func runScriptAndReturnResults(_ path: String, itemName: String, scriptName: String, suppressError: Bool = false, timeout: Int = 60) async -> CLIResults {
     if suppressError {
         display.detail("Running \(scriptName) for \(itemName)")
     } else {
@@ -136,7 +136,13 @@ func runScriptAndReturnResults(_ path: String, itemName: String, scriptName: Str
         munkiStatusPercent(-1)
     }
 
-    let results = await runCliAsync(path)
+    let results: CLIResults
+    do {
+        results = try await runCliAsync(path, timeout: timeout)
+    } catch {
+        // runCliAsync(timeout:) only ever throws ProcessError.timeout
+        results = CLIResults(exitcode: -1, error: "\(scriptName) timed out after \(timeout) seconds", timedOut: true)
+    }
 
     if DisplayOptions.munkistatusoutput {
         // clear indeterminate progress bar
@@ -172,7 +178,7 @@ func runEmbeddedScript(name: String, pkginfo: PlistDict, suppressError: Bool = f
 
 /// Runs a script embedded in the pkginfo.
 /// Returns CLIResults
-func runEmbeddedScriptAndReturnResults(name: String, pkginfo: PlistDict, suppressError: Bool = false) async -> CLIResults {
+func runEmbeddedScriptAndReturnResults(name: String, pkginfo: PlistDict, suppressError: Bool = false, timeout: Int = 60) async -> CLIResults {
     // get the script text
     let itemName = pkginfo["name"] as? String ?? "<unknown>"
     guard let scriptText = pkginfo[name] as? String else {
@@ -185,7 +191,7 @@ func runEmbeddedScriptAndReturnResults(name: String, pkginfo: PlistDict, suppres
     }
     let scriptPath = (tempdir as NSString).appendingPathComponent(name)
     if createExecutableFile(atPath: scriptPath, withStringContents: scriptText) {
-        return await runScriptAndReturnResults(scriptPath, itemName: itemName, scriptName: name, suppressError: suppressError)
+        return await runScriptAndReturnResults(scriptPath, itemName: itemName, scriptName: name, suppressError: suppressError, timeout: timeout)
     } else {
         return CLIResults(exitcode: -1, error: "Failed to create executable file for \(name)")
     }


### PR DESCRIPTION
## The problem

We recently ran into a `version_script` that hung: an x86_64 binary running under Rosetta never returned from `--version`. `managedsoftwareupdate` was wedged for 8+ hours on the affected Mac, pegging CPU and making Managed Software Center unusable, with no detection or recovery — it required manual intervention.

Any `version_script` that shells out to a binary's `--version` is trusting that binary to always return promptly. That's not guaranteed, and a hang currently has no backstop in Munki.

`version_script` — an embedded pkginfo script whose entire job is to print an installed version string to stdout — has no execution timeout in Munki's Swift implementation. If it hangs, it hangs forever, wedging the entire `managedsoftwareupdate` run (every other item check, install, everything) until something external kills the process.

This matches how every other embedded pkginfo script works today — none of them have a timeout, and I don't think that's an oversight. It's a reasonable, deliberate choice for that whole class of scripts.

## Timeout vs. no timeout

Munki already has the exact mechanism needed to fix this, and already uses it elsewhere. `AsyncProcessRunner` (`cliutils.swift`) has two ways to run a process:

- `run()` — no timeout, runs until the process exits on its own.
- `run(timeout:)` — enforces a deadline; on timeout it calls `task.terminate()` (actually kills the hung process) and throws `ProcessError.timeout`.

`preflight`/`postflight`/conditional scripts already go through the timeout-enforcing path, via `runExternalScript()`, with a 60-second default.

`version_script` does not — it goes through `runScriptAndReturnResults()` → `runCliAsync(path)`, the no-timeout overload, with no bound at all.

That split makes sense to me too — Munki already treats some script categories differently on purpose (some get a timeout, some don't), and that's the right call for scripts whose runtime genuinely can't be predicted up front.

## Why version_script is different from other embedded scripts

Munki's other embedded pkginfo scripts — `installcheck_script`/`uninstallcheck_script`, and the install/uninstall lifecycle scripts (`preinstall_script`, `postinstall_script`, `preuninstall_script`, `uninstall_script`, `postuninstall_script`) — all share the exact same no-timeout path as `version_script`.

- `installcheck_script`/`uninstallcheck_script` are open-ended predicates. They may legitimately need to inspect a lot of state — filesystem checks, multiple conditions, whatever it takes to decide whether an install is needed. There's no basis for assuming they should be fast.
- The install/uninstall lifecycle scripts legitimately do real work that can take a long time. A blanket timeout on this category would be a real regression for existing pkginfos in the field, not a hypothetical one.

`version_script` is different in kind from both groups: its contract is narrow and singular — report an installed version string, nothing else.

That's the same "should be fast" property that `preflight`/`postflight`/conditional scripts already have, and already get a timeout for. Munki already treats "fast, narrow-purpose, runs unattended every check cycle" as a category that deserves a bound. `version_script` fits that category, and is currently the only member of it that isn't protected.

## What I'm proposing

Add an optional timeout to the code path that runs `version_script`, defaulting to 60 seconds (matching the existing `runExternalScript` default).

On timeout, the hung process is killed (fixing the CPU-pegging/wedge symptom) and the item is treated as `.notPresent` — which was already verified as the existing, correct behavior for any `version_script` that exits non-zero or prints nothing. A timeout is now also logged as a `WARNING` (visible at normal verbosity, not gated behind `-vv`), so an admin can actually see that it happened instead of it looking identical to a normal "not installed" result.

The change is fully isolated: `runScriptAndReturnResults()` / `runEmbeddedScriptAndReturnResults()` are used exclusively by `compareUsingVersionScript()` in the current codebase — no other embedded script type goes through this code path.

## Open question for discussion

**Should the timeout be a hardcoded 60 seconds, or configurable per-item?**

The 60s default seems reasonable for the actual use case (reporting a version string should be near-instant), but it's a real behavior change for anyone currently running a `version_script` that happens to take longer than that for some other reason — that pkginfo would start being silently treated as "not installed" and reinstalled every cycle, forever, rather than hanging (loudly, if inconveniently).

I think that's a strict improvement over an indefinite hang, but we don't have visibility into every `version_script` in the wild, and we'd rather surface this trade-off than assume it away.

Options I can see:
1. Hardcode 60s (simplest, matches existing `runExternalScript` convention) — this is what the current PR implements.
2. Make it configurable via a new pkginfo key (e.g. `version_script_timeout`),  defaulting to 60s.
3. Something else — open to how you'd want to shape this.