### PR TITLE
Scope blocking app launch arguments by application

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -190,23 +190,40 @@ class MSCBlockingAppsController: NSObject {
                 }
             }
 
-            if let launchArguments = update_item["blocking_applications_launch_args"] as? [String] {
-                let appPaths = Array(Set(runningBlockingApps.map(\.pathname).filter {
+            if let launchArgumentMappings = update_item["blocking_applications_launch_args"] as? [String: Any] {
+                let itemAppPaths = Set(runningBlockingApps.map(\.pathname).filter {
                     $0.hasSuffix(".app")
-                }))
-                let configuredApps = appPaths.filter { appLaunchArguments[$0] == nil }
-                let conflicts = recordLaunchArguments(
-                    launchArguments,
-                    for: appPaths,
-                    in: &appLaunchArguments
-                )
-                for appPath in configuredApps {
-                    msc_debug_log("Found blocking_applications_launch_args for \(appPath)")
-                }
-                for appPath in conflicts {
-                    msc_debug_log(
-                        "Ignoring conflicting blocking_applications_launch_args for \(appPath)"
+                })
+                for appIdentifier in launchArgumentMappings.keys.sorted() {
+                    guard let launchArguments = launchArgumentMappings[appIdentifier] as? [String] else {
+                        msc_debug_log(
+                            "Ignoring invalid blocking_applications_launch_args for \(appIdentifier)"
+                        )
+                        continue
+                    }
+                    let appPaths = Array(Set(
+                        getRunningBlockingApps([appIdentifier]).map(\.pathname)
+                    ).intersection(itemAppPaths)).sorted()
+                    if appPaths.isEmpty {
+                        msc_debug_log(
+                            "Ignoring blocking_applications_launch_args for non-blocking application \(appIdentifier)"
+                        )
+                        continue
+                    }
+                    let configuredApps = appPaths.filter { appLaunchArguments[$0] == nil }
+                    let conflicts = recordLaunchArguments(
+                        launchArguments,
+                        for: appPaths,
+                        in: &appLaunchArguments
                     )
+                    for appPath in configuredApps {
+                        msc_debug_log("Found blocking_applications_launch_args for \(appPath)")
+                    }
+                    for appPath in conflicts {
+                        msc_debug_log(
+                            "Ignoring conflicting blocking_applications_launch_args for \(appPath)"
+                        )
+                    }
                 }
             }
         }

--- a/code/cli/munki/munkiCLItesting/analyzeTests.swift
+++ b/code/cli/munki/munkiCLItesting/analyzeTests.swift
@@ -23,15 +23,18 @@ struct assistedQuitMetadataTests {
     @Test func copiesLaunchArguments() {
         let pkginfo: PlistDict = [
             "blocking_applications_launch_args": [
-                "--restore-last-session",
-                "--profile-directory=Profile With Spaces",
+                "Google Chrome.app": [
+                    "--restore-last-session",
+                    "--profile-directory=Profile With Spaces",
+                ],
             ],
         ]
         var processedItem = PlistDict()
 
         copyAssistedQuitMetadata(from: pkginfo, to: &processedItem)
 
-        #expect(processedItem["blocking_applications_launch_args"] as? [String] == [
+        let launchArguments = processedItem["blocking_applications_launch_args"] as? PlistDict
+        #expect(launchArguments?["Google Chrome.app"] as? [String] == [
             "--restore-last-session",
             "--profile-directory=Profile With Spaces",
         ])
@@ -41,7 +44,9 @@ struct assistedQuitMetadataTests {
         let pkginfo: PlistDict = [
             "blocking_applications_manual_quit_only": true,
             "blocking_applications_quit_script": "#!/bin/sh\nexit 0",
-            "blocking_applications_launch_args": ["--restore-last-session"],
+            "blocking_applications_launch_args": [
+                "Google Chrome.app": ["--restore-last-session"],
+            ],
         ]
         var processedItem = PlistDict()
 
@@ -49,7 +54,8 @@ struct assistedQuitMetadataTests {
 
         #expect(processedItem["blocking_applications_manual_quit_only"] as? Bool == true)
         #expect(processedItem["blocking_applications_quit_script"] as? String == "#!/bin/sh\nexit 0")
-        #expect(processedItem["blocking_applications_launch_args"] as? [String] == ["--restore-last-session"])
+        let launchArguments = processedItem["blocking_applications_launch_args"] as? PlistDict
+        #expect(launchArguments?["Google Chrome.app"] as? [String] == ["--restore-last-session"])
     }
 
     @Test func ignoresAbsentMetadata() {


### PR DESCRIPTION
This is a follow up to #1379 based on [Greg's review comment](https://github.com/munki/munki/pull/1379#issuecomment-5413466181).

The original `blocking_applications_launch_args` schema uses one argument array for an entire pkginfo item. If an item lists several blocking applications, Managed Software Center passes the same application-specific arguments to all of them.

For example, a Chrome-specific `--restore-last-session` array would also be passed to Firefox and Safari if those applications appeared in the same `blocking_applications` list. Launch arguments need to be associated with individual applications instead.

### Changes

Changes `blocking_applications_launch_args` to a dictionary mapping blocking application identifiers to arrays of strings. Managed Software Center passes each array only to its corresponding application through `NSWorkspace.OpenConfiguration.arguments`.

For Google Chrome, a pkginfo can contain:

```xml
<key>blocking_applications</key>
<array>
    <string>Google Chrome.app</string>
    <string>Firefox.app</string>
</array>
<key>blocking_applications_launch_args</key>
<dict>
    <key>Google Chrome.app</key>
    <array>
        <string>--restore-last-session</string>
    </array>
</dict>
```

Chrome receives `--restore-last-session`; Firefox reopens without additional arguments. Each array element is passed as one application argument without shell parsing.

Dictionary keys accept the same forms as `blocking_applications`: names with or without `.app` and full executable paths. Mapping keys and blocker entries can use different equivalent forms because both resolve to the running application bundle path. Applications inferred from `installs` are supported as well.

Mappings are scoped to effective blockers for that pkginfo item. Unrelated mappings and non-bundle processes are ignored. Malformed values are ignored individually, so one bad mapping does not discard valid sibling mappings.

The key is copied into the processed managed-install, optional-install, and removal metadata so it is available wherever the existing Assisted Quit keys are available.

If equivalent keys or multiple pending items configure the same canonical application differently, the first deterministic value is retained and the conflict is written to the MSC debug log. Arrays are never combined.

### Compatibility

The array schema was introduced by #1379 on the unreleased Munki 7.4 development branch. This follow-up intentionally replaces it rather than supporting both ambiguous and per-application forms. Existing pkginfo files omit the new key and retain current behavior.

Existing assisted quit safeguards remain unchanged. Arguments affect only applications MSC closed and would already reopen, and do not override the user's reopen choice, removal handling, or failed update behavior.

### Testing

I tested this with branch-built `managedsoftwareupdate`, `makecatalogs`, and Managed Software Center using an isolated local Munki repo. This tested catalog generation, update analysis, the Assisted Quit sheet, successful installation, and real application relaunches without changing the installed application versions.

One test item blocked two running applications, Google Chrome and Safari. The processed `InstallInfo.plist` preserved the dictionary unchanged.

The following cases passed:

- Distinct valid mappings: Chrome reopened under a new PID with `--restore-last-session`, and Safari reopened under a new PID with `--args-for-safari-test`.
- Valid Chrome mapping with a malformed Safari scalar: Chrome still reopened with `--restore-last-session`, and Safari reopened with no additional arguments.
- Equivalent forms: the mapping key `Google Chrome` matched `Google Chrome.app` in `blocking_applications` and resolved to `/Applications/Google Chrome.app`.
- Unrelated mapping: a mapping for `Unrelated App.app` had no effect because it was not an effective blocker for the item.

Chrome's tab URL list was identical before and after the live tests.