### PR TITLE
Handle cached manifests blocking nested paths

### DIFF
--- a/code/cli/munki/munkiCLItesting/fileUtilsTests.swift
+++ b/code/cli/munki/munkiCLItesting/fileUtilsTests.swift
@@ -170,6 +170,30 @@ struct pathIsDirectoryTests {
     }
 }
 
+struct createMissingDirsTests {
+    @Test func existingDirectoryReturnsTrue() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        #expect(createMissingDirs(testDirectoryPath))
+    }
+
+    @Test func existingFileReturnsFalse() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let filePath = testDirectoryPath + "/not-a-directory-\(UUID().uuidString)"
+        try #require(
+            FileManager.default.createFile(
+                atPath: filePath, contents: nil, attributes: nil
+            ),
+            "Can't create test file"
+        )
+
+        #expect(!createMissingDirs(filePath))
+    }
+}
+
 struct pathIsRegularFileTests {
     @Test func nonExistentPathReturnsFalse() {
         #expect(!pathIsRegularFile("/this/path/does/not/exist"))

--- a/code/cli/munki/munkiCLItesting/manifestsTests.swift
+++ b/code/cli/munki/munkiCLItesting/manifestsTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 @Suite(.serialized)
 struct manifestsTests {
-    @Test func prepareManifestDirectoryReplacesCachedManifestFile() throws {
+    @Test func prepareManifestDestinationReplacesCachedManifestFile() throws {
         let testDirectoryPath = try #require(
             TempDir.shared.path, "Can't get temp directory path"
         )
@@ -23,11 +23,12 @@ struct manifestsTests {
             "Can't create cached manifest file"
         )
 
-        #expect(prepareManifestDirectory(manifestDirectory, cacheRoot: testDirectoryPath))
+        let manifestPath = manifestDirectory + "/child"
+        #expect(prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
         #expect(pathIsDirectory(manifestDirectory))
     }
 
-    @Test func prepareManifestDirectoryReplacesCachedAncestorManifest() throws {
+    @Test func prepareManifestDestinationReplacesCachedAncestorManifest() throws {
         let testDirectoryPath = try #require(
             TempDir.shared.path, "Can't get temp directory path"
         )
@@ -42,11 +43,12 @@ struct manifestsTests {
             "Can't create cached ancestor manifest"
         )
 
-        #expect(prepareManifestDirectory(manifestDirectory, cacheRoot: testDirectoryPath))
+        let manifestPath = manifestDirectory + "/child"
+        #expect(prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
         #expect(pathIsDirectory(manifestDirectory))
     }
 
-    @Test func prepareManifestDirectoryDoesNotRemoveSymlink() throws {
+    @Test func prepareManifestDestinationDoesNotRemoveParentSymlink() throws {
         let testDirectoryPath = try #require(
             TempDir.shared.path, "Can't get temp directory path"
         )
@@ -62,8 +64,102 @@ struct manifestsTests {
             atPath: manifestDirectory, withDestinationPath: targetPath
         )
 
-        #expect(!prepareManifestDirectory(manifestDirectory, cacheRoot: testDirectoryPath))
+        let manifestPath = manifestDirectory + "/child"
+        #expect(!prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
         #expect(pathIsSymlink(manifestDirectory))
+    }
+
+    @Test func prepareManifestDestinationRemovesCachedDirectory() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let manifestPath = testDirectoryPath + "/manifest-directory-\(UUID().uuidString)"
+        let cachedChildPath = manifestPath + "/cached-child"
+        try FileManager.default.createDirectory(
+            atPath: manifestPath, withIntermediateDirectories: false
+        )
+        try #require(
+            FileManager.default.createFile(
+                atPath: cachedChildPath,
+                contents: Data("cached manifest".utf8),
+                attributes: nil
+            ),
+            "Can't create cached child manifest"
+        )
+
+        #expect(prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
+        #expect(!pathExists(manifestPath))
+        #expect(
+            FileManager.default.createFile(
+                atPath: manifestPath,
+                contents: Data("new parent manifest".utf8),
+                attributes: nil
+            )
+        )
+        #expect(pathIsRegularFile(manifestPath))
+    }
+
+    @Test func prepareManifestDestinationPreservesCachedManifestFile() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let manifestPath = testDirectoryPath + "/cached-manifest-\(UUID().uuidString)"
+        let contents = Data("cached manifest".utf8)
+        try #require(
+            FileManager.default.createFile(
+                atPath: manifestPath, contents: contents, attributes: nil
+            ),
+            "Can't create cached manifest"
+        )
+
+        #expect(prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: manifestPath)) == contents)
+    }
+
+    @Test func prepareManifestDestinationDoesNotRemoveFinalSymlink() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let targetPath = testDirectoryPath + "/target-file-\(UUID().uuidString)"
+        let manifestPath = testDirectoryPath + "/manifest-link-\(UUID().uuidString)"
+        try #require(
+            FileManager.default.createFile(
+                atPath: targetPath, contents: nil, attributes: nil
+            ),
+            "Can't create symlink target"
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: manifestPath, withDestinationPath: targetPath
+        )
+
+        #expect(!prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
+        #expect(pathIsSymlink(manifestPath))
+    }
+
+    @Test func prepareManifestDestinationRejectsCacheRoot() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+
+        #expect(!prepareManifestDestination(testDirectoryPath, cacheRoot: testDirectoryPath))
+        #expect(pathIsDirectory(testDirectoryPath))
+    }
+
+    @Test func prepareManifestDestinationRejectsPathOutsideCache() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let cacheRoot = testDirectoryPath + "/cache-\(UUID().uuidString)"
+        let outsidePath = testDirectoryPath + "/outside-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: cacheRoot, withIntermediateDirectories: false
+        )
+        try FileManager.default.createDirectory(
+            atPath: outsidePath, withIntermediateDirectories: false
+        )
+
+        #expect(!prepareManifestDestination(outsidePath, cacheRoot: cacheRoot))
+        #expect(pathIsDirectory(outsidePath))
     }
 
     /// Test that we can read a (plist) manifest file

