### PR TITLE
Log the error domain and code when a download fails

### DIFF
--- a/code/cli/munki/shared/network/fetch.swift
+++ b/code/cli/munki/shared/network/fetch.swift
@@ -292,8 +292,18 @@ func getURL(
             errorDescription = urlError.localizedDescription
             display.detail("Download error \(errorCode): \(errorDescription)")
         } else {
+            // not a URLError -- most usefully a POSIX errno from the socket
+            // layer, so report the domain and code and not just the
+            // description, which on its own can be very misleading
+            errorCode = error.code
             errorDescription = error.localizedDescription
-            display.detail("Download error: \(errorDescription)")
+            display.detail("Download error \(error.domain) \(errorCode): \(errorDescription)")
+        }
+        if let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError {
+            display.detail(
+                "Underlying error \(underlyingError.domain) \(underlyingError.code): " +
+                    "\(underlyingError.localizedDescription)"
+            )
         }
         if session.SSLerror != 0 {
             errorCode = session.SSLerror


### PR DESCRIPTION
A download failure that isn't a `URLError` logs only its `localizedDescription`, and `FetchError.connection` carries a placeholder code of `0`, so both the domain and the real errno are lost. When a machine runs out of ephemeral ports and `connect()` returns POSIX `EEXIST`, the run reports:

```
ERROR: Could not retrieve catalog Production from server: Connection error 0: The operation couldn't be completed. File exists
```

That reads like a filesystem problem, and it sends you looking at the local cache and the download path rather than at the socket layer. With the domain and code in the line it identifies itself as `NSPOSIXErrorDomain 17` and the search starts in the right place.

This reports the domain and code for non-`URLError` failures, carries the real code into `FetchError.connection` in place of `0`, and logs any `NSUnderlyingError`. `URLError` handling and the SSL branch are untouched.

Builds and runs clean against a live repo; the improved line itself was written from the error object rather than captured on a live failure, since the machines that were failing have since drifted back under the port limit.
