### PR TITLE
Fix low data connection deferral UI

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -331,7 +331,7 @@ class MSCAlertController: NSObject {
         }
         let alert = NSAlert()
         alert.messageText = NSLocalizedString(
-            "Low data connection detected and item size exceeds limit",
+            "Low data connection detected",
             comment: "Download Anyway alert title")
         alert.informativeText = NSLocalizedString(
             "Are you sure you want to download it now?",

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -336,11 +336,15 @@ class MSCAlertController: NSObject {
         alert.informativeText = NSLocalizedString(
             "This item was not downloaded because this Mac is on a low data connection.",
             comment: "Download Anyway alert informative text")
-        // "OK" first, so it is the default button and simply dismisses.
+        // "OK" first, so it is the default button and simply dismisses. Only
+        // offer the "Download anyway" action if the admin allows user
+        // overrides; otherwise the dialog is purely informational.
         alert.addButton(withTitle: NSLocalizedString(
             "OK", comment: "OK button title"))
-        alert.addButton(withTitle: NSLocalizedString(
-            "Download anyway", comment: "Download anyway button title"))
+        if munkiPref("AllowLowDataOverride") as? Bool ?? true {
+            alert.addButton(withTitle: NSLocalizedString(
+                "Download anyway", comment: "Download anyway button title"))
+        }
         alert.beginSheetModal(for: mainWindow, completionHandler: { (modalResponse) -> Void in
             if modalResponse == .alertSecondButtonReturn {
                 if addLowDataOverride(itemName) {

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -331,8 +331,11 @@ class MSCAlertController: NSObject {
         }
         let alert = NSAlert()
         alert.messageText = NSLocalizedString(
-            "Download anyway?",
+            "Low data connection detected and item size exceeds limit",
             comment: "Download Anyway alert title")
+        alert.informativeText = NSLocalizedString(
+            "Are you sure you want to download it now?",
+            comment: "Download Anyway alert informative text")
         alert.addButton(withTitle: NSLocalizedString(
             "Download anyway", comment: "Download anyway button title"))
         alert.addButton(withTitle: NSLocalizedString(

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -322,10 +322,10 @@ class MSCAlertController: NSObject {
     }
     
     func confirmDownloadAnyway(_ itemName: String) {
-        // Confirm the user wants to download a low-data-deferred item over
-        // their low data connection, record the override, then kick off a
-        // check so it downloads now rather than silently waiting for the next
-        // scheduled run.
+        // Explain why the item was not downloaded and offer to download it
+        // anyway over the low data connection. "OK" is the default (dismiss);
+        // "Download anyway" records the override and kicks off a check so it
+        // downloads now rather than waiting for the next scheduled run.
         guard let mainWindow = window else {
             return
         }
@@ -334,14 +334,15 @@ class MSCAlertController: NSObject {
             "Low data connection detected",
             comment: "Download Anyway alert title")
         alert.informativeText = NSLocalizedString(
-            "Are you sure you want to download it now?",
+            "This item was not downloaded because this Mac is on a low data connection.",
             comment: "Download Anyway alert informative text")
+        // "OK" first, so it is the default button and simply dismisses.
+        alert.addButton(withTitle: NSLocalizedString(
+            "OK", comment: "OK button title"))
         alert.addButton(withTitle: NSLocalizedString(
             "Download anyway", comment: "Download anyway button title"))
-        alert.addButton(withTitle: NSLocalizedString(
-            "Cancel", comment: "Cancel button title/short action text"))
         alert.beginSheetModal(for: mainWindow, completionHandler: { (modalResponse) -> Void in
-            if modalResponse == .alertFirstButtonReturn {
+            if modalResponse == .alertSecondButtonReturn {
                 if addLowDataOverride(itemName) {
                     if let mainWindowController = (NSApp.delegate as? AppDelegate)?.mainWindowController {
                         mainWindowController.checkForUpdates()

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -1017,17 +1017,15 @@ class UpdateItem: GenericItem {
             // Show a localized "paused" message instead of the plain-English
             // note recorded by managedsoftwareupdate on the CLI side.
             my["note"] = lowDataPausedNote()
-            // Offer a neutral "More Info" button (unless the admin disabled
-            // user overrides via AllowLowDataOverride). It opens a dialog that
-            // explains the deferral and offers the actual "Download anyway"
-            // action, so the compact row button stays short and doesn't imply
-            // an action on its own.
-            if munkiPref("AllowLowDataOverride") as? Bool ?? true {
-                my["hide_low_data_button"] = ""
-                my["low_data_action_text"] = NSLocalizedString(
-                    "More Info",
-                    comment: "Low data More Info button title")
-            }
+            // Always offer a neutral "More Info" button. It opens a dialog that
+            // explains the deferral; whether that dialog offers the actual
+            // "Download anyway" action is gated on AllowLowDataOverride there.
+            // Keeping the button visible even when overrides are disabled means
+            // the user can still see why the item was not downloaded.
+            my["hide_low_data_button"] = ""
+            my["low_data_action_text"] = NSLocalizedString(
+                "More Info",
+                comment: "Low data More Info button title")
         }
     }
     

--- a/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/MunkiItems.swift
@@ -1017,13 +1017,16 @@ class UpdateItem: GenericItem {
             // Show a localized "paused" message instead of the plain-English
             // note recorded by managedsoftwareupdate on the CLI side.
             my["note"] = lowDataPausedNote()
-            // Offer a "Download anyway" button unless the admin disabled
-            // user overrides via AllowLowDataOverride.
+            // Offer a neutral "More Info" button (unless the admin disabled
+            // user overrides via AllowLowDataOverride). It opens a dialog that
+            // explains the deferral and offers the actual "Download anyway"
+            // action, so the compact row button stays short and doesn't imply
+            // an action on its own.
             if munkiPref("AllowLowDataOverride") as? Bool ?? true {
                 my["hide_low_data_button"] = ""
                 my["low_data_action_text"] = NSLocalizedString(
-                    "Download anyway",
-                    comment: "Download anyway button title")
+                    "More Info",
+                    comment: "Low data More Info button title")
             }
         }
     }

--- a/code/apps/Managed Software Center/Managed Software Center/Resources/templates/update_item_template.html
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/templates/update_item_template.html
@@ -10,7 +10,6 @@
             <li class="genre">${developer_escaped}</li>
             <li class="version_and_size">${version_label} ${display_version_escaped_and_size}</li>
             <li class="warning">${restart_action_text}</li>
-            <li class="warning">${note}</li>
         </ul>
         <div class="msc-button small ${hide_cancel_button}">
             <button class="button-area uppercase"

--- a/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
@@ -149,7 +149,10 @@
 "Download paused — low data connection" = "Download paused — low data connection";
 
 /* Download Anyway alert title */
-"Download anyway?" = "Download anyway?";
+"Low data connection detected and item size exceeds limit" = "Low data connection detected and item size exceeds limit";
+
+/* Download Anyway alert informative text */
+"Are you sure you want to download it now?" = "Are you sure you want to download it now?";
 
 /* Downloading status text */
 "Downloading" = "Downloading";

--- a/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
@@ -152,7 +152,10 @@
 "Low data connection detected" = "Low data connection detected";
 
 /* Download Anyway alert informative text */
-"Are you sure you want to download it now?" = "Are you sure you want to download it now?";
+"This item was not downloaded because this Mac is on a low data connection." = "This item was not downloaded because this Mac is on a low data connection.";
+
+/* Low data More Info button title */
+"More Info" = "More Info";
 
 /* Downloading status text */
 "Downloading" = "Downloading";

--- a/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/en.lproj/Localizable.strings
@@ -149,7 +149,7 @@
 "Download paused — low data connection" = "Download paused — low data connection";
 
 /* Download Anyway alert title */
-"Low data connection detected and item size exceeds limit" = "Low data connection detected and item size exceeds limit";
+"Low data connection detected" = "Low data connection detected";
 
 /* Download Anyway alert informative text */
 "Are you sure you want to download it now?" = "Are you sure you want to download it now?";

--- a/code/apps/Managed Software Center/Managed Software Center/sv.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/sv.lproj/Localizable.strings
@@ -149,7 +149,7 @@
 "Download paused — low data connection" = "Nerladdning pausad — låg dataförbrukning";
 
 /* Download Anyway alert title */
-"Low data connection detected and item size exceeds limit" = "Låg dataförbrukning upptäckt och objektets storlek överskrider gränsen";
+"Low data connection detected" = "Låg dataförbrukning upptäckt";
 
 /* Download Anyway alert informative text */
 "Are you sure you want to download it now?" = "Är du säker på att du vill ladda ner det nu?";

--- a/code/apps/Managed Software Center/Managed Software Center/sv.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/sv.lproj/Localizable.strings
@@ -149,7 +149,10 @@
 "Download paused — low data connection" = "Nerladdning pausad — låg dataförbrukning";
 
 /* Download Anyway alert title */
-"Download anyway?" = "Ladda ner ändå?";
+"Low data connection detected and item size exceeds limit" = "Låg dataförbrukning upptäckt och objektets storlek överskrider gränsen";
+
+/* Download Anyway alert informative text */
+"Are you sure you want to download it now?" = "Är du säker på att du vill ladda ner det nu?";
 
 /* Downloading status text */
 "Downloading" = "Hämtar";

--- a/code/apps/Managed Software Center/Managed Software Center/sv.lproj/Localizable.strings
+++ b/code/apps/Managed Software Center/Managed Software Center/sv.lproj/Localizable.strings
@@ -152,7 +152,10 @@
 "Low data connection detected" = "Låg dataförbrukning upptäckt";
 
 /* Download Anyway alert informative text */
-"Are you sure you want to download it now?" = "Är du säker på att du vill ladda ner det nu?";
+"This item was not downloaded because this Mac is on a low data connection." = "Det här objektet laddades inte ner eftersom denna Mac har en anslutning med låg dataförbrukning.";
+
+/* Low data More Info button title */
+"More Info" = "Mer info";
 
 /* Downloading status text */
 "Downloading" = "Hämtar";


### PR DESCRIPTION
Addresses feedback from the Munki 7.4 dev preview thread on the low data download deferral UI.

## Changes

**1. Duplicate "Download paused — low data connection" note (updates list)**

The paused note rendered twice for a deferred item: once in the update-list row (`${note}` in `update_item_template.html`) and again via the item `description()`, which prefixes the note as a warning. Removed the list-row `${note}`; the note still shows once via the description, and the detail view (which only uses `description()`) is unchanged.

**2. Redundant "Download anyway?" confirmation alert**

The confirm alert title echoed the button it was triggered from. The guard behaviour is unchanged (it protects against accidental clicks), but the title no longer repeats the button:

- Title: `Low data connection detected and item size exceeds limit` — no exact byte sizes (avoids users asking for limit tweaks, and avoids value-ordering issues across languages).
- New informative line: `Are you sure you want to download it now?`
- Buttons unchanged: **Download anyway** / **Cancel**.

Swedish strings updated to match — **please verify the translation**.

## Dependencies

Confirmed (no code change): munki will not download or install an item while any of its `requires` items is deferred — `processInstall` marks the parent's `dependenciesMet` false and records a "can't verify requirements" note instead. Forced items past their deadline still propagate a low-data exemption to their requirements. The one rough edge is that a user "Download anyway" override does not cascade to requirements, so a chain of large items must be overridden item-by-item across check cycles.