--- a/code/cli/munki/munkiCLItesting/manifestsTests.swift
+++ b/code/cli/munki/munkiCLItesting/manifestsTests.swift
@@ -7,7 +7,65 @@
 
 import Testing
 
+@Suite(.serialized)
 struct manifestsTests {
+    @Test func prepareManifestDirectoryReplacesCachedManifestFile() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let manifestDirectory = testDirectoryPath + "/manifest-file-\(UUID().uuidString)"
+        try #require(
+            FileManager.default.createFile(
+                atPath: manifestDirectory,
+                contents: Data("cached manifest".utf8),
+                attributes: nil
+            ),
+            "Can't create cached manifest file"
+        )
+
+        #expect(prepareManifestDirectory(manifestDirectory, cacheRoot: testDirectoryPath))
+        #expect(pathIsDirectory(manifestDirectory))
+    }
+
+    @Test func prepareManifestDirectoryReplacesCachedAncestorManifest() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let ancestorPath = testDirectoryPath + "/ancestor-file-\(UUID().uuidString)"
+        let manifestDirectory = ancestorPath + "/nested/manifest"
+        try #require(
+            FileManager.default.createFile(
+                atPath: ancestorPath,
+                contents: Data("cached manifest".utf8),
+                attributes: nil
+            ),
+            "Can't create cached ancestor manifest"
+        )
+
+        #expect(prepareManifestDirectory(manifestDirectory, cacheRoot: testDirectoryPath))
+        #expect(pathIsDirectory(manifestDirectory))
+    }
+
+    @Test func prepareManifestDirectoryDoesNotRemoveSymlink() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let targetPath = testDirectoryPath + "/target-file-\(UUID().uuidString)"
+        let manifestDirectory = testDirectoryPath + "/manifest-link-\(UUID().uuidString)"
+        try #require(
+            FileManager.default.createFile(
+                atPath: targetPath, contents: nil, attributes: nil
+            ),
+            "Can't create symlink target"
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: manifestDirectory, withDestinationPath: targetPath
+        )
+
+        #expect(!prepareManifestDirectory(manifestDirectory, cacheRoot: testDirectoryPath))
+        #expect(pathIsSymlink(manifestDirectory))
+    }
+
     /// Test that we can read a (plist) manifest file
     @Test func manifestDataReturnsExpectedDict() async throws {
         let manifestPath = try #require(

--- a/code/cli/munki/munkiCLItesting/manifestsTests.swift
+++ b/code/cli/munki/munkiCLItesting/manifestsTests.swift
@@ -48,25 +48,29 @@ struct manifestsTests {
         #expect(pathIsDirectory(manifestDirectory))
     }
 
-    @Test func prepareManifestDestinationDoesNotRemoveParentSymlink() throws {
+    @Test func prepareManifestDestinationReplacesParentSymlink() throws {
         let testDirectoryPath = try #require(
             TempDir.shared.path, "Can't get temp directory path"
         )
-        let targetPath = testDirectoryPath + "/target-file-\(UUID().uuidString)"
+        let targetPath = testDirectoryPath + "/target-directory-\(UUID().uuidString)"
         let manifestDirectory = testDirectoryPath + "/manifest-link-\(UUID().uuidString)"
+        let targetContents = targetPath + "/preserved"
+        try FileManager.default.createDirectory(
+            atPath: targetPath, withIntermediateDirectories: false
+        )
         try #require(
-            FileManager.default.createFile(
-                atPath: targetPath, contents: nil, attributes: nil
-            ),
-            "Can't create symlink target"
+            FileManager.default.createFile(atPath: targetContents, contents: nil),
+            "Can't create file in symlink target"
         )
         try FileManager.default.createSymbolicLink(
             atPath: manifestDirectory, withDestinationPath: targetPath
         )
 
         let manifestPath = manifestDirectory + "/child"
-        #expect(!prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
-        #expect(pathIsSymlink(manifestDirectory))
+        #expect(prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
+        #expect(pathIsDirectory(manifestDirectory))
+        #expect(!pathIsSymlink(manifestDirectory))
+        #expect(pathIsRegularFile(targetContents))
     }
 
     @Test func prepareManifestDestinationRemovesCachedDirectory() throws {
@@ -116,24 +120,39 @@ struct manifestsTests {
         #expect(try Data(contentsOf: URL(fileURLWithPath: manifestPath)) == contents)
     }
 
-    @Test func prepareManifestDestinationDoesNotRemoveFinalSymlink() throws {
+    @Test func prepareManifestDestinationReplacesFinalSymlink() throws {
         let testDirectoryPath = try #require(
             TempDir.shared.path, "Can't get temp directory path"
         )
         let targetPath = testDirectoryPath + "/target-file-\(UUID().uuidString)"
         let manifestPath = testDirectoryPath + "/manifest-link-\(UUID().uuidString)"
         try #require(
-            FileManager.default.createFile(
-                atPath: targetPath, contents: nil, attributes: nil
-            ),
+            FileManager.default.createFile(atPath: targetPath, contents: nil),
             "Can't create symlink target"
         )
         try FileManager.default.createSymbolicLink(
             atPath: manifestPath, withDestinationPath: targetPath
         )
 
-        #expect(!prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
-        #expect(pathIsSymlink(manifestPath))
+        #expect(prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
+        #expect(!pathExists(manifestPath))
+        #expect(pathIsRegularFile(targetPath))
+    }
+
+    @Test func prepareManifestDestinationReplacesDanglingSymlink() throws {
+        let testDirectoryPath = try #require(
+            TempDir.shared.path, "Can't get temp directory path"
+        )
+        let missingTargetPath = testDirectoryPath + "/missing-\(UUID().uuidString)"
+        let manifestPath = testDirectoryPath + "/manifest-link-\(UUID().uuidString)"
+        try FileManager.default.createSymbolicLink(
+            atPath: manifestPath, withDestinationPath: missingTargetPath
+        )
+
+        #expect(prepareManifestDestination(manifestPath, cacheRoot: testDirectoryPath))
+        #expect(!pathIsSymlink(manifestPath))
+        #expect(!pathExists(manifestPath))
+        #expect(!pathExists(missingTargetPath))
     }
 
     @Test func prepareManifestDestinationRejectsCacheRoot() throws {

--- a/code/cli/munki/shared/installer/dmg.swift
+++ b/code/cli/munki/shared/installer/dmg.swift
@@ -233,8 +233,8 @@ func copyFromDmg(dmgPath: String, itemList: [PlistDict]) async -> Int {
 func createMissingDirs(_ path: String) -> Bool {
     let filemanager = FileManager.default
     if filemanager.fileExists(atPath: path) {
-        // the path exists; don't need to create anything
-        return true
+        // An existing non-directory cannot contain the requested path.
+        return pathIsDirectory(path, followSymlinks: true)
     }
     var parentPath = path
     // find a parent path that actually exists

--- a/code/cli/munki/shared/updatecheck/manifests.swift
+++ b/code/cli/munki/shared/updatecheck/manifests.swift
@@ -17,6 +17,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+import Darwin.C
 import Foundation
 
 private let PRIMARY_MANIFEST_TAG = "_primary_manifest_"
@@ -75,6 +76,47 @@ class Manifests {
     }
 }
 
+/// Makes a local directory available for a manifest download. A cached
+/// manifest may occupy this path when a repository changes a manifest name
+/// into a directory prefix.
+func prepareManifestDirectory(_ path: String, cacheRoot: String) -> Bool {
+    let standardizedPath = (path as NSString).standardizingPath
+    let standardizedRoot = (cacheRoot as NSString).standardizingPath
+    if standardizedPath != standardizedRoot,
+       !standardizedPath.hasPrefix(standardizedRoot + "/")
+    {
+        display.error("Manifest directory is outside the manifest cache: \(path)")
+        return false
+    }
+
+    let relativePath = String(standardizedPath.dropFirst(standardizedRoot.count + 1))
+    var candidatePath = standardizedRoot
+    for component in relativePath.split(separator: "/") {
+        candidatePath = (candidatePath as NSString).appendingPathComponent(String(component))
+        if pathIsSymlink(candidatePath) {
+            display.error("Symlink blocks manifest directory creation at \(candidatePath)")
+            return false
+        }
+        if !pathExists(candidatePath) {
+            break
+        }
+        if pathIsDirectory(candidatePath) {
+            continue
+        }
+        if !pathIsRegularFile(candidatePath) {
+            display.error("Unsupported file type blocks manifest directory creation at \(candidatePath)")
+            return false
+        }
+        if unlink(candidatePath) != 0 {
+            let description = String(cString: strerror(errno))
+            display.error("Could not remove manifest blocking directory creation at \(candidatePath): \(description)")
+            return false
+        }
+        break
+    }
+    return createMissingDirs(path)
+}
+
 /// Gets a manifest from the server.
 ///
 /// Returns:
@@ -87,10 +129,11 @@ func getManifest(_ name: String, suppressErrors: Bool = false) throws -> String 
         return manifestLocalPath
     }
 
+    let manifestCacheRoot = managedInstallsDir(subpath: "manifests")
     let manifestLocalPath = managedInstallsDir(subpath: "manifests/\(name)")
     // make sure the directory exists to store it
     let manifestLocalPathDir = (manifestLocalPath as NSString).deletingLastPathComponent
-    if !createMissingDirs(manifestLocalPathDir) {
+    if !prepareManifestDirectory(manifestLocalPathDir, cacheRoot: manifestCacheRoot) {
         throw ManifestError.notRetrieved(
             "Could not create a local directory to store manifest")
     }

--- a/code/cli/munki/shared/updatecheck/manifests.swift
+++ b/code/cli/munki/shared/updatecheck/manifests.swift
@@ -17,7 +17,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-import Darwin.C
 import Foundation
 
 private let PRIMARY_MANIFEST_TAG = "_primary_manifest_"
@@ -76,20 +75,20 @@ class Manifests {
     }
 }
 
-/// Makes a local directory available for a manifest download. A cached
-/// manifest may occupy this path when a repository changes a manifest name
-/// into a directory prefix.
-func prepareManifestDirectory(_ path: String, cacheRoot: String) -> Bool {
+/// Prepares a local destination for a manifest download. Cached manifests and
+/// directories may conflict when repository manifest paths change shape.
+func prepareManifestDestination(_ path: String, cacheRoot: String) -> Bool {
     let standardizedPath = (path as NSString).standardizingPath
     let standardizedRoot = (cacheRoot as NSString).standardizingPath
-    if standardizedPath != standardizedRoot,
-       !standardizedPath.hasPrefix(standardizedRoot + "/")
+    if standardizedPath == standardizedRoot ||
+        !standardizedPath.hasPrefix(standardizedRoot + "/")
     {
         display.error("Manifest directory is outside the manifest cache: \(path)")
         return false
     }
 
-    let relativePath = String(standardizedPath.dropFirst(standardizedRoot.count + 1))
+    let parentPath = (standardizedPath as NSString).deletingLastPathComponent
+    let relativePath = String(parentPath.dropFirst(standardizedRoot.count + 1))
     var candidatePath = standardizedRoot
     for component in relativePath.split(separator: "/") {
         candidatePath = (candidatePath as NSString).appendingPathComponent(String(component))
@@ -107,14 +106,36 @@ func prepareManifestDirectory(_ path: String, cacheRoot: String) -> Bool {
             display.error("Unsupported file type blocks manifest directory creation at \(candidatePath)")
             return false
         }
-        if unlink(candidatePath) != 0 {
-            let description = String(cString: strerror(errno))
-            display.error("Could not remove manifest blocking directory creation at \(candidatePath): \(description)")
+        do {
+            try FileManager.default.removeItem(atPath: candidatePath)
+        } catch {
+            display.error("Could not remove manifest blocking directory creation at \(candidatePath): \(error.localizedDescription)")
             return false
         }
         break
     }
-    return createMissingDirs(path)
+    if !createMissingDirs(parentPath) {
+        return false
+    }
+
+    if pathIsSymlink(standardizedPath) {
+        display.error("Symlink blocks manifest download at \(standardizedPath)")
+        return false
+    }
+    if !pathExists(standardizedPath) || pathIsRegularFile(standardizedPath) {
+        return true
+    }
+    if !pathIsDirectory(standardizedPath) {
+        display.error("Unsupported file type blocks manifest download at \(standardizedPath)")
+        return false
+    }
+    do {
+        try FileManager.default.removeItem(atPath: standardizedPath)
+    } catch {
+        display.error("Could not remove directory blocking manifest download at \(standardizedPath): \(error.localizedDescription)")
+        return false
+    }
+    return true
 }
 
 /// Gets a manifest from the server.
@@ -131,11 +152,10 @@ func getManifest(_ name: String, suppressErrors: Bool = false) throws -> String 
 
     let manifestCacheRoot = managedInstallsDir(subpath: "manifests")
     let manifestLocalPath = managedInstallsDir(subpath: "manifests/\(name)")
-    // make sure the directory exists to store it
-    let manifestLocalPathDir = (manifestLocalPath as NSString).deletingLastPathComponent
-    if !prepareManifestDirectory(manifestLocalPathDir, cacheRoot: manifestCacheRoot) {
+    // make sure the destination is available to store it
+    if !prepareManifestDestination(manifestLocalPath, cacheRoot: manifestCacheRoot) {
         throw ManifestError.notRetrieved(
-            "Could not create a local directory to store manifest")
+            "Could not prepare local storage for manifest")
     }
 
     // try to get the manifest from the server

--- a/code/cli/munki/shared/updatecheck/manifests.swift
+++ b/code/cli/munki/shared/updatecheck/manifests.swift
@@ -93,8 +93,13 @@ func prepareManifestDestination(_ path: String, cacheRoot: String) -> Bool {
     for component in relativePath.split(separator: "/") {
         candidatePath = (candidatePath as NSString).appendingPathComponent(String(component))
         if pathIsSymlink(candidatePath) {
-            display.error("Symlink blocks manifest directory creation at \(candidatePath)")
-            return false
+            do {
+                try FileManager.default.removeItem(atPath: candidatePath)
+            } catch {
+                display.error("Could not remove symlink blocking manifest directory creation at \(candidatePath): \(error.localizedDescription)")
+                return false
+            }
+            break
         }
         if !pathExists(candidatePath) {
             break
@@ -119,8 +124,12 @@ func prepareManifestDestination(_ path: String, cacheRoot: String) -> Bool {
     }
 
     if pathIsSymlink(standardizedPath) {
-        display.error("Symlink blocks manifest download at \(standardizedPath)")
-        return false
+        do {
+            try FileManager.default.removeItem(atPath: standardizedPath)
+        } catch {
+            display.error("Could not remove symlink blocking manifest download at \(standardizedPath): \(error.localizedDescription)")
+            return false
+        }
     }
     if !pathExists(standardizedPath) || pathIsRegularFile(standardizedPath) {
         return true


### PR DESCRIPTION
## Summary

Munki 7.3 can leave a client unable to complete update checks when a repository changes a manifest path between a file and a directory prefix. For example, a client that previously cached the manifest `policy/conditions` cannot retrieve a new manifest named `policy/conditions/test_manifest`. The inverse transition also fails when a cached `policy/conditions` directory blocks a new manifest at that path.

The Swift client treats the cached `policy/conditions` file as if it were the directory needed for the new manifest. The subsequent download receives an HTTP 200 response, but Munki cannot create the local `.download` file below that path and reports an unrelated connection error:

```text
ERROR: Could not retrieve manifest policy/conditions/test_manifest from the server: Download error 200: no error
```

This change prepares the complete local manifest destination for both transition directions. It removes a regular cached manifest when that file must become a directory, and removes a stale cached directory when that path must become a manifest file.

Recovery is confined to the manifest cache. Symlinks below the configured cache root are replaced without following or modifying their targets, while unsupported path components are rejected. Removal failures report descriptive errors from Foundation `FileManager`.

## Regression from the Swift client

The legacy Python `get_manifest()` implementation uses `os.path.isdir()` before creating a nested manifest directory. An existing regular file fails that check and produces a local folder-creation error before an HTTP request is attempted.

The Swift `getManifest()` implementation calls `createMissingDirs()`. That helper currently returns `true` for any existing path:

```swift
if filemanager.fileExists(atPath: path) {
    return true
}
```

It does not verify that the existing path is a directory. This behavior was introduced with the Swift implementation and is present in Munki 7.3.0.

After that incorrect success, `Gurl` attempts to create `<destination>.download`. `FileManager.createFile()` returns `false` because an intermediate path component is a regular file, and `FileHandle(forWritingAtPath:)` returns `nil`. Neither result is checked. The URL session continues, the response body has no writable destination, and the eventual error is presented as `Download error 200: no error`.

The normal manifest cleanup cannot recover the client because cleanup runs after a successful update check. The manifest retrieval error aborts the check first, leaving the blocking cached file in place for the next run.

The inverse transition reaches the final download move, but that move fails because the generic fetch layer replaces regular files rather than directories. Manifest-specific preparation removes the stale directory before retrieval without changing replacement behavior for packages, catalogs, icons, or other resources.

## Reproduction

I reproduced this with Munki `7.3.0.5790`:

1. Serve a manifest named `policy/conditions` and run an update check so it is cached locally.
2. Replace that repository manifest with `policy/conditions/test_manifest` and include the new name from another manifest.
3. Run another update check.

The client retains this regular file:

```text
/Library/Managed Installs/manifests/policy/conditions
```

The next check needs the same path to be a directory:

```text
/Library/Managed Installs/manifests/policy/conditions/test_manifest
```

The server and load balancer recorded a complete HTTP 200 response for the child manifest while the client produced:

```text
Getting manifest policy/conditions/test_manifest...
Status: 200
ERROR: Could not retrieve manifest policy/conditions/test_manifest from the server: Download error 200: no error
```

Starting from an empty `/Library/Managed Installs` directory did not reproduce the error. Munki created the nested directory and retrieved the same manifest successfully. Restoring the former `policy/conditions` manifest as a regular file reproduced the error consistently.

## Changes

- Make `createMissingDirs()` return `false` when the requested path exists but is not a directory.
- Add manifest-specific destination preparation for both file-to-directory and directory-to-file cache transitions.
- Preserve an existing regular manifest for normal conditional retrieval and replacement.
- Confine recovery to the manifest cache and remove stale cache items with Foundation `FileManager` APIs.
- Replace symlinks below the configured manifest cache root without following them, while preserving administrator-configured path indirection at or above the cache root.
- Leave unsupported path types in place and fail closed rather than removing them.

The manifest-specific removal is intentionally narrow. The generic directory helper does not delete existing files, since it is also used by installer and client-resource paths.

## Tests

Added regression coverage for:

- An existing directory accepted by `createMissingDirs()`.
- An existing regular file rejected by `createMissingDirs()`.
- Replacement of a cached manifest file with the required directory, including when the file is above the immediate destination directory.
- Removal of a cached directory and its descendant manifests when the directory path becomes a manifest file.
- Preservation of an existing regular manifest at the final destination.
- Replacement of symlinks occupying a required parent path or final manifest destination without modifying their targets.
- Replacement of a dangling symlink at the final manifest destination.

The full `munkiCLItesting` Xcode suite passes with its normal parallel test configuration.