### PR TITLE
Treat a missing application usage table as no data instead of an error

### DIFF
--- a/code/cli/munki/shared/appusage.swift
+++ b/code/cli/munki/shared/appusage.swift
@@ -233,7 +233,7 @@ class ApplicationUsageQuery {
         do {
             try conn = SQL3Connection(db)
         } catch {
-            logger.error("Error connecting to \(db): \(error.localizedDescription)")
+            logger.error("Error connecting to \(db): \(error)")
             conn = nil
         }
     }
@@ -242,6 +242,29 @@ class ApplicationUsageQuery {
     deinit {
         if let conn {
             try? conn.close()
+        }
+    }
+
+    /// Returns true if the error is sqlite3 reporting that a table does not exist.
+    /// Both tables in this database are created lazily by ApplicationUsageRecorder:
+    /// application_usage the first time an app launch or quit is recorded, and
+    /// install_requests the first time the user makes a self-service install or
+    /// removal request. A table that has not been created yet means "nothing has
+    /// been recorded", not "the database is broken".
+    func isMissingTableError(_ error: Error) -> Bool {
+        guard let sqlError = error as? SQL3Error else { return false }
+        return sqlError.description.hasPrefix("Could not prepare statement: no such table:")
+    }
+
+    /// Log a failed query. A table that does not exist yet is an expected state
+    /// and not worth an error-level message.
+    /// SQL3Error does not adopt LocalizedError, so localizedDescription would
+    /// discard the message sqlite3 gave us; interpolate the error instead.
+    func logQueryFailure(_ error: Error) {
+        if isMissingTableError(error) {
+            logger.debug("No data yet in \(db): \(error)")
+        } else {
+            logger.error("Error querying \(db): \(error)")
         }
     }
 
@@ -260,14 +283,16 @@ class ApplicationUsageQuery {
                 return Int(timeDiff / dayInSeconds)
             }
         } catch {
-            logger.error("Error querying \(db): \(error.localizedDescription)")
+            logQueryFailure(error)
         }
         return 0
     }
 
     /// Perform db query and return the number of days since the last event
     /// occurred for bundle_id.
-    /// Returns -2 if database is missing or broken;
+    /// Returns -2 if database is missing or broken, which includes the
+    /// application_usage table not existing yet -- no usage has been recorded
+    /// at all, so we report "no data" rather than "not used recently";
     /// Returns -1 if there is no event record for the bundle_id
     /// Returns int number of days since last event otherwise
     func daysSinceLastUsageEvent(_ event: String, bundleID: String) -> Int {
@@ -288,7 +313,7 @@ class ApplicationUsageQuery {
                 return -1
             }
         } catch {
-            logger.error("Error querying \(db): \(error.localizedDescription)")
+            logQueryFailure(error)
             return -2
         }
     }
@@ -296,7 +321,10 @@ class ApplicationUsageQuery {
     /// Perform db query and return the number of days since the last
     /// install request occurred for itemName..
     /// Returns -2 if database is missing or broken;
-    /// Returns -1 if there are no matching records for the itemName
+    /// Returns -1 if there are no matching records for the itemName, which
+    /// includes the install_requests table not existing yet -- it is created
+    /// the first time the user makes a self-service request, so its absence
+    /// means no install requests have ever been made;
     /// Returns int number of days since last event otherwise
     func daysSinceLastInstallEvent(_ event: String, itemName: String) -> Int {
         guard let connection = conn else { return -2 }
@@ -316,8 +344,8 @@ class ApplicationUsageQuery {
                 return -1
             }
         } catch {
-            logger.error("Error querying \(db): \(error.localizedDescription)")
-            return -2
+            logQueryFailure(error)
+            return isMissingTableError(error) ? -1 : -2
         }
     }
 }


### PR DESCRIPTION
**The claim:** on any Mac where nobody has ever clicked Install or Remove in Managed Software Center, every run of `managedsoftwareupdate` logs one ERROR per installed optional item that carries `unused_software_removal_info`. The condition is an expected state, not a fault, and the message does not say what actually happened.

**What is wrong**

`shouldBeRemovedIfUnused()` runs for every currently installed optional install that has `unused_software_removal_info`. Its second step calls `daysSinceLastInstallEvent()`, which prepares

```
SELECT last_time FROM install_requests WHERE event=? AND item_name=?
```

`install_requests` is created lazily by `ApplicationUsageRecorder.log_install_request()`, the first time somebody makes a self-service request in MSC. Until then the table does not exist, `sqlite3_prepare` fails with `no such table: install_requests`, and `ApplicationUsageQuery` reports it at error level.

The text is also unhelpful. `SQL3Error` does not adopt `LocalizedError`, so `localizedDescription` throws away the sqlite3 message and substitutes Foundation's placeholder. The `error 1` is Swift's default code for a non-`LocalizedError`, not `SQLITE_ERROR`. Interpolating the error itself gives the real message.

**How to reproduce**

1. A Mac with Munki 7.3.0 (or current `Munki7_4dev`) where MSC has never been used to install or remove anything, so `/Library/Managed Installs/application_usage.sqlite` has an `application_usage` table but no `install_requests` table. Confirm with `sqlite3 application_usage.sqlite .tables`.
2. Have at least one optional install that is currently installed and has `unused_software_removal_info` with `removal_days` smaller than the days of usage data on the machine.
3. Run `sudo managedsoftwareupdate --checkonly`.

**Before**

```
ERROR: Error querying /Library/Managed Installs/application_usage.sqlite: The operation couldn't be completed. (managedsoftwareupdate.SQL3Error error 1.)
```

once per such item, every run.

**After**

Nothing at the default log level. With `-vv`:

```
No data yet in /Library/Managed Installs/application_usage.sqlite: Could not prepare statement: no such table: install_requests
```

A genuine query failure still logs at error level, now as `Error querying <db>: Could not prepare statement: <sqlite3 message>`.

**What the change does**

Detects the missing-table case with the same prefix match `_detect_table` in `ApplicationUsageRecorder` already uses, logs it at debug level, and returns the documented no-data value: `-1` from `daysSinceLastInstallEvent`, since the table's absence proves no install request has ever been recorded, and `-2` from `daysSinceLastUsageEvent`, which stays conservative because no usage data exists at all. Removal decisions do not change: the caller tests `daysSinceInstallRequest >= 0`, so `-1` and `-2` fall through identically. One file, 21 lines of code, the rest is comments.

**Versions**

Present in 7.3.0 and `Munki7_4dev`. The Python implementation created `install_requests` lazily too and caught the same exception, but `str(err)` carried the real sqlite3 text, so the port lost the message rather than introduced the condition.

Discussion in MacAdmins Slack: https://macadmins.slack.com/archives/C04QVPFGU/p1784744636360719

Running in our fleet since late July. The error lines are gone from every run and the unused-software check behaves as before.
