### PR TITLE
Fix low-data 'More Info' button label wrapping at narrow window width

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/base.css
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/base.css
@@ -682,6 +682,7 @@ div.msc-button-inner {
     -webkit-border-radius: 12px;
     background: var(--small-btn-background);
     text-transform: uppercase;
+    white-space: nowrap;
     color: var(--small-button-text-color-enabled);
     font: normal normal bold 10px/14px 'Helvetica';
     padding-left: 10px;

--- a/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/updates.css
+++ b/code/apps/Managed Software Center/Managed Software Center/Resources/WebResources/updates.css
@@ -516,6 +516,7 @@ div.lockup .row2 {
 
 div.lockup .row1 .list {
     flex-grow: 1;
+    min-width: 0;
     border-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes the low-data "More Info" (paused) button label wrapping and spilling out of the fixed-height (24px) pill when an update row is squeezed at a narrow window width.

The label and the app-name column share the update row via flexbox. When a row's secondary line carries a long, unbreakable token (e.g. a version like `128.0.6613.120`), that column's minimum width grows and crowds the button into a space narrower than the one-line label, so the label wraps — and because the pill is a fixed 24px tall, the second line spills out below the rounded background. It only hits whichever rows have the longest neighbouring content, which is why not every row shows it.

## Fix

- `base.css` — `white-space: nowrap` on `.msc-button-inner` so a multi-word (or longer localized) label stays on one line.
- `updates.css` — `min-width: 0` on `.row1 .list` so the text column can shrink and yield space (its version line ellipsizes) instead of forcing the button to wrap.

This is a general layout guard, not a per-string workaround — it holds for every locale and every small-button label.

## Testing

Built and driven in the real Managed Software Center app at its minimum window width with several pending low-data-deferred updates, in English. Before the fix the row with the longest version string wrapped "MORE / INFO"; after, all rows keep the label on one line.

### Before
![before](https://raw.githubusercontent.com/grahamgilbert/munki/pr-assets/pr-assets/msc-en-before.png)

### After
![after](https://raw.githubusercontent.com/grahamgilbert/munki/pr-assets/pr-assets/msc-en-after.png)
