### PR TITLE
MSC OnDemand/optional_installs/uninstalls button customization(/localization) support

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -1565,13 +1565,13 @@ class MainWindowController: NSWindowController {
                 }
                 if btn_classes.contains("install-updates") {
                     //(btn as! DOMHTMLElement).innerText = item["myitem_action_text"] as? String ?? ""
-                    self.setInnerText(item["myitem_action_text"] as? String ?? "", elementID: btn_id)
+                    self.setInnerHTML(item["myitem_action_text"] as? String ?? "", elementID: btn_id)
                 } else if btn_classes.contains("long_action_text") {
                     //(btn as! DOMHTMLElement).innerText = item["long_action_text"] as? String ?? ""
-                    self.setInnerText(item["long_action_text"] as? String ?? "", elementID: btn_id)
+                    self.setInnerHTML(item["long_action_text"] as? String ?? "", elementID: btn_id)
                 } else {
                     //(btn as! DOMHTMLElement).innerText = item["short_action_text"] as? String ?? ""
-                    self.setInnerText(item["short_action_text"] as? String ?? "", elementID: btn_id)
+                    self.setInnerHTML(item["short_action_text"] as? String ?? "", elementID: btn_id)
                 }
                 // use innerHTML instead of innerText because sometimes the status
                 // text contains html, like '<span class="warning">Some warning</span>'

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MainWindowController.swift
@@ -1565,13 +1565,13 @@ class MainWindowController: NSWindowController {
                 }
                 if btn_classes.contains("install-updates") {
                     //(btn as! DOMHTMLElement).innerText = item["myitem_action_text"] as? String ?? ""
-                    self.setInnerHTML(item["myitem_action_text"] as? String ?? "", elementID: btn_id)
+                    self.setInnerText(item["myitem_action_text"] as? String ?? "", elementID: btn_id)
                 } else if btn_classes.contains("long_action_text") {
                     //(btn as! DOMHTMLElement).innerText = item["long_action_text"] as? String ?? ""
-                    self.setInnerHTML(item["long_action_text"] as? String ?? "", elementID: btn_id)
+                    self.setInnerText(item["long_action_text"] as? String ?? "", elementID: btn_id)
                 } else {
                     //(btn as! DOMHTMLElement).innerText = item["short_action_text"] as? String ?? ""
-                    self.setInnerHTML(item["short_action_text"] as? String ?? "", elementID: btn_id)
+                    self.setInnerText(item["short_action_text"] as? String ?? "", elementID: btn_id)
                 }
                 // use innerHTML instead of innerText because sometimes the status
                 // text contains html, like '<span class="warning">Some warning</span>'

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -317,6 +317,57 @@ class GenericItem: BaseItem {
                                  comment: "Not Currently Available display text")
     }
     
+    func custom_label(forSubKey sub_key: String) -> String? {
+        // Return the admin-defined label for one action_labels sub-key, or nil
+        // if the pkginfo doesn't supply a usable one. add_localizations() has
+        // already swapped in a translation if the pkginfo provided one for the
+        // user's preferred language.
+        guard let action_labels = my["action_labels"] as? [String: Any],
+              let label = action_labels[sub_key] as? String,
+              !label.isEmpty
+        else {
+            return nil
+        }
+        // the value ends up in our html templates, so escape it like we do
+        // display_name and the other admin-supplied strings
+        return escapeHTML(label)
+    }
+
+    func custom_action_label(forStatus status: String) -> String? {
+        // Return the admin-defined replacement for our built-in action button
+        // text at this status, or nil if there isn't one. Each sub-key is named
+        // for the string it replaces, which is not always the status name.
+        let label_key_for_status = [
+            "not-installed": "install",
+            "installing": "installing",
+            "installed": "remove",
+            "installed-not-removable": "installed",
+            "removing": "removing",
+            "update-available": "update",
+        ]
+        guard let label_key = label_key_for_status[status] else {
+            return nil
+        }
+        return custom_label(forSubKey: label_key)
+    }
+
+    func custom_status_label(forStatus status: String) -> String? {
+        // Same idea, but for the status line rather than the button. Only the
+        // statuses whose status line shows one of our sub-key strings appear
+        // here; "Not installed" and "Update available" are different strings
+        // that no sub-key names, so they are left alone.
+        let label_key_for_status = [
+            "installing": "installing",
+            "installed": "installed",
+            "installed-not-removable": "installed",
+            "removing": "removing",
+        ]
+        guard let label_key = label_key_for_status[status] else {
+            return nil
+        }
+        return custom_label(forSubKey: label_key)
+    }
+
     func status_text() -> String {
         // Return localized status display text
         if my["low_data_deferred"] as? Bool ?? false {
@@ -389,6 +440,9 @@ class GenericItem: BaseItem {
                 NSLocalizedString("Unavailable",
                                   comment: "Unavailable status text")
         ]
+        if let label = custom_status_label(forStatus: status) {
+            return label
+        }
         return text_for[status] ?? status
     }
     
@@ -454,7 +508,7 @@ class GenericItem: BaseItem {
                                   comment: "Unavailable status text")
         ]
         let status = my["status"] as? String ?? ""
-        return text_for[status] ?? status
+        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
     }
     
     func long_action_text() -> String {
@@ -519,7 +573,7 @@ class GenericItem: BaseItem {
                                   comment: "Unavailable long action text")
         ]
         let status = my["status"] as? String ?? ""
-        return text_for[status] ?? status
+        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
     }
     
     func myitem_action_text() -> String {
@@ -577,7 +631,7 @@ class GenericItem: BaseItem {
                                   comment: "Install Required action text"),
         ]
         let status = my["status"] as? String ?? ""
