### PR TITLE
Merge configured blocking applications

### DIFF
--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCAlertController.swift
@@ -591,15 +591,7 @@ class MSCAlertController: NSObject {
         }
         var apps_to_check = [String]()
         for update_item in getUpdateList() {
-            if let blocking_apps = update_item["blocking_applications"] as? [String] {
-                apps_to_check += blocking_apps
-            } else if let installs_items = update_item["installs"] as? [PlistDict] {
-                let installs_apps = installs_items.filter(
-                    { ($0["type"] as? String ?? "" == "application" &&
-                        !($0["path"] as? String ?? "").isEmpty) }).map(
-                            { ($0["path"] as? NSString ?? "").lastPathComponent })
-                apps_to_check += installs_apps
-            }
+            apps_to_check += blockingApplicationsForItem(update_item.my)
         }
         let running_apps = getRunningBlockingApps(apps_to_check)
         if running_apps.isEmpty {

--- a/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/Controllers/MSCBlockingAppsController.swift
@@ -75,17 +75,15 @@ class MSCBlockingAppsController: NSObject {
     private let forceQuitDelay: TimeInterval = 5.0
 
     // Manual quit tracking - apps that cannot/should not be quit by us
-    private var manualQuitAppNames: Set<String> = [] // app names that require manual quit
     private var manualQuitAppPaths: Set<String> = [] // app paths that require manual quit
 
-    // Custom quit script tracking - maps app names to their quit scripts
-    private var appQuitScripts: [String: String] = [:] // keyed by app name (e.g. "Safari.app")
+    // Custom quit script tracking - maps resolved app paths to their quit scripts
+    private var appQuitScripts: [String: String] = [:]
 
     // Launch arguments for reopening apps, keyed by resolved app bundle path
     private var appLaunchArguments: [String: [String]] = [:]
 
     // Removal tracking - apps being removed shouldn't be reopened
-    private var appsBeingRemovedNames: Set<String> = [] // app names being removed
     private var appsBeingRemovedPaths: Set<String> = [] // app paths being removed
 
     // Non-bundle executable tracking - executables that are not .app bundles
@@ -134,10 +132,10 @@ class MSCBlockingAppsController: NSObject {
 
         // Gather apps to check from update list
         appsToCheck = []
-        manualQuitAppNames = []
+        manualQuitAppPaths = []
         appQuitScripts = [:]
         appLaunchArguments = [:]
-        appsBeingRemovedNames = []
+        appsBeingRemovedPaths = []
         nonBundleExecutablePaths = []
 
         var running_apps: [BlockingAppInfo] = []
@@ -164,49 +162,51 @@ class MSCBlockingAppsController: NSObject {
                 // this item has no blocking apps or none are running
                 nonBlockedItemsPending = true
             } else {
-                running_apps += runningBlockingApps
+                for app in runningBlockingApps where !running_apps.contains(where: {
+                    $0.user == app.user && $0.pathname == app.pathname
+                }) {
+                    running_apps.append(app)
+                }
             }
 
             // Track apps that require manual quit
             if manualQuit {
-                for appName in itemBlockingApps {
-                    manualQuitAppNames.insert(appName)
+                for app in runningBlockingApps {
+                    manualQuitAppPaths.insert(app.pathname)
                 }
             }
 
             // Track apps that are being removed (shouldn't be reopened)
             if isBeingRemoved {
-                for appName in itemBlockingApps {
-                    appsBeingRemovedNames.insert(appName)
-                    msc_debug_log("App is being removed, won't reopen: \(appName)")
+                for app in runningBlockingApps {
+                    appsBeingRemovedPaths.insert(app.pathname)
+                    msc_debug_log("App is being removed, won't reopen: \(app.pathname)")
                 }
             }
 
             // Track custom quit scripts for blocking apps
             if let quitScript = update_item["blocking_applications_quit_script"] as? String {
-                for appName in itemBlockingApps {
-                    appQuitScripts[appName] = quitScript
-                    msc_debug_log("Found blocking_applications_quit_script for \(appName)")
+                for app in runningBlockingApps {
+                    appQuitScripts[app.pathname] = quitScript
+                    msc_debug_log("Found blocking_applications_quit_script for \(app.pathname)")
                 }
             }
 
-            if let launchArgumentMappings = update_item["blocking_applications_launch_args"] as? [String: Any] {
-                let itemAppPaths = Set(runningBlockingApps.map(\.pathname).filter {
-                    $0.hasSuffix(".app")
-                })
+            if let launchArgumentMappings = update_item["blocking_applications_with_launch_args"] as? [String: Any] {
                 for appIdentifier in launchArgumentMappings.keys.sorted() {
                     guard let launchArguments = launchArgumentMappings[appIdentifier] as? [String] else {
                         msc_debug_log(
-                            "Ignoring invalid blocking_applications_launch_args for \(appIdentifier)"
+                            "Ignoring invalid blocking_applications_with_launch_args for \(appIdentifier)"
                         )
                         continue
                     }
                     let appPaths = Array(Set(
                         getRunningBlockingApps([appIdentifier]).map(\.pathname)
-                    ).intersection(itemAppPaths)).sorted()
+                            .filter { $0.hasSuffix(".app") }
+                    )).sorted()
                     if appPaths.isEmpty {
                         msc_debug_log(
-                            "Ignoring blocking_applications_launch_args for non-blocking application \(appIdentifier)"
+                            "Ignoring blocking_applications_with_launch_args for non-application blocker \(appIdentifier)"
                         )
                         continue
                     }
@@ -217,11 +217,11 @@ class MSCBlockingAppsController: NSObject {
                         in: &appLaunchArguments
                     )
                     for appPath in configuredApps {
-                        msc_debug_log("Found blocking_applications_launch_args for \(appPath)")
+                        msc_debug_log("Found blocking_applications_with_launch_args for \(appPath)")
                     }
                     for appPath in conflicts {
                         msc_debug_log(
-                            "Ignoring conflicting blocking_applications_launch_args for \(appPath)"
+                            "Ignoring conflicting blocking_applications_with_launch_args for \(appPath)"
                         )
                     }
                 }
@@ -251,13 +251,11 @@ class MSCBlockingAppsController: NSObject {
 
         // Build a set of unique apps with their paths for icon lookup
         var uniqueApps = [(displayName: String, path: String)]()
-        var seenNames = Set<String>()
-        manualQuitAppPaths = []
-        appsBeingRemovedPaths = []
+        var seenPaths = Set<String>()
         for app in my_apps {
             let displayName = (app.display_name as NSString).deletingPathExtension
-            if !displayName.isEmpty, !seenNames.contains(displayName) {
-                seenNames.insert(displayName)
+            if !displayName.isEmpty, !seenPaths.contains(app.pathname) {
+                seenPaths.insert(app.pathname)
                 var appPath = app.pathname
                 if !appPath.isEmpty {
                     while !appPath.isEmpty, appPath != "/", !appPath.hasSuffix(".app") {
@@ -271,17 +269,11 @@ class MSCBlockingAppsController: NSObject {
                 }
                 uniqueApps.append((displayName: displayName, path: appPath))
 
-                // Check if this app requires manual quit or is being removed
-                if !appPath.isEmpty {
-                    let appFileName = (appPath as NSString).lastPathComponent
-                    if manualQuitAppNames.contains(appFileName) {
-                        manualQuitAppPaths.insert(appPath)
-                        msc_debug_log("App requires manual quit: \(displayName) at \(appPath)")
-                    }
-                    if appsBeingRemovedNames.contains(appFileName) {
-                        appsBeingRemovedPaths.insert(appPath)
-                        msc_debug_log("App is being removed: \(displayName) at \(appPath)")
-                    }
+                if manualQuitAppPaths.contains(appPath) {
+                    msc_debug_log("App requires manual quit: \(displayName) at \(appPath)")
+                }
+                if appsBeingRemovedPaths.contains(appPath) {
+                    msc_debug_log("App is being removed: \(displayName) at \(appPath)")
                 }
             }
         }
@@ -1013,10 +1005,8 @@ class MSCBlockingAppsController: NSObject {
         appsToCheck = []
         blockingAppsStackView = nil
         closedApps = []
-        manualQuitAppNames = []
         manualQuitAppPaths = []
         appQuitScripts = [:]
-        appsBeingRemovedNames = []
         appsBeingRemovedPaths = []
         nonBundleExecutablePaths = []
         reopenCheckbox = nil
@@ -1121,8 +1111,7 @@ class MSCBlockingAppsController: NSObject {
                 }
 
                 // Check for custom quit script
-                let appFileName = (app.path as NSString).lastPathComponent
-                if let quitScript = appQuitScripts[appFileName] {
+                if let quitScript = appQuitScripts[app.path] {
                     // Run the custom quit script instead of default termination
                     msc_debug_log("Running blocking_applications_quit_script for \(app.displayName)")
                     DispatchQueue.global(qos: .userInitiated).async {

--- a/code/apps/Managed Software Center/Managed Software Center/munki.swift
+++ b/code/apps/Managed Software Center/Managed Software Center/munki.swift
@@ -784,20 +784,20 @@ func getRunningBlockingApps(_ appnames: [String]) -> [BlockingAppInfo] {
 
 /// returns a list of blocking_applications for pkginfo item
 func blockingApplicationsForItem(_ pkginfo: PlistDict) -> [String] {
-    if let blockingApplications = pkginfo["blocking_applications"] as? [String] {
-        return blockingApplications
-    } else {
-        // if no blocking_applications specified, get appnames
-        // from 'installs' list if it exists
-        if let installs = pkginfo["installs"] as? [PlistDict] {
-            let apps = installs.filter {
-                $0["type"] as? String ?? "" == "application"
-            }
-            let appNames = apps.map {
-                ($0["path"] as? NSString)?.lastPathComponent ?? ""
-            }.filter { !$0.isEmpty }
-            return appNames
+    let blockingApplications = pkginfo["blocking_applications"] as? [String]
+    let configuredApplications = pkginfo["blocking_applications_with_launch_args"] as? [String: Any]
+    if blockingApplications != nil || configuredApplications != nil {
+        return Array(Set((blockingApplications ?? []) + (configuredApplications?.keys.map { $0 } ?? []))).sorted()
+    }
+    // if no explicit blocking applications are specified, get appnames
+    // from 'installs' list if it exists
+    if let installs = pkginfo["installs"] as? [PlistDict] {
+        let apps = installs.filter {
+            $0["type"] as? String ?? "" == "application"
         }
+        return apps.map {
+            ($0["path"] as? NSString)?.lastPathComponent ?? ""
+        }.filter { !$0.isEmpty }
     }
     return []
 }

--- a/code/cli/munki/Package.swift
+++ b/code/cli/munki/Package.swift
@@ -47,6 +47,7 @@ let package = Package(
                 "shared/authrestart.swift",
                 "shared/authrestartclient.swift",
                 "shared/BlockingApplications.swift",
+                "shared/BlockingApplicationMetadata.swift",
                 "shared/bootstrapping.swift",
                 "shared/display.swift",
                 "shared/facts.swift",

--- a/code/cli/munki/munki.xcodeproj/project.pbxproj
+++ b/code/cli/munki/munki.xcodeproj/project.pbxproj
@@ -270,6 +270,9 @@
 		C0684E3B2DC131750091E774 /* UNIXProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06C21392C88CA1F0023E9D9 /* UNIXProcessInfo.swift */; };
 		C0684E3D2DC19C7A0091E774 /* BlockingApplications.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0684E3C2DC19C7A0091E774 /* BlockingApplications.swift */; };
 		C0684E3E2DC19C7A0091E774 /* BlockingApplications.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0684E3C2DC19C7A0091E774 /* BlockingApplications.swift */; };
+		C0AD97002F61A0000029A293 /* BlockingApplicationMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD97032F61A0000029A293 /* BlockingApplicationMetadata.swift */; };
+		C0AD97012F61A0000029A293 /* BlockingApplicationMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD97032F61A0000029A293 /* BlockingApplicationMetadata.swift */; };
+		C0AD97022F61A0000029A293 /* BlockingApplicationMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AD97032F61A0000029A293 /* BlockingApplicationMetadata.swift */; };
 		C0684E432DC580850091E774 /* dmgutils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01364532C321FE7008DB215 /* dmgutils.swift */; };
 		C0684E442DC585560091E774 /* osutils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07074E42C34910F00B86310 /* osutils.swift */; };
 		C0684E452DC585FC0091E774 /* info.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0209B882C63DDF1007664A0 /* info.swift */; };
@@ -805,6 +808,7 @@
 		C0684DD12DBFDBD20091E774 /* precache_agent */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = precache_agent; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0684E2D2DC040450091E774 /* installhelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = installhelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0684E3C2DC19C7A0091E774 /* BlockingApplications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockingApplications.swift; sourceTree = "<group>"; };
+		C0AD97032F61A0000029A293 /* BlockingApplicationMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockingApplicationMetadata.swift; sourceTree = "<group>"; };
 		C0684E472DC586660091E774 /* osinstallerinfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = osinstallerinfo.swift; sourceTree = "<group>"; };
 		C0684E542DC735960091E774 /* Testing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Testing.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework; sourceTree = DEVELOPER_DIR; };
 		C0684E5C2DC736EE0091E774 /* munkiCLItesting.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = munkiCLItesting.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1255,6 +1259,7 @@
 				C0B7FA002D288C2700CC14F0 /* authrestart.swift */,
 				C005199A2D2A28510060DDB6 /* authrestartclient.swift */,
 				C0684E3C2DC19C7A0091E774 /* BlockingApplications.swift */,
+				C0AD97032F61A0000029A293 /* BlockingApplicationMetadata.swift */,
 				C06C21332C8793720023E9D9 /* bootstrapping.swift */,
 				C07A6FB12C2B22D300090743 /* constants.swift */,
 				C01364572C3265D6008DB215 /* display.swift */,
@@ -2201,6 +2206,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0AD97002F61A0000029A293 /* BlockingApplicationMetadata.swift in Sources */,
 				C0684E9B2DC7E5700091E774 /* manifests.swift in Sources */,
 				C0684E6C2DC73C150091E774 /* plistutils.swift in Sources */,
 				C058EF7F2DCF9FB0002775E0 /* MiddlewareProtocol.swift in Sources */,
@@ -2311,6 +2317,7 @@
 				C00519A92D2A5C180060DDB6 /* authrestartclient.swift in Sources */,
 				C01792D32C6BC81B008CBC22 /* fetch.swift in Sources */,
 				C0684E3D2DC19C7A0091E774 /* BlockingApplications.swift in Sources */,
+				C0AD97012F61A0000029A293 /* BlockingApplicationMetadata.swift in Sources */,
 				C07AED662C66D0A000DE6119 /* facts.swift in Sources */,
 				C030A98F2C39C135007F0B34 /* munkihash.swift in Sources */,
 				C07AED722C67F77000DE6119 /* sslerrors.swift in Sources */,
@@ -2432,6 +2439,7 @@
 				C07AED6C2C66F56C00DE6119 /* manifests.swift in Sources */,
 				C07074E62C34910F00B86310 /* osutils.swift in Sources */,
 				C0684E3E2DC19C7A0091E774 /* BlockingApplications.swift in Sources */,
+				C0AD97022F61A0000029A293 /* BlockingApplicationMetadata.swift in Sources */,
 				C030A9C12C419565007F0B34 /* osinstaller.swift in Sources */,
 				C06C21352C8793720023E9D9 /* bootstrapping.swift in Sources */,
 				C0D9C2B12C62D4120019A067 /* powermanager.swift in Sources */,

--- a/code/cli/munki/munkiCLItesting/analyzeTests.swift
+++ b/code/cli/munki/munkiCLItesting/analyzeTests.swift
@@ -22,7 +22,7 @@ import Testing
 struct assistedQuitMetadataTests {
     @Test func copiesLaunchArguments() {
         let pkginfo: PlistDict = [
-            "blocking_applications_launch_args": [
+            "blocking_applications_with_launch_args": [
                 "Google Chrome.app": [
                     "--restore-last-session",
                     "--profile-directory=Profile With Spaces",
@@ -33,7 +33,7 @@ struct assistedQuitMetadataTests {
 
         copyAssistedQuitMetadata(from: pkginfo, to: &processedItem)
 
-        let launchArguments = processedItem["blocking_applications_launch_args"] as? PlistDict
+        let launchArguments = processedItem["blocking_applications_with_launch_args"] as? PlistDict
         #expect(launchArguments?["Google Chrome.app"] as? [String] == [
             "--restore-last-session",
             "--profile-directory=Profile With Spaces",
@@ -44,7 +44,7 @@ struct assistedQuitMetadataTests {
         let pkginfo: PlistDict = [
             "blocking_applications_manual_quit_only": true,
             "blocking_applications_quit_script": "#!/bin/sh\nexit 0",
-            "blocking_applications_launch_args": [
+            "blocking_applications_with_launch_args": [
                 "Google Chrome.app": ["--restore-last-session"],
             ],
         ]
@@ -54,7 +54,7 @@ struct assistedQuitMetadataTests {
 
         #expect(processedItem["blocking_applications_manual_quit_only"] as? Bool == true)
         #expect(processedItem["blocking_applications_quit_script"] as? String == "#!/bin/sh\nexit 0")
-        let launchArguments = processedItem["blocking_applications_launch_args"] as? PlistDict
+        let launchArguments = processedItem["blocking_applications_with_launch_args"] as? PlistDict
         #expect(launchArguments?["Google Chrome.app"] as? [String] == ["--restore-last-session"])
     }
 
@@ -63,8 +63,85 @@ struct assistedQuitMetadataTests {
 
         copyAssistedQuitMetadata(from: [:], to: &processedItem)
 
-        #expect(processedItem["blocking_applications_launch_args"] == nil)
+        #expect(processedItem["blocking_applications_with_launch_args"] == nil)
         #expect(processedItem["name"] as? String == "GoogleChrome")
+    }
+}
+
+struct blockingApplicationsForItemTests {
+    @Test func combinesExplicitBlockerSources() {
+        let pkginfo: PlistDict = [
+            "blocking_applications": ["Firefox.app", "Google Chrome.app"],
+            "blocking_applications_with_launch_args": [
+                "Google Chrome.app": ["--restore-last-session"],
+                "Safari.app": [],
+            ],
+        ]
+
+        #expect(blockingApplicationsForItem(pkginfo) == [
+            "Firefox.app",
+            "Google Chrome.app",
+            "Safari.app",
+        ])
+    }
+
+    @Test func malformedArgumentsStillDeclareBlocker() {
+        let pkginfo: PlistDict = [
+            "blocking_applications_with_launch_args": [
+                "Google Chrome.app": "--restore-last-session",
+            ],
+        ]
+
+        #expect(blockingApplicationsForItem(pkginfo) == ["Google Chrome.app"])
+    }
+
+    @Test func explicitBlockersSuppressInstallsInference() {
+        let pkginfo: PlistDict = [
+            "blocking_applications_with_launch_args": [
+                "Google Chrome.app": ["--restore-last-session"],
+            ],
+            "installs": [[
+                "type": "application",
+                "path": "/Applications/Safari.app",
+            ]],
+        ]
+
+        #expect(blockingApplicationsForItem(pkginfo) == ["Google Chrome.app"])
+    }
+
+    @Test func infersBlockersWhenExplicitSourcesAreAbsent() {
+        let pkginfo: PlistDict = [
+            "installs": [[
+                "type": "application",
+                "path": "/Applications/Safari.app",
+            ]],
+        ]
+
+        #expect(blockingApplicationsForItem(pkginfo) == ["Safari.app"])
+    }
+
+    @Test func emptyExplicitSourceSuppressesInstallsInference() {
+        let pkginfo: PlistDict = [
+            "blocking_applications_with_launch_args": [:],
+            "installs": [[
+                "type": "application",
+                "path": "/Applications/Safari.app",
+            ]],
+        ]
+
+        #expect(blockingApplicationsForItem(pkginfo).isEmpty)
+    }
+
+    @Test func invalidConfiguredBlockersAllowInstallsInference() {
+        let pkginfo: PlistDict = [
+            "blocking_applications_with_launch_args": ["Google Chrome.app"],
+            "installs": [[
+                "type": "application",
+                "path": "/Applications/Safari.app",
+            ]],
+        ]
+
+        #expect(blockingApplicationsForItem(pkginfo) == ["Safari.app"])
     }
 }
 

--- a/code/cli/munki/shared/BlockingApplicationMetadata.swift
+++ b/code/cli/munki/shared/BlockingApplicationMetadata.swift
@@ -1,0 +1,36 @@
+//
+//  BlockingApplicationMetadata.swift
+//  munki
+//
+//  Copyright 2026 The Munki Project. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+func blockingApplicationsForItem(_ pkginfo: PlistDict) -> [String] {
+    let blockingApplications = pkginfo["blocking_applications"] as? [String]
+    let configuredApplications = pkginfo["blocking_applications_with_launch_args"] as? [String: Any]
+    if blockingApplications != nil || configuredApplications != nil {
+        return Array(Set((blockingApplications ?? []) + (configuredApplications?.keys.map { $0 } ?? []))).sorted()
+    }
+    if let installs = pkginfo["installs"] as? [PlistDict] {
+        return installs.filter {
+            $0["type"] as? String ?? "" == "application"
+        }.map {
+            ($0["path"] as? NSString)?.lastPathComponent ?? ""
+        }.filter { !$0.isEmpty }
+    }
+    return []
+}

--- a/code/cli/munki/shared/BlockingApplications.swift
+++ b/code/cli/munki/shared/BlockingApplications.swift
@@ -55,21 +55,7 @@ func isAppRunning(_ appName: String) -> Bool {
 /// or, if there is no blocking_applications list, true if any application in the installs list is running.
 func blockingApplicationsRunning(_ pkginfo: PlistDict) -> Bool {
     let display = DisplayAndLog.main
-    var appNames = [String]()
-    if let blockingApplications = pkginfo["blocking_applications"] as? [String] {
-        appNames = blockingApplications
-    } else {
-        // if no blocking_applications specified, get appnames
-        // from 'installs' list if it exists
-        if let installs = pkginfo["installs"] as? [PlistDict] {
-            let apps = installs.filter {
-                $0["type"] as? String ?? "" == "application"
-            }
-            appNames = apps.map {
-                ($0["path"] as? NSString)?.lastPathComponent ?? ""
-            }.filter { !$0.isEmpty }
-        }
-    }
+    let appNames = blockingApplicationsForItem(pkginfo)
     display.debug1("Checking for \(appNames)")
     let runningApps = appNames.filter { isAppRunning($0) }
     if !runningApps.isEmpty {

--- a/code/cli/munki/shared/updatecheck/analyze.swift
+++ b/code/cli/munki/shared/updatecheck/analyze.swift
@@ -27,7 +27,7 @@ import Foundation
 let assistedQuitPkginfoKeys = [
     "blocking_applications_manual_quit_only",
     "blocking_applications_quit_script",
-    "blocking_applications_launch_args",
+    "blocking_applications_with_launch_args",
 ]
 
 func copyAssistedQuitMetadata(from pkginfo: PlistDict, to item: inout PlistDict) {


### PR DESCRIPTION
This is a follow-up to [#1379](https://github.com/munki/munki/pull/1379) and [#1381](https://github.com/munki/munki/pull/1381), based on [Greg's follow-up comment](https://github.com/munki/munki/pull/1381#issuecomment-5593078051).

#1381 changed `blocking_applications_launch_args` from an array to a dictionary keyed by application identifier. This correctly associates arguments with individual applications, but requires an application with launch arguments to also appear in `blocking_applications`.

For example, Chrome is repeated here:

```xml
<key>blocking_applications</key>
<array>
    <string>Google Chrome.app</string>
    <string>Firefox.app</string>
</array>
<key>blocking_applications_launch_args</key>
<dict>
    <key>Google Chrome.app</key>
    <array>
        <string>--restore-last-session</string>
    </array>
</dict>
```

Since neither schema introduced by #1379 or #1381 has shipped, Greg and I agreed to replace the current key rather than retain that repetition. We also agreed to keep `blocking_applications` as an array instead of allowing multiple types under the established key.

## Changes
This replaces `blocking_applications_launch_args` with `blocking_applications_with_launch_args`. The dictionary keys are blocking applications. Munki merges them with the strings in `blocking_applications`, so an application with launch arguments does not need to be specified twice:

```xml
<key>blocking_applications</key>
<array>
    <string>Firefox.app</string>
</array>
<key>blocking_applications_with_launch_args</key>
<dict>
    <key>Google Chrome.app</key>
    <array>
        <string>--restore-last-session</string>
    </array>
</dict>
```

In this example, both Firefox and Chrome block the update. Chrome receives `--restore-last-session` if Managed Software Center closes and reopens it. Firefox reopens without additional arguments. A pkginfo with only a configured blocker is also valid:

```xml
<key>blocking_applications_with_launch_args</key>
<dict>
    <key>Google Chrome.app</key>
    <array>
        <string>--restore-last-session</string>
    </array>
</dict>
```
`blocking_applications` remains an array of strings. This avoids changing the type expected by existing clients, linting tools, and editors.

## Behavior
The agreed upon behavior is as follow:
- If either `blocking_applications` or `blocking_applications_with_launch_args` is present, use the union of the array strings and dictionary keys.
- If neither key is present, retain the existing inference from application entries in installs.
- Resolve and deduplicate equivalent identifiers by the running application path, as the current #1381 implementation does.
- If an application appears in both keys, treat it as one blocker and use the arguments from the dictionary.
- If a dictionary value is malformed, keep its key as a blocker but ignore the arguments and reopen the application normally.

The same blocker selection is used by managedsoftwareupdate, the Assisted Quit sheet, and Managed Software Center's fallback blocking-app alert. The key is copied into processed managed-install, optional-install, optional-uninstall, and removal metadata.


## Testing
I added tests for:
- Copying blocking_applications_with_launch_args into processed update metadata.
- Combining blocking_applications strings and dictionary keys.
- Deduplicating an application present in both sources.
- Treating a malformed dictionary value as a blocker without arguments.
- Suppressing installs inference when an explicit blocker source is present.
- Suppressing inference with an explicitly empty dictionary.
- Retaining installs inference when both explicit sources are absent.
- Retaining installs inference when the outer dictionary has the wrong type.

The Assisted Quit relaunch path and direct argument handling remain the implementations tested in #1379 and #1381.