-        return text_for[status] ?? status
+        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
     }
     
     func version_label() -> String {
@@ -689,7 +743,8 @@ class GenericItem: BaseItem {
         let language_code = _get_preferred_locale(available_locales)
         if language_code != fallback_locale {
             if let locale_dict = localized_strings[language_code] as? [String: Any] {
-                let localized_keys = ["category",
+                let localized_keys = ["action_labels",
+                                      "category",
                                       "description",
                                       "display_name",
                                       "preinstall_alert",

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -508,7 +508,7 @@ class GenericItem: BaseItem {
                                   comment: "Unavailable status text")
         ]
         let status = my["status"] as? String ?? ""
-        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
+        return custom_action_label(forStatus: status) ?? escapeHTML(text_for[status] ?? status)
     }
     
     func long_action_text() -> String {
@@ -573,7 +573,7 @@ class GenericItem: BaseItem {
                                   comment: "Unavailable long action text")
         ]
         let status = my["status"] as? String ?? ""
-        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
+        return custom_action_label(forStatus: status) ?? escapeHTML(text_for[status] ?? status)
     }
     
     func myitem_action_text() -> String {
@@ -631,7 +631,7 @@ class GenericItem: BaseItem {
                                   comment: "Install Required action text"),
         ]
         let status = my["status"] as? String ?? ""
-        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
+        return custom_action_label(forStatus: status) ?? escapeHTML(text_for[status] ?? status)
     }
     
     func version_label() -> String {

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -318,11 +318,11 @@ class GenericItem: BaseItem {
     }
     
     func custom_label(forSubKey sub_key: String) -> String? {
-        // Return the admin-defined label for one action_labels sub-key, or nil
+        // Return the admin-defined label for one custom_action_labels sub-key, or nil
         // if the pkginfo doesn't supply a usable one. add_localizations() has
         // already swapped in a translation if the pkginfo provided one for the
         // user's preferred language.
-        guard let action_labels = my["action_labels"] as? [String: Any],
+        guard let action_labels = my["custom_action_labels"] as? [String: Any],
               let label = action_labels[sub_key] as? String,
               !label.isEmpty
         else {
@@ -741,7 +741,7 @@ class GenericItem: BaseItem {
         let language_code = _get_preferred_locale(available_locales)
         if language_code != fallback_locale {
             if let locale_dict = localized_strings[language_code] as? [String: Any] {
-                let localized_keys = ["action_labels",
+                let localized_keys = ["custom_action_labels",
                                       "category",
                                       "description",
                                       "display_name",

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -328,9 +328,7 @@ class GenericItem: BaseItem {
         else {
             return nil
         }
-        // the value ends up in our html templates, so escape it like we do
-        // display_name and the other admin-supplied strings
-        return escapeHTML(label)
+        return label
     }
 
     func custom_action_label(forStatus status: String) -> String? {
@@ -508,7 +506,7 @@ class GenericItem: BaseItem {
                                   comment: "Unavailable status text")
         ]
         let status = my["status"] as? String ?? ""
-        return custom_action_label(forStatus: status) ?? escapeHTML(text_for[status] ?? status)
+        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
     }
     
     func long_action_text() -> String {
@@ -573,7 +571,7 @@ class GenericItem: BaseItem {
                                   comment: "Unavailable long action text")
         ]
         let status = my["status"] as? String ?? ""
-        return custom_action_label(forStatus: status) ?? escapeHTML(text_for[status] ?? status)
+        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
     }
     
     func myitem_action_text() -> String {
@@ -631,7 +629,7 @@ class GenericItem: BaseItem {
                                   comment: "Install Required action text"),
         ]
         let status = my["status"] as? String ?? ""
-        return custom_action_label(forStatus: status) ?? escapeHTML(text_for[status] ?? status)
+        return custom_action_label(forStatus: status) ?? text_for[status] ?? status
     }
     
     func version_label() -> String {

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -852,6 +852,7 @@ func processOptionalInstall(
         }
     }
     let optionalKeys = [
+        "action_labels",
         "preinstall_alert",
         "preuninstall_alert",
         "preupgrade_alert",
@@ -938,6 +939,7 @@ func processOptionalUninstall(
         processedItem["note"] = pkgInfoNote
     }
     let optionalKeys = [
+        "action_labels",
         "preuninstall_alert",
         "minimum_os_version",
         "localized_strings",

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -852,7 +852,7 @@ func processOptionalInstall(
         }
     }
     let optionalKeys = [
-        "action_labels",
+        "custom_action_labels",
         "preinstall_alert",
         "preuninstall_alert",
         "preupgrade_alert",
@@ -939,7 +939,7 @@ func processOptionalUninstall(
         processedItem["note"] = pkgInfoNote
     }
     let optionalKeys = [
-        "action_labels",
+        "custom_action_labels",
         "preuninstall_alert",
         "minimum_os_version",
         "localized_strings",


### PR DESCRIPTION
OnDemand has always displayed the same button text/labels as optional_installs do, which are often not applicable to the 'action' being performed. In looking at the code paths required to enable this, both optional_installs and the new auto-optional_uninstalls capability COULD leverage this as well, and the lines of code/files changed were small, so I went for it.
I also chose (with the guidance/assistance of a friendly LLM clanker) to split functions that handle the status items and convert the handling from `Text` to `.setInnerHTML` so that it's more consistent with other escaping of pkginfo/admin-provided customized or substituted text. Please let me know if we'd like to rename keys, undo the 'consistency' change, or otherwise roll back affecting optional_installs as part of this at all.
Tested by only updating the app and basing off the munki7_4dev's currently posted package., screenshots of working QA procedures posted to Slack (I can post them here as well).
Ready with wiki edits when the time comes. Thanks for your consideration